### PR TITLE
Refactor Private AI Keys to allow team owned keys

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
 
 jobs:
   frontend-tests:
@@ -38,7 +38,7 @@ jobs:
       run: make test-clean
 
     - name: Run backend tests
-      run: make backend-test
+      run: make backend-test-cov
 
     - name: Clean up test containers
       if: always()

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ This repository contains the backend and frontend services for the amazee.ai app
 
 ### Backend Tests
 ```bash
-make backend-test     # Run backend tests
-make backend-test-cov # Run backend tests with coverage report
+make backend-test       # Run backend tests
+make backend-test-cov   # Run backend tests with coverage report
+make backend-test-regex # Waits for a string which pytest will parse to only collect a subset of tests
 ```
 
 ### Frontend Tests
@@ -99,7 +100,7 @@ make test-clean
 
 The development environment includes:
 - Hot reloading for frontend (Next.js) on port 3000
-- Hot reloading for backend (Python) on port 8800 
+- Hot reloading for backend (Python) on port 8800
 - PostgreSQL database on port 5432
 
 Access the services at:

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -137,7 +137,6 @@ async def create_vector_db(
             db_ai_key.region = region
             db_ai_key.id = -1
 
-        logger.info(f"Vector DB created: {db_ai_key.to_dict()}")
         return VectorDB.model_validate(db_ai_key.to_dict())
     except Exception as e:
         logger.error(f"Failed to create vector database: {str(e)}", exc_info=True)
@@ -285,8 +284,10 @@ async def create_llm_token(
 
     if team is not None:
         owner_email = team.admin_email
+        litellm_team = team.id
     else:
         owner_email = owner.email
+        litellm_team = owner.team_id or -1
 
     try:
         # Generate LiteLLM token
@@ -297,7 +298,8 @@ async def create_llm_token(
         litellm_token = await litellm_service.create_key(
             email=owner_email,
             name=private_ai_key.name,
-            user_id=owner_id
+            user_id=owner_id,
+            team_id=litellm_team
         )
 
         # Create response object

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -2,12 +2,10 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from typing import List, Optional
 from fastapi import status
-import requests
-from pydantic import BaseModel
 import logging
 
 from app.db.database import get_db
-from app.schemas.models import PrivateAIKey, PrivateAIKeyCreate, PrivateAIKeySpend
+from app.schemas.models import PrivateAIKey, PrivateAIKeyCreate, PrivateAIKeySpend, BudgetPeriodUpdate
 from app.db.postgres import PostgresManager
 from app.db.models import DBPrivateAIKey, DBRegion, DBUser, DBTeam
 from app.services.litellm import LiteLLMService
@@ -19,9 +17,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(
     tags=["Private AI Keys"]
 )
-
-class BudgetPeriodUpdate(BaseModel):
-    budget_duration: str
 
 @router.post("", response_model=PrivateAIKey)
 @router.post("/", response_model=PrivateAIKey)

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -372,8 +372,11 @@ async def list_private_ai_keys(
                 (DBPrivateAIKey.team_id == current_user.team_id)
             )
         else:
-            # Non-admin users can only see their own keys
-            query = query.filter(DBPrivateAIKey.owner_id == current_user.id)
+            # Non-admin users can see their own keys and team-owned keys
+            query = query.filter(
+                (DBPrivateAIKey.owner_id == current_user.id) |
+                (DBPrivateAIKey.team_id == current_user.team_id)
+            )
 
     private_ai_keys = query.all()
     return [key.to_dict() for key in private_ai_keys]

--- a/app/api/teams.py
+++ b/app/api/teams.py
@@ -1,16 +1,15 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
-from typing import List, Optional
+from typing import List
 from datetime import datetime, UTC
 
 from app.db.database import get_db
-from app.db.models import DBTeam, DBUser
+from app.db.models import DBTeam
 from app.core.security import check_system_admin, check_specific_team_admin
 from app.schemas.models import (
     Team, TeamCreate, TeamUpdate,
     TeamWithUsers
 )
-from app.api.auth import get_current_user_from_auth
 
 router = APIRouter()
 

--- a/app/api/teams.py
+++ b/app/api/teams.py
@@ -50,7 +50,6 @@ async def register_team(
 @router.get("", response_model=List[Team], dependencies=[Depends(check_system_admin)])
 @router.get("/", response_model=List[Team], dependencies=[Depends(check_system_admin)])
 async def list_teams(
-    current_user: DBUser = Depends(get_current_user_from_auth),
     db: Session = Depends(get_db)
 ):
     """
@@ -61,7 +60,6 @@ async def list_teams(
 @router.get("/{team_id}", response_model=TeamWithUsers, dependencies=[Depends(check_specific_team_admin)])
 async def get_team(
     team_id: int,
-    current_user: DBUser = Depends(get_current_user_from_auth),
     db: Session = Depends(get_db)
 ):
     """
@@ -79,7 +77,6 @@ async def get_team(
 async def update_team(
     team_id: int,
     team_update: TeamUpdate,
-    current_user: DBUser = Depends(get_current_user_from_auth),
     db: Session = Depends(get_db)
 ):
     """
@@ -103,7 +100,6 @@ async def update_team(
 @router.delete("/{team_id}", dependencies=[Depends(check_system_admin)])
 async def delete_team(
     team_id: int,
-    current_user: DBUser = Depends(get_current_user_from_auth),
     db: Session = Depends(get_db)
 ):
     """

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -1,17 +1,12 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
-from typing import List, Literal
+from typing import List
 
 from app.db.database import get_db
 from app.schemas.models import User, UserUpdate, UserCreate, TeamOperation, UserRoleUpdate
 from app.db.models import DBUser, DBTeam
-from app.api.auth import get_current_user_from_auth
-from app.core.security import get_password_hash, check_system_admin, check_team_admin
+from app.core.security import get_password_hash, check_system_admin, get_current_user_from_auth, VALID_ROLES, get_role_min_team_admin
 from datetime import datetime, UTC
-
-# Define valid user roles as a Literal type
-UserRole = Literal["admin", "key_creator", "read_only"]
-VALID_ROLES: List[UserRole] = ["admin", "key_creator", "read_only"]
 
 router = APIRouter()
 
@@ -28,8 +23,8 @@ async def search_users(
     users = db.query(DBUser).filter(DBUser.email.ilike(f"%{email}%")).limit(10).all()
     return users
 
-@router.get("", response_model=List[User], dependencies=[Depends(check_team_admin)])
-@router.get("/", response_model=List[User], dependencies=[Depends(check_team_admin)])
+@router.get("", response_model=List[User], dependencies=[Depends(get_role_min_team_admin)])
+@router.get("/", response_model=List[User], dependencies=[Depends(get_role_min_team_admin)])
 async def list_users(
     current_user: DBUser = Depends(get_current_user_from_auth),
     db: Session = Depends(get_db)
@@ -51,8 +46,8 @@ async def list_users(
         result.append(user)
     return result
 
-@router.post("", response_model=User, status_code=status.HTTP_201_CREATED, dependencies=[Depends(check_team_admin)])
-@router.post("/", response_model=User, status_code=status.HTTP_201_CREATED, dependencies=[Depends(check_team_admin)])
+@router.post("", response_model=User, status_code=status.HTTP_201_CREATED, dependencies=[Depends(get_role_min_team_admin)])
+@router.post("/", response_model=User, status_code=status.HTTP_201_CREATED, dependencies=[Depends(get_role_min_team_admin)])
 async def create_user(
     user: UserCreate,
     current_user: DBUser = Depends(get_current_user_from_auth),
@@ -114,7 +109,7 @@ async def get_user(
     # Otherwise, return 404 to avoid leaking information about user existence
     raise HTTPException(status_code=404, detail="User not found")
 
-@router.put("/{user_id}", response_model=User, dependencies=[Depends(check_team_admin)])
+@router.put("/{user_id}", response_model=User, dependencies=[Depends(get_role_min_team_admin)])
 async def update_user(
     user_id: int,
     user_update: UserUpdate,
@@ -142,7 +137,7 @@ async def update_user(
     db.refresh(db_user)
     return db_user
 
-@router.post("/{user_id}/add-to-team", response_model=User, dependencies=[Depends(check_team_admin)])
+@router.post("/{user_id}/add-to-team", response_model=User, dependencies=[Depends(get_role_min_team_admin)])
 async def add_user_to_team(
     user_id: int,
     team_operation: TeamOperation,
@@ -228,7 +223,7 @@ async def delete_user(
     db.commit()
     return {"message": "User deleted successfully"}
 
-@router.post("/{user_id}/role", response_model=User, dependencies=[Depends(check_team_admin)])
+@router.post("/{user_id}/role", response_model=User, dependencies=[Depends(get_role_min_team_admin)])
 async def update_user_role(
     user_id: int,
     role_update: UserRoleUpdate,

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -77,6 +77,10 @@ async def create_user(
             detail=f"Invalid role. Must be one of: {', '.join(VALID_ROLES)}"
         )
 
+    # Default to the lowest permissions for a user in a team
+    if user.role is None and user.team_id is not None:
+        user.role = 'read_only'
+
     # Create the user
     hashed_password = get_password_hash(user.password)
     db_user = DBUser(
@@ -84,7 +88,7 @@ async def create_user(
         hashed_password=hashed_password,
         is_admin=False,  # Users are created as non-admin by default
         team_id=user.team_id,
-        role=user.role if hasattr(user, 'role') and user.role else 'read_only'  # Default to read_only if not specified
+        role=user.role
     )
 
     db.add(db_user)

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
-from typing import List
+from typing import List, get_args
 
 from app.db.database import get_db
 from app.schemas.models import User, UserUpdate, UserCreate, TeamOperation, UserRoleUpdate
@@ -71,10 +71,10 @@ async def create_user(
         )
 
     # Validate role if provided
-    if user.role and user.role not in UserRole:
+    if user.role and user.role not in get_args(UserRole):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid role. Must be one of: {', '.join(UserRole)}"
+            detail=f"Invalid role. Must be one of: {', '.join(get_args(UserRole))}"
         )
 
     # Default to the lowest permissions for a user in a team
@@ -244,10 +244,10 @@ async def update_user_role(
     Update a user's role. Accessible by admin users or team admins for their team members.
     """
     # Validate role
-    if role_update.role not in UserRole:
+    if role_update.role not in get_args(UserRole):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid role. Must be one of: {', '.join(UserRole)}"
+            detail=f"Invalid role. Must be one of: {', '.join(get_args(UserRole))}"
         )
 
     # Get the user to update

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,20 +1,34 @@
 from datetime import datetime, timedelta, UTC
-from typing import Optional
+from typing import Optional, Literal, List
 from jose import JWTError, jwt
 from passlib.context import CryptContext
 from fastapi import Depends, HTTPException, status, Cookie, Header
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-
+import logging
 from app.core.config import settings
 from app.db.database import get_db
 from sqlalchemy.orm import Session
 from app.db.models import DBUser, DBAPIToken
+
+logger = logging.getLogger(__name__)
 
 # Password hashing
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 # Custom bearer scheme
 bearer_scheme = HTTPBearer(auto_error=False)
+
+# Define valid user roles as a Literal type
+UserRole = Literal["admin", "key_creator", "read_only", "user"]
+VALID_ROLES: List[UserRole] = ["admin", "key_creator", "read_only", "user"]
+
+# Define a hierarchy for roles
+user_role_hierarchy: dict[UserRole, int] = {
+    "admin": 0,
+    "user": 1,
+    "key_creator": 2,
+    "read_only": 3,
+}
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     """Verify a password against its hash."""
@@ -122,19 +136,27 @@ async def check_system_admin(current_user: DBUser = Depends(get_current_user_fro
             detail="Not authorized to perform this action"
         )
 
-async def check_team_admin(current_user: DBUser = Depends(get_current_user_from_auth)):
-    """Check if the current user is an admin of a team"""
-    # System admin overrides all
-    if (not current_user.is_admin) and (not (current_user.team_id and current_user.role == "admin")):
+def get_user_role(minimum_role: str, current_user: DBUser):
+    if current_user.is_admin:
+        return "system_admin"
+    elif user_role_hierarchy[current_user.role] > user_role_hierarchy[minimum_role]:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to perform this action"
+        )
+    return current_user.role
+
+async def get_role_min_team_admin(current_user: DBUser = Depends(get_current_user_from_auth)):
+    return get_user_role("admin", current_user)
+
+async def check_specific_team_admin(current_user: DBUser = Depends(get_current_user_from_auth), team_id: int = None):
+    get_user_role("admin", current_user)
+    # system administrators will fail the team check
+    if not current_user.is_admin and not current_user.team_id == team_id:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Not authorized to perform this action"
         )
 
-async def check_specific_team_admin(current_user: DBUser = Depends(get_current_user_from_auth), team_id: int = None):
-    # System admin overrides all
-    if (not current_user.is_admin) and (not (current_user.team_id == team_id and current_user.role == "admin")):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Not authorized to perform this action"
-        )
+async def get_role_min_key_creator(current_user: DBUser = Depends(get_current_user_from_auth)):
+    return get_user_role("key_creator", current_user)

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -99,6 +99,7 @@ class DBPrivateAIKey(Base):
             "litellm_api_url": self.litellm_api_url or "",
             "region": self.region.name if self.region else None,
             "owner_id": self.owner_id,
+            "team_id": self.team_id,
             "created_at": self.created_at
         }
 

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -70,13 +70,13 @@ class DBPrivateAIKey(Base):
     __tablename__ = "ai_tokens"
 
     id = Column(Integer, primary_key=True, index=True)
-    database_name = Column(String, unique=True, index=True)
+    database_name = Column(String, unique=True, index=True, nullable=True)
     name = Column(String, nullable=True)  # User-friendly display name
-    database_host = Column(String)
+    database_host = Column(String, nullable=True)
     database_username = Column(String)
-    database_password = Column(String)
-    litellm_token = Column(String)
-    litellm_api_url = Column(String)
+    database_password = Column(String, nullable=True)
+    litellm_token = Column(String, nullable=True)
+    litellm_api_url = Column(String, nullable=True)
     owner_id = Column(Integer, ForeignKey("users.id"))
     region_id = Column(Integer, ForeignKey("regions.id"))
     created_at = Column(DateTime(timezone=True), default=func.now())

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -89,7 +89,7 @@ class DBPrivateAIKey(Base):
 
     def to_dict(self):
         return {
-            "id": self.id,
+            "id": self.id or -1,
             "name": self.name,
             "database_name": self.database_name,
             "database_host": self.database_host,

--- a/app/db/postgres.py
+++ b/app/db/postgres.py
@@ -1,5 +1,4 @@
 import asyncpg
-from typing import Dict
 import uuid
 import logging
 from app.db.models import DBRegion
@@ -16,7 +15,7 @@ class PostgresManager:
         else:
             raise ValueError("Region is required for PostgresManager")
 
-    async def create_database(self) -> Dict:
+    async def create_database(self) -> dict:
         # Generate unique database name and credentials
         db_name = f"db_{uuid.uuid4().hex[:8]}"
         db_user = f"user_{uuid.uuid4().hex[:8]}"

--- a/app/db/postgres.py
+++ b/app/db/postgres.py
@@ -13,11 +13,10 @@ class PostgresManager:
             self.admin_user = region.postgres_admin_user
             self.admin_password = region.postgres_admin_password
             self.port = region.postgres_port
-            self.litellm_api_url = region.litellm_api_url
         else:
             raise ValueError("Region is required for PostgresManager")
 
-    async def create_database(self, owner: str, litellm_token: str, name: str = None, user_id: int = None) -> Dict:
+    async def create_database(self) -> Dict:
         # Generate unique database name and credentials
         db_name = f"db_{uuid.uuid4().hex[:8]}"
         db_user = f"user_{uuid.uuid4().hex[:8]}"
@@ -75,9 +74,7 @@ class PostgresManager:
                 "database_name": db_name,
                 "database_username": db_user,
                 "database_password": db_password,
-                "database_host": self.host,
-                "litellm_token": litellm_token,
-                "litellm_api_url": self.litellm_api_url
+                "database_host": self.host
             }
         except Exception as e:
             logger.error(f"Error creating database: {str(e)}")

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -1,9 +1,7 @@
-from pydantic import BaseModel, EmailStr, ConfigDict
+from pydantic import BaseModel, ConfigDict
 from typing import Optional, List, ClassVar
 from datetime import datetime
-from sqlalchemy import Column, Integer, DateTime, String, JSON, ForeignKey
 from sqlalchemy.orm import relationship
-from app.db.database import Base
 
 class Token(BaseModel):
     access_token: str
@@ -121,6 +119,19 @@ class PrivateAIKey(PrivateAIKeyBase):
     team_id: Optional[int] = None
     model_config = ConfigDict(from_attributes=True)
 
+class BudgetPeriodUpdate(BaseModel):
+    budget_duration: str
+
+class PrivateAIKeySpend(BaseModel):
+    spend: float
+    expires: datetime
+    created_at: datetime
+    updated_at: datetime
+    max_budget: Optional[float] = None
+    budget_duration: Optional[str] = None
+    budget_reset_at: Optional[datetime] = None
+    model_config = ConfigDict(from_attributes=True)
+
 class AuditLog(BaseModel):
     id: int
     timestamp: datetime
@@ -193,14 +204,4 @@ class TeamOperation(BaseModel):
 
 class UserRoleUpdate(BaseModel):
     role: str
-    model_config = ConfigDict(from_attributes=True)
-
-class PrivateAIKeySpend(BaseModel):
-    spend: float
-    expires: datetime
-    created_at: datetime
-    updated_at: datetime
-    max_budget: Optional[float] = None
-    budget_duration: Optional[str] = None
-    budget_reset_at: Optional[datetime] = None
     model_config = ConfigDict(from_attributes=True)

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -110,9 +110,15 @@ class PrivateAIKeyCreate(BaseModel):
     region_id: int
     name: str
     owner_id: Optional[int] = None
+    team_id: Optional[int] = None
+
+class TeamPrivateAIKeyCreate(PrivateAIKeyCreate):
+    team_id: int  # Override to make team_id required
+    owner_id: Optional[int] = None  # Explicitly set to None for team keys
 
 class PrivateAIKey(PrivateAIKeyBase):
-    owner_id: int
+    owner_id: Optional[int] = None
+    team_id: Optional[int] = None
     model_config = ConfigDict(from_attributes=True)
 
 class AuditLog(BaseModel):

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -110,6 +110,23 @@ class PrivateAIKeyCreate(BaseModel):
     owner_id: Optional[int] = None
     team_id: Optional[int] = None
 
+class VectorDBCreate(BaseModel):
+    region_id: int
+    name: str
+    owner_id: Optional[int] = None
+    team_id: Optional[int] = None
+
+class VectorDB(BaseModel):
+    database_name: str
+    database_host: str
+    database_username: str
+    database_password: str
+    owner_id: Optional[int] = None
+    team_id: Optional[int] = None
+    region: str
+    name: str
+    model_config = ConfigDict(from_attributes=True)
+
 class TeamPrivateAIKeyCreate(PrivateAIKeyCreate):
     team_id: int  # Override to make team_id required
     owner_id: Optional[int] = None  # Explicitly set to None for team keys
@@ -130,6 +147,15 @@ class PrivateAIKeySpend(BaseModel):
     max_budget: Optional[float] = None
     budget_duration: Optional[str] = None
     budget_reset_at: Optional[datetime] = None
+    model_config = ConfigDict(from_attributes=True)
+
+class LiteLLMToken(BaseModel):
+    litellm_token: str
+    litellm_api_url: str
+    owner_id: Optional[int] = None
+    team_id: Optional[int] = None
+    region: str
+    name: str
     model_config = ConfigDict(from_attributes=True)
 
 class AuditLog(BaseModel):

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -194,3 +194,13 @@ class TeamOperation(BaseModel):
 class UserRoleUpdate(BaseModel):
     role: str
     model_config = ConfigDict(from_attributes=True)
+
+class PrivateAIKeySpend(BaseModel):
+    spend: float
+    expires: datetime
+    created_at: datetime
+    updated_at: datetime
+    max_budget: Optional[float] = None
+    budget_duration: Optional[str] = None
+    budget_reset_at: Optional[datetime] = None
+    model_config = ConfigDict(from_attributes=True)

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -16,6 +16,8 @@ class UserBase(BaseModel):
 class UserCreate(UserBase):
     password: str
     team_id: Optional[int] = None
+    role: Optional[str] = None
+    model_config = ConfigDict(from_attributes=True)
 
 class UserUpdate(BaseModel):
     email: Optional[str] = None

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -93,13 +93,14 @@ class Region(RegionBase):
     model_config = ConfigDict(from_attributes=True)
 
 class PrivateAIKeyBase(BaseModel):
-    database_name: str
+    id: int
+    database_name: Optional[str] = None
     name: Optional[str] = None
-    database_host: str
-    database_username: str  # This is the database username, not the user's email
-    database_password: str
-    litellm_token: str
-    litellm_api_url: str
+    database_host: Optional[str] = None
+    database_username: Optional[str] = None  # This is the database username, not the user's email
+    database_password: Optional[str] = None
+    litellm_token: Optional[str] = None
+    litellm_api_url: Optional[str] = None
     region: Optional[str] = None
     created_at: Optional[datetime] = None
     model_config = ConfigDict(from_attributes=True)
@@ -117,6 +118,7 @@ class VectorDBCreate(BaseModel):
     team_id: Optional[int] = None
 
 class VectorDB(BaseModel):
+    id: int
     database_name: str
     database_host: str
     database_username: str
@@ -150,6 +152,7 @@ class PrivateAIKeySpend(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 class LiteLLMToken(BaseModel):
+    id: int
     litellm_token: str
     litellm_api_url: str
     owner_id: Optional[int] = None

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -15,10 +15,10 @@ class LiteLLMService:
         if not self.master_key:
             raise ValueError("LiteLLM API key is required")
 
-    async def create_key(self, email: str = None, name: str = None, user_id: int = None) -> str:
+    async def create_key(self, email: str, name: str, user_id: int, team_id: int) -> str:
         """Create a new API key for LiteLLM"""
         try:
-            logger.info(f"Creating new LiteLLM API key for email: {email}, name: {name}, user_id: {user_id}")
+            logger.info(f"Creating new LiteLLM API key for email: {email}, name: {name}, user_id: {user_id}, team_id: {team_id}")
             request_data = {
                 "duration": "8760h",  # Set token duration to 1 year (365 days * 24 hours)
                 "models": ["all-team-models"],   # Allow access to all models
@@ -28,21 +28,19 @@ class LiteLLMService:
             }
 
             # Add email and name to key_alias and metadata if provided
-            if email:
-                key_alias = email
-                metadata = {"service_account_id": email}
+            key_alias = f"{email} - {name}"
+            metadata = {"service_account_id": email}
+            metadata["amazeeai_private_ai_key_name"] = name
 
-                # Add name to key_alias and metadata if provided
-                if name:
-                    key_alias = f"{email} - {name}"
-                    metadata["amazeeai_private_ai_key_name"] = name
+            # Add user_id to metadata if provided
+            metadata["amazeeai_user_id"] = str(user_id or None)
+            metadata["amazeeai_team_id"] = str(team_id)
 
-                # Add user_id to metadata if provided
-                if user_id is not None:
-                    metadata["amazeeai_user_id"] = str(user_id)
-
-                request_data["key_alias"] = key_alias
-                request_data["metadata"] = metadata
+            request_data["key_alias"] = key_alias
+            request_data["metadata"] = metadata
+            request_data["team_id"] = str(team_id)
+            if user_id is not None:
+                request_data["user_id"] = str(user_id)
 
             logger.info("Making request to LiteLLM API to generate key")
             response = requests.post(

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -9,7 +9,7 @@ class LiteLLMService:
     def __init__(self, api_url: str, api_key: str):
         self.api_url = api_url
         self.master_key = api_key
-        
+
         if not self.api_url:
             raise ValueError("LiteLLM API URL is required")
         if not self.master_key:
@@ -26,24 +26,24 @@ class LiteLLMService:
                 "config": {},
                 "spend": 0,
             }
-            
+
             # Add email and name to key_alias and metadata if provided
             if email:
                 key_alias = email
                 metadata = {"service_account_id": email}
-                
+
                 # Add name to key_alias and metadata if provided
                 if name:
                     key_alias = f"{email} - {name}"
                     metadata["amazeeai_private_ai_key_name"] = name
-                
+
                 # Add user_id to metadata if provided
                 if user_id is not None:
                     metadata["amazeeai_user_id"] = str(user_id)
-                
+
                 request_data["key_alias"] = key_alias
                 request_data["metadata"] = metadata
-            
+
             logger.info("Making request to LiteLLM API to generate key")
             response = requests.post(
                 f"{self.api_url}/key/generate",
@@ -65,7 +65,7 @@ class LiteLLMService:
                     error_msg = f"Status {e.response.status_code}: {error_details}"
                 except ValueError:
                     error_msg = f"Status {e.response.status_code}: {e.response.text}"
-            print(f"Error creating LiteLLM key: {error_msg}")
+            logger.error(f"Error creating LiteLLM key: {error_msg}")
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Failed to create LiteLLM key: {error_msg}"
@@ -85,5 +85,33 @@ class LiteLLMService:
             response.raise_for_status()
             return True
         except requests.exceptions.RequestException as e:
-            print(f"Error deleting LiteLLM key: {str(e)}")
+            logger.error(f"Error deleting LiteLLM key: {str(e)}")
             return False
+
+    async def get_key_info(self, litellm_token: str) -> dict:
+        """Get information about a LiteLLM API key"""
+        try:
+            response = requests.get(
+                f"{self.api_url}/key/info",
+                headers={
+                    "Authorization": f"Bearer {self.master_key}"
+                },
+                params={
+                    "key": litellm_token
+                }
+            )
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            error_msg = str(e)
+            logger.error(f"Error getting LiteLLM key information: {error_msg}")
+            if hasattr(e, 'response') and e.response is not None:
+                try:
+                    error_details = e.response.json()
+                    error_msg = f"Status {e.response.status_code}: {error_details}"
+                except ValueError:
+                    error_msg = f"Status {e.response.status_code}: {e.response.text}"
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to get LiteLLM key information: {error_msg}"
+            )

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -115,3 +115,31 @@ class LiteLLMService:
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Failed to get LiteLLM key information: {error_msg}"
             )
+
+    async def update_budget(self, litellm_token: str, budget_duration: str):
+        """Update the budget for a LiteLLM API key"""
+        try:
+            # Update budget period in LiteLLM
+            response = requests.post(
+                f"{self.api_url}/key/update",
+                headers={
+                    "Authorization": f"Bearer {self.master_key}"
+                },
+                json={
+                    "key": litellm_token,
+                    "budget_duration": budget_duration
+                }
+            )
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            error_msg = str(e)
+            if hasattr(e, 'response') and e.response is not None:
+                try:
+                    error_details = e.response.json()
+                    error_msg = f"Status {e.response.status_code}: {error_details}"
+                except ValueError:
+                    error_msg = f"Status {e.response.status_code}: {e.response.text}"
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to update LiteLLM budget: {error_msg}"
+            )

--- a/frontend/src/app/admin/private-ai-keys/page.tsx
+++ b/frontend/src/app/admin/private-ai-keys/page.tsx
@@ -4,25 +4,6 @@ import { useState, useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient, useQueries } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
-import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -34,7 +15,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
-import { Loader2, Eye, EyeOff, Search, Pencil } from 'lucide-react';
+import { Loader2, Search, Pencil } from 'lucide-react';
 import { get, del, put } from '@/utils/api';
 import { useDebounce } from '@/hooks/use-debounce';
 import {
@@ -50,22 +31,12 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
+import { PrivateAIKeysTable } from '@/components/private-ai-keys-table';
+import { PrivateAIKey } from '@/types/private-ai-key';
 
 interface User {
   id: number;
   email: string;
-}
-
-interface PrivateAIKey {
-  database_name: string;
-  name: string;  // User-friendly display name
-  database_host: string;
-  database_username: string;
-  database_password: string;
-  litellm_token: string;
-  litellm_api_url: string;
-  owner_id: number;
-  region: string;
 }
 
 interface SpendInfo {
@@ -94,12 +65,11 @@ function formatTimeUntil(date: string): string {
 export default function PrivateAIKeysPage() {
   const { toast } = useToast();
   const queryClient = useQueryClient();
-  const [visibleCredentials, setVisibleCredentials] = useState<Set<string>>(new Set());
   const [searchTerm, setSearchTerm] = useState('');
   const [isUserSearchOpen, setIsUserSearchOpen] = useState(false);
   const [selectedUser, setSelectedUser] = useState<User | null>(null);
   const [openBudgetDialog, setOpenBudgetDialog] = useState<string | null>(null);
-  const [loadedSpendKeys, setLoadedSpendKeys] = useState<Set<string>>(new Set());
+  const [loadedSpendKeys, setLoadedSpendKeys] = useState<Set<number>>(new Set());
   const debouncedSearchTerm = useDebounce(searchTerm, 300);
 
   // Queries
@@ -169,11 +139,11 @@ export default function PrivateAIKeysPage() {
   // Query to get spend information for each key
   const spendQueries = useQueries({
     queries: privateAIKeys
-      .filter(key => loadedSpendKeys.has(key.database_name))
+      .filter(key => loadedSpendKeys.has(key.id))
       .map((key) => ({
-        queryKey: ['private-ai-key-spend', key.database_name],
+        queryKey: ['private-ai-key-spend', key.id],
         queryFn: async () => {
-          const response = await get(`/private-ai-keys/${key.database_name}/spend`);
+          const response = await get(`/private-ai-keys/${key.id}/spend`);
           const data = await response.json();
           return data as SpendInfo;
         },
@@ -185,16 +155,16 @@ export default function PrivateAIKeysPage() {
   const spendMap = useMemo(() => {
     return spendQueries.reduce((acc, query, index) => {
       if (query.data) {
-        acc[privateAIKeys.filter(key => loadedSpendKeys.has(key.database_name))[index].database_name] = query.data;
+        acc[privateAIKeys.filter(key => loadedSpendKeys.has(key.id))[index].id] = query.data;
       }
       return acc;
-    }, {} as Record<string, SpendInfo>);
+    }, {} as Record<number, SpendInfo>);
   }, [spendQueries, privateAIKeys, loadedSpendKeys]);
 
   // Mutations
   const deletePrivateAIKeyMutation = useMutation({
-    mutationFn: async (keyName: string) => {
-      await del(`/private-ai-keys/${keyName}`);
+    mutationFn: async (keyId: number) => {
+      await del(`/private-ai-keys/${keyId}`);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['private-ai-keys'] });
@@ -214,15 +184,15 @@ export default function PrivateAIKeysPage() {
 
   // Add mutation for updating budget period
   const updateBudgetPeriodMutation = useMutation({
-    mutationFn: async ({ keyName, budgetDuration }: { keyName: string; budgetDuration: string }) => {
-      const response = await put(`/private-ai-keys/${keyName}/budget-period`, {
+    mutationFn: async ({ keyId, budgetDuration }: { keyId: number; budgetDuration: string }) => {
+      const response = await put(`/private-ai-keys/${keyId}/budget-period`, {
         budget_duration: budgetDuration
       });
       return response.json();
     },
     onSuccess: (data, variables) => {
       // Update the spend information for this specific key
-      queryClient.setQueryData(['private-ai-key-spend', variables.keyName], data);
+      queryClient.setQueryData(['private-ai-key-spend', variables.keyId], data);
       setOpenBudgetDialog(null); // Close the dialog
       toast({
         title: 'Success',
@@ -237,14 +207,6 @@ export default function PrivateAIKeysPage() {
       });
     },
   });
-
-  if (isLoadingPrivateAIKeys) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <Loader2 className="h-8 w-8 animate-spin" />
-      </div>
-    );
-  }
 
   return (
     <div className="space-y-4">
@@ -312,242 +274,20 @@ export default function PrivateAIKeysPage() {
         )}
       </div>
 
-      <div className="rounded-md border">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Name</TableHead>
-              <TableHead>Credentials</TableHead>
-              <TableHead>Region</TableHead>
-              <TableHead>Owner</TableHead>
-              <TableHead>Spend</TableHead>
-              <TableHead>Actions</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {privateAIKeys.map((key) => (
-              <TableRow key={key.database_name}>
-                <TableCell>{key.name || key.database_name}</TableCell>
-                <TableCell>
-                  <div className="space-y-2">
-                    <div className="flex items-center gap-2">
-                      <span>Database: {key.database_name}</span>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <span>Host: {key.database_host}</span>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <span>Username: {key.database_username}</span>
-                    </div>
-                    {key.database_password && (
-                      <div className="flex items-center gap-2">
-                        <span>Password:</span>
-                        {visibleCredentials.has(`${key.database_name}-password`) ? (
-                          <div className="flex items-center gap-2">
-                            <code className="px-2 py-1 bg-muted rounded text-sm font-mono">
-                              {key.database_password}
-                            </code>
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              onClick={() => {
-                                setVisibleCredentials(prev => {
-                                  const next = new Set(prev);
-                                  next.delete(`${key.database_name}-password`);
-                                  return next;
-                                });
-                              }}
-                            >
-                              <EyeOff className="h-4 w-4" />
-                            </Button>
-                          </div>
-                        ) : (
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            onClick={() => {
-                              setVisibleCredentials(prev => {
-                                const next = new Set(prev);
-                                next.add(`${key.database_name}-password`);
-                                return next;
-                              });
-                            }}
-                          >
-                            <Eye className="h-4 w-4" />
-                          </Button>
-                        )}
-                      </div>
-                    )}
-                    {key.litellm_token && (
-                      <div className="flex items-center gap-2">
-                        <span>LLM Key:</span>
-                        {visibleCredentials.has(`${key.database_name}-token`) ? (
-                          <div className="flex items-center gap-2">
-                            <code className="px-2 py-1 bg-muted rounded text-sm font-mono">
-                              {key.litellm_token}
-                            </code>
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              onClick={() => {
-                                setVisibleCredentials(prev => {
-                                  const next = new Set(prev);
-                                  next.delete(`${key.database_name}-token`);
-                                  return next;
-                                });
-                              }}
-                            >
-                              <EyeOff className="h-4 w-4" />
-                            </Button>
-                          </div>
-                        ) : (
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            onClick={() => {
-                              setVisibleCredentials(prev => {
-                                const next = new Set(prev);
-                                next.add(`${key.database_name}-token`);
-                                return next;
-                              });
-                            }}
-                          >
-                            <Eye className="h-4 w-4" />
-                          </Button>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                </TableCell>
-                <TableCell>
-                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-                    {key.region}
-                  </span>
-                </TableCell>
-                <TableCell>
-                  <div className="flex flex-col gap-1">
-                    <span className="text-sm">{usersMap[key.owner_id]?.email || 'Unknown'}</span>
-                    <span className="text-xs text-muted-foreground">ID: {key.owner_id}</span>
-                  </div>
-                </TableCell>
-                <TableCell>
-                  {loadedSpendKeys.has(key.database_name) ? (
-                    spendMap[key.database_name] ? (
-                      <div className="flex flex-col gap-1">
-                        <div className="flex items-center gap-2">
-                          <span className="text-sm font-medium">
-                            ${spendMap[key.database_name].spend.toFixed(2)}
-                          </span>
-                          <span className="text-xs text-muted-foreground">
-                            {spendMap[key.database_name]?.max_budget !== null 
-                              ? `/ $${spendMap[key.database_name]?.max_budget?.toFixed(2)}`
-                              : '(No budget)'}
-                          </span>
-                        </div>
-                        <span className="text-xs text-muted-foreground">
-                          {spendMap[key.database_name].budget_duration || 'No budget period'}
-                          {spendMap[key.database_name].budget_reset_at && ` • Resets ${formatTimeUntil(spendMap[key.database_name].budget_reset_at as string)}`}
-                          <Dialog open={openBudgetDialog === key.database_name} onOpenChange={(open) => setOpenBudgetDialog(open ? key.database_name : null)}>
-                            <DialogTrigger asChild>
-                              <Button variant="ghost" size="icon" className="h-4 w-4 ml-1">
-                                <Pencil className="h-3 w-3" />
-                              </Button>
-                            </DialogTrigger>
-                            <DialogContent>
-                              <DialogHeader>
-                                <DialogTitle>Update Budget Period</DialogTitle>
-                                <DialogDescription>
-                                  Set the budget period for this key. Examples: &quot;30d&quot; (30 days), &quot;24h&quot; (24 hours), &quot;60m&quot; (60 minutes)
-                                </DialogDescription>
-                              </DialogHeader>
-                              <div className="grid gap-4 py-4">
-                                <div className="grid gap-2">
-                                  <Label htmlFor="budget-duration">Budget Period</Label>
-                                  <Input
-                                    id="budget-duration"
-                                    defaultValue={spendMap[key.database_name].budget_duration || ''}
-                                    placeholder="e.g. 30d"
-                                  />
-                                </div>
-                              </div>
-                              <DialogFooter>
-                                <Button
-                                  onClick={() => {
-                                    const input = document.getElementById('budget-duration') as HTMLInputElement;
-                                    if (input) {
-                                      updateBudgetPeriodMutation.mutate({
-                                        keyName: key.database_name,
-                                        budgetDuration: input.value
-                                      });
-                                    }
-                                  }}
-                                  disabled={updateBudgetPeriodMutation.isPending}
-                                >
-                                  {updateBudgetPeriodMutation.isPending ? (
-                                    <>
-                                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                                      Updating...
-                                    </>
-                                  ) : (
-                                    'Update'
-                                  )}
-                                </Button>
-                              </DialogFooter>
-                            </DialogContent>
-                          </Dialog>
-                        </span>
-                      </div>
-                    ) : (
-                      <span className="text-sm text-muted-foreground">Loading...</span>
-                    )
-                  ) : (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => {
-                        setLoadedSpendKeys(prev => new Set([...prev, key.database_name]));
-                      }}
-                    >
-                      Load Spend
-                    </Button>
-                  )}
-                </TableCell>
-                <TableCell>
-                  <AlertDialog>
-                    <AlertDialogTrigger asChild>
-                      <Button variant="destructive" size="sm">Delete</Button>
-                    </AlertDialogTrigger>
-                    <AlertDialogContent>
-                      <AlertDialogHeader>
-                        <AlertDialogTitle>Delete Private AI Key</AlertDialogTitle>
-                        <AlertDialogDescription>
-                          Are you sure you want to delete this private AI key? This action cannot be undone.
-                        </AlertDialogDescription>
-                      </AlertDialogHeader>
-                      <AlertDialogFooter>
-                        <AlertDialogCancel>Cancel</AlertDialogCancel>
-                        <AlertDialogAction
-                          onClick={() => deletePrivateAIKeyMutation.mutate(key.database_name)}
-                          className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                        >
-                          {deletePrivateAIKeyMutation.isPending ? (
-                            <>
-                              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                              Deleting...
-                            </>
-                          ) : (
-                            'Delete'
-                          )}
-                        </AlertDialogAction>
-                      </AlertDialogFooter>
-                    </AlertDialogContent>
-                  </AlertDialog>
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </div>
+      <PrivateAIKeysTable
+        keys={privateAIKeys}
+        onDelete={deletePrivateAIKeyMutation.mutate}
+        isLoading={isLoadingPrivateAIKeys}
+        showOwner={true}
+        showSpend={true}
+        spendMap={spendMap}
+        onLoadSpend={(keyId) => setLoadedSpendKeys(prev => new Set([...prev, keyId]))}
+        onUpdateBudget={(keyId, budgetDuration) => {
+          updateBudgetPeriodMutation.mutate({ keyId, budgetDuration });
+        }}
+        isDeleting={deletePrivateAIKeyMutation.isPending}
+        isUpdatingBudget={updateBudgetPeriodMutation.isPending}
+      />
     </div>
   );
 }

--- a/frontend/src/app/admin/private-ai-keys/page.tsx
+++ b/frontend/src/app/admin/private-ai-keys/page.tsx
@@ -271,7 +271,7 @@ export default function PrivateAIKeysPage() {
         onDelete={deletePrivateAIKeyMutation.mutate}
         isLoading={isLoadingPrivateAIKeys}
         isDeleting={deletePrivateAIKeyMutation.isPending}
-        showSpend={true}
+        allowModification={true}
         showOwner={true}
         spendMap={spendMap}
         onLoadSpend={(keyId) => setLoadedSpendKeys(prev => new Set([...prev, keyId]))}

--- a/frontend/src/app/admin/private-ai-keys/page.tsx
+++ b/frontend/src/app/admin/private-ai-keys/page.tsx
@@ -3,19 +3,8 @@
 import { useState, useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient, useQueries } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
-import { Loader2, Search, Pencil } from 'lucide-react';
+import { Loader2, Search } from 'lucide-react';
 import { get, del, put } from '@/utils/api';
 import { useDebounce } from '@/hooks/use-debounce';
 import {
@@ -49,26 +38,12 @@ interface SpendInfo {
   budget_reset_at: string | null;
 }
 
-function formatTimeUntil(date: string): string {
-  const now = new Date();
-  const resetDate = new Date(date);
-  const diffMs = resetDate.getTime() - now.getTime();
-  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-  const diffMinutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
-
-  if (diffHours > 0) {
-    return `in ${diffHours}h ${diffMinutes}m`;
-  }
-  return `in ${diffMinutes}m`;
-}
-
 export default function PrivateAIKeysPage() {
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const [searchTerm, setSearchTerm] = useState('');
   const [isUserSearchOpen, setIsUserSearchOpen] = useState(false);
   const [selectedUser, setSelectedUser] = useState<User | null>(null);
-  const [openBudgetDialog, setOpenBudgetDialog] = useState<string | null>(null);
   const [loadedSpendKeys, setLoadedSpendKeys] = useState<Set<number>>(new Set());
   const debouncedSearchTerm = useDebounce(searchTerm, 300);
 
@@ -211,7 +186,6 @@ export default function PrivateAIKeysPage() {
     onSuccess: (data, variables) => {
       // Update the spend information for this specific key
       queryClient.setQueryData(['private-ai-key-spend', variables.keyId], data);
-      setOpenBudgetDialog(null); // Close the dialog
       toast({
         title: 'Success',
         description: 'Budget period updated successfully',

--- a/frontend/src/app/admin/teams/page.tsx
+++ b/frontend/src/app/admin/teams/page.tsx
@@ -31,7 +31,20 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import React from 'react';
+
+const USER_ROLES = [
+  { value: 'admin', label: 'Admin' },
+  { value: 'key_creator', label: 'Key Creator' },
+  { value: 'read_only', label: 'Read Only' },
+];
 
 interface TeamUser {
   id: number;
@@ -74,6 +87,7 @@ export default function TeamsPage() {
   const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
   const [newUserEmail, setNewUserEmail] = useState('');
   const [newUserPassword, setNewUserPassword] = useState('');
+  const [newUserRole, setNewUserRole] = useState('read_only');
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<User[]>([]);
   const [isSearching, setIsSearching] = useState(false);
@@ -180,7 +194,7 @@ export default function TeamsPage() {
   });
 
   const createUserMutation = useMutation({
-    mutationFn: async (userData: { email: string; password: string; team_id?: number }) => {
+    mutationFn: async (userData: { email: string; password: string; team_id?: number; role: string }) => {
       try {
         const response = await post('/users', userData);
         return response.json();
@@ -203,6 +217,7 @@ export default function TeamsPage() {
       setIsCreatingUserInTeam(false);
       setNewUserEmail('');
       setNewUserPassword('');
+      setNewUserRole('read_only');
     },
     onError: (error: Error) => {
       toast({
@@ -296,6 +311,7 @@ export default function TeamsPage() {
       email: newUserEmail,
       password: newUserPassword,
       team_id: parseInt(selectedTeamId),
+      role: newUserRole,
     });
   };
 
@@ -781,6 +797,26 @@ export default function TeamsPage() {
                   className="col-span-3"
                   required
                 />
+              </div>
+              <div className="grid grid-cols-4 items-center gap-4">
+                <label htmlFor="new-user-role" className="text-right">
+                  Role
+                </label>
+                <Select
+                  value={newUserRole}
+                  onValueChange={setNewUserRole}
+                >
+                  <SelectTrigger className="col-span-3">
+                    <SelectValue placeholder="Select a role" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {USER_ROLES.map((role) => (
+                      <SelectItem key={role.value} value={role.value}>
+                        {role.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
             </div>
             <DialogFooter>

--- a/frontend/src/app/team-admin/private-ai-keys/page.tsx
+++ b/frontend/src/app/team-admin/private-ai-keys/page.tsx
@@ -60,7 +60,6 @@ export default function TeamAIKeysPage() {
   const [selectedRegion, setSelectedRegion] = useState<string>('');
   const [selectedUserId, setSelectedUserId] = useState<string>('team');
   const [loadedSpendKeys, setLoadedSpendKeys] = useState<Set<number>>(new Set());
-  const [openBudgetDialog, setOpenBudgetDialog] = useState<number | null>(null);
 
   const queryClient = useQueryClient();
 
@@ -90,16 +89,6 @@ export default function TeamAIKeysPage() {
       return Object.fromEntries(teamResults);
     },
     enabled: teamIds.length > 0,
-  });
-
-  const { data: teams = [] } = useQuery({
-    queryKey: ['teams'],
-    queryFn: async () => {
-      const response = await get('teams', { credentials: 'include' });
-      const data = await response.json();
-      console.log('Teams list:', data);
-      return data;
-    },
   });
 
   const { data: regions = [] } = useQuery<Region[]>({
@@ -206,7 +195,6 @@ export default function TeamAIKeysPage() {
         ...oldData,
         [variables.keyId]: data
       }));
-      setOpenBudgetDialog(null); // Close the dialog
       toast({
         title: 'Success',
         description: 'Budget period updated successfully',
@@ -306,7 +294,7 @@ export default function TeamAIKeysPage() {
                     </SelectContent>
                   </Select>
                   <p className="text-sm text-muted-foreground">
-                    Select "Team (Shared)" to create a key accessible to all team members
+                    Select &quot;Team (Shared)&quot; to create a key accessible to all team members
                   </p>
                 </div>
               </div>

--- a/frontend/src/app/team-admin/users/page.tsx
+++ b/frontend/src/app/team-admin/users/page.tsx
@@ -67,6 +67,7 @@ export default function TeamUsersPage() {
   const [selectedUser, setSelectedUser] = useState<{ id: string; currentRole: string } | null>(null);
   const [newUserEmail, setNewUserEmail] = useState('');
   const [newUserPassword, setNewUserPassword] = useState('');
+  const [newUserRole, setNewUserRole] = useState('read_only');
 
   const queryClient = useQueryClient();
 
@@ -82,7 +83,7 @@ export default function TeamUsersPage() {
   });
 
   const createUserMutation = useMutation({
-    mutationFn: async (data: { email: string; password: string }) => {
+    mutationFn: async (data: { email: string; password: string; role: string }) => {
       const response = await post('users', {
         ...data,
         team_id: user?.team_id,
@@ -94,6 +95,7 @@ export default function TeamUsersPage() {
       setIsAddingUser(false);
       setNewUserEmail('');
       setNewUserPassword('');
+      setNewUserRole('read_only');
       toast({
         title: 'Success',
         description: 'User added to team successfully',
@@ -163,6 +165,7 @@ export default function TeamUsersPage() {
     createUserMutation.mutate({
       email: newUserEmail,
       password: newUserPassword,
+      role: newUserRole,
     });
   };
 
@@ -214,6 +217,24 @@ export default function TeamUsersPage() {
                     onChange={(e) => setNewUserPassword(e.target.value)}
                     required
                   />
+                </div>
+                <div className="grid gap-2">
+                  <label htmlFor="role">Role</label>
+                  <Select
+                    value={newUserRole}
+                    onValueChange={setNewUserRole}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select a role" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {USER_ROLES.map((role) => (
+                        <SelectItem key={role.value} value={role.value}>
+                          {role.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </div>
               </div>
               <DialogFooter>

--- a/frontend/src/components/private-ai-keys-table.tsx
+++ b/frontend/src/components/private-ai-keys-table.tsx
@@ -1,0 +1,282 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Eye, EyeOff, Pencil, Loader2 } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+import { formatTimeUntil } from '@/lib/utils';
+import { PrivateAIKey } from '@/types/private-ai-key';
+
+interface PrivateAIKeysTableProps {
+  keys: PrivateAIKey[];
+  onDelete: (keyId: number) => void;
+  isLoading?: boolean;
+  showOwner?: boolean;
+  showSpend?: boolean;
+  spendMap?: Record<number, any>;
+  onLoadSpend?: (keyId: number) => void;
+  onUpdateBudget?: (keyId: number, budgetDuration: string) => void;
+  isDeleting?: boolean;
+  isUpdatingBudget?: boolean;
+}
+
+export function PrivateAIKeysTable({
+  keys,
+  onDelete,
+  isLoading = false,
+  showOwner = false,
+  showSpend = false,
+  spendMap = {},
+  onLoadSpend,
+  onUpdateBudget,
+  isDeleting = false,
+  isUpdatingBudget = false,
+}: PrivateAIKeysTableProps) {
+  const { toast } = useToast();
+  const [showPassword, setShowPassword] = useState<Record<number | string, boolean>>({});
+  const [openBudgetDialog, setOpenBudgetDialog] = useState<number | null>(null);
+
+  const togglePasswordVisibility = (keyId: number | string) => {
+    setShowPassword(prev => ({
+      ...prev,
+      [keyId]: !prev[keyId]
+    }));
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>Database Credentials</TableHead>
+            <TableHead>LLM Credentials</TableHead>
+            <TableHead>Region</TableHead>
+            {showOwner && <TableHead>Owner</TableHead>}
+            {showSpend && <TableHead>Spend</TableHead>}
+            <TableHead>Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {keys.map((key, index) => (
+            <TableRow key={key.id || `key-${index}`}>
+              <TableCell>{key.name}</TableCell>
+              <TableCell>
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <span>Database: {key.database_name}</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span>Host: {key.database_host}</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span>Username: {key.database_username}</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span>Password: </span>
+                    <span className="font-mono">
+                      {showPassword[key.id || `key-${index}`] ? key.database_password : '••••••••'}
+                    </span>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => togglePasswordVisibility(key.id || `key-${index}`)}
+                    >
+                      {showPassword[key.id || `key-${index}`] ? (
+                        <EyeOff className="h-4 w-4" />
+                      ) : (
+                        <Eye className="h-4 w-4" />
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              </TableCell>
+              <TableCell>
+                {key.litellm_token ? (
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-2">
+                      <span>Token: </span>
+                      <span className="font-mono">
+                        {showPassword[`${key.id}-token`] ? key.litellm_token : '••••••••'}
+                      </span>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => togglePasswordVisibility(`${key.id}-token`)}
+                      >
+                        {showPassword[`${key.id}-token`] ? (
+                          <EyeOff className="h-4 w-4" />
+                        ) : (
+                          <Eye className="h-4 w-4" />
+                        )}
+                      </Button>
+                    </div>
+                    {key.litellm_api_url && (
+                      <div className="flex items-center gap-2">
+                        <span>API URL: {key.litellm_api_url}</span>
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <span className="text-muted-foreground">No LLM credentials</span>
+                )}
+              </TableCell>
+              <TableCell>{key.region}</TableCell>
+              {showOwner && (
+                <TableCell>
+                  <div className="flex flex-col gap-1">
+                    <span className="text-sm">{key.owner_id}</span>
+                  </div>
+                </TableCell>
+              )}
+              {showSpend && (
+                <TableCell>
+                  {spendMap[key.id] ? (
+                    <div className="flex flex-col gap-1">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium">
+                          ${spendMap[key.id].spend.toFixed(2)}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {spendMap[key.id]?.max_budget !== null
+                            ? `/ $${spendMap[key.id]?.max_budget?.toFixed(2)}`
+                            : '(No budget)'}
+                        </span>
+                      </div>
+                      <span className="text-xs text-muted-foreground">
+                        {spendMap[key.id].budget_duration || 'No budget period'}
+                        {spendMap[key.id].budget_reset_at && ` • Resets ${formatTimeUntil(spendMap[key.id].budget_reset_at as string)}`}
+                        {onUpdateBudget && (
+                          <Dialog open={openBudgetDialog === key.id} onOpenChange={(open) => setOpenBudgetDialog(open ? key.id : null)}>
+                            <DialogTrigger asChild>
+                              <Button variant="ghost" size="icon" className="h-4 w-4 ml-1">
+                                <Pencil className="h-3 w-3" />
+                              </Button>
+                            </DialogTrigger>
+                            <DialogContent>
+                              <DialogHeader>
+                                <DialogTitle>Update Budget Period</DialogTitle>
+                                <DialogDescription>
+                                  Set the budget period for this key. Examples: &quot;30d&quot; (30 days), &quot;24h&quot; (24 hours), &quot;60m&quot; (60 minutes)
+                                </DialogDescription>
+                              </DialogHeader>
+                              <div className="grid gap-4 py-4">
+                                <div className="grid gap-2">
+                                  <Label htmlFor="budget-duration">Budget Period</Label>
+                                  <Input
+                                    id="budget-duration"
+                                    defaultValue={spendMap[key.id].budget_duration || ''}
+                                    placeholder="e.g. 30d"
+                                  />
+                                </div>
+                              </div>
+                              <DialogFooter>
+                                <Button
+                                  onClick={() => {
+                                    const input = document.getElementById('budget-duration') as HTMLInputElement;
+                                    if (input) {
+                                      onUpdateBudget(key.id, input.value);
+                                    }
+                                  }}
+                                  disabled={isUpdatingBudget}
+                                >
+                                  {isUpdatingBudget ? (
+                                    <>
+                                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                      Updating...
+                                    </>
+                                  ) : (
+                                    'Update'
+                                  )}
+                                </Button>
+                              </DialogFooter>
+                            </DialogContent>
+                          </Dialog>
+                        )}
+                      </span>
+                    </div>
+                  ) : (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => onLoadSpend?.(key.id)}
+                    >
+                      Load Spend
+                    </Button>
+                  )}
+                </TableCell>
+              )}
+              <TableCell>
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button variant="destructive" size="sm">Delete</Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Delete Private AI Key</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Are you sure you want to delete this private AI key? This action cannot be undone.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancel</AlertDialogCancel>
+                      <AlertDialogAction
+                        onClick={() => onDelete(key.id)}
+                        className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                      >
+                        {isDeleting ? (
+                          <>
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            Deleting...
+                          </>
+                        ) : (
+                          'Delete'
+                        )}
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/frontend/src/components/private-ai-keys-table.tsx
+++ b/frontend/src/components/private-ai-keys-table.tsx
@@ -46,6 +46,8 @@ interface PrivateAIKeysTableProps {
   onUpdateBudget?: (keyId: number, budgetDuration: string) => void;
   isDeleting?: boolean;
   isUpdatingBudget?: boolean;
+  teamDetails?: Record<number, { name: string }>;
+  teamMembers?: { id: number; email: string }[];
 }
 
 export function PrivateAIKeysTable({
@@ -59,6 +61,8 @@ export function PrivateAIKeysTable({
   onUpdateBudget,
   isDeleting = false,
   isUpdatingBudget = false,
+  teamDetails = {},
+  teamMembers = [],
 }: PrivateAIKeysTableProps) {
   const { toast } = useToast();
   const [showPassword, setShowPassword] = useState<Record<number | string, boolean>>({});
@@ -161,7 +165,13 @@ export function PrivateAIKeysTable({
               {showOwner && (
                 <TableCell>
                   <div className="flex flex-col gap-1">
-                    <span className="text-sm">{key.owner_id}</span>
+                    {key.owner_id ? (
+                      <span className="text-sm">
+                        {teamMembers.find(member => member.id === key.owner_id)?.email || `User ${key.owner_id}`}
+                      </span>
+                    ) : key.team_id ? (
+                      <span className="text-sm">(Team) {teamDetails[key.team_id]?.name || 'Team (Shared)'}</span>
+                    ) : null}
                   </div>
                 </TableCell>
               )}

--- a/frontend/src/components/private-ai-keys-table.tsx
+++ b/frontend/src/components/private-ai-keys-table.tsx
@@ -31,7 +31,6 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Eye, EyeOff, Pencil, Loader2 } from 'lucide-react';
-import { useToast } from '@/hooks/use-toast';
 import { formatTimeUntil } from '@/lib/utils';
 import { PrivateAIKey } from '@/types/private-ai-key';
 
@@ -41,7 +40,12 @@ interface PrivateAIKeysTableProps {
   isLoading?: boolean;
   showOwner?: boolean;
   showSpend?: boolean;
-  spendMap?: Record<number, any>;
+  spendMap?: Record<number, {
+    spend: number;
+    max_budget: number | null;
+    budget_duration: string | null;
+    budget_reset_at: string | null;
+  }>;
   onLoadSpend?: (keyId: number) => void;
   onUpdateBudget?: (keyId: number, budgetDuration: string) => void;
   isDeleting?: boolean;
@@ -64,7 +68,6 @@ export function PrivateAIKeysTable({
   teamDetails = {},
   teamMembers = [],
 }: PrivateAIKeysTableProps) {
-  const { toast } = useToast();
   const [showPassword, setShowPassword] = useState<Record<number | string, boolean>>({});
   const [openBudgetDialog, setOpenBudgetDialog] = useState<number | null>(null);
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,3 +4,16 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function formatTimeUntil(date: string): string {
+  const now = new Date();
+  const resetDate = new Date(date);
+  const diffMs = resetDate.getTime() - now.getTime();
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffMinutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
+
+  if (diffHours > 0) {
+    return `in ${diffHours}h ${diffMinutes}m`;
+  }
+  return `in ${diffMinutes}m`;
+}

--- a/frontend/src/types/private-ai-key.ts
+++ b/frontend/src/types/private-ai-key.ts
@@ -1,0 +1,13 @@
+export interface PrivateAIKey {
+  id: number;
+  name: string;
+  database_name: string;
+  database_host: string;
+  database_username: string;
+  database_password: string;
+  region: string;
+  created_at: string;
+  owner_id: number;
+  litellm_token?: string;
+  litellm_api_url?: string;
+}

--- a/frontend/src/types/private-ai-key.ts
+++ b/frontend/src/types/private-ai-key.ts
@@ -8,6 +8,8 @@ export interface PrivateAIKey {
   region: string;
   created_at: string;
   owner_id: number;
+  team_id?: number;
+  team_name?: string;
   litellm_token?: string;
   litellm_api_url?: string;
 }

--- a/scripts/manage_migrations.py
+++ b/scripts/manage_migrations.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import os
 import sys
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,10 @@ def test_team(db):
     return team
 
 @pytest.fixture
+def test_team_id(test_team):
+    return test_team.id
+
+@pytest.fixture
 def test_team_user(db, test_team):
     user = DBUser(
         email="teamuser@example.com",
@@ -154,6 +158,32 @@ def team_admin_token(client, test_team_admin):
     return response.json()["access_token"]
 
 @pytest.fixture
+def test_team_key_creator(db, test_team):
+    user = DBUser(
+        email="teamkeycreator@example.com",
+        hashed_password=get_password_hash("password123"),
+        is_active=True,
+        is_admin=False,
+        role="key_creator",
+        team_id=test_team.id,
+        created_at=datetime.now(UTC)
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    db.merge(test_team)
+    db.refresh(test_team)
+    return user
+
+@pytest.fixture
+def team_key_creator_token(client, test_team_key_creator):
+    response = client.post(
+        "/auth/login",
+        data={"username": test_team_key_creator.email, "password": "password123"}
+    )
+    return response.json()["access_token"]
+
+@pytest.fixture
 def test_region(db):
     region = DBRegion(
         name="test-region",
@@ -169,3 +199,27 @@ def test_region(db):
     db.commit()
     db.refresh(region)
     return region
+
+@pytest.fixture
+def test_team_read_only(db, test_team):
+    user = DBUser(
+        email="teamreadonly@example.com",
+        hashed_password=get_password_hash("password123"),
+        is_active=True,
+        is_admin=False,
+        role="read_only",
+        team_id=test_team.id,
+        created_at=datetime.now(UTC)
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+@pytest.fixture
+def team_read_only_token(client, test_team_read_only):
+    response = client.post(
+        "/auth/login",
+        data={"username": test_team_read_only.email, "password": "password123"}
+    )
+    return response.json()["access_token"]

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -10,52 +10,6 @@ from app.core.security import get_password_hash
 def mock_litellm_response():
     return {"key": "test-private-key-123"}
 
-def test_create_region(client, test_admin, admin_token):
-    """Test creating a new region with private AI key settings"""
-    region_data = {
-        "name": "new-region",
-        "postgres_host": "new-host",
-        "postgres_port": 5432,
-        "postgres_admin_user": "new-admin",
-        "postgres_admin_password": "new-password",
-        "litellm_api_url": "https://new-litellm.com",
-        "litellm_api_key": "new-litellm-key"
-    }
-
-    response = client.post(
-        "/regions/",
-        headers={"Authorization": f"Bearer {admin_token}"},
-        json=region_data
-    )
-
-    assert response.status_code == 200
-    data = response.json()
-    assert data["name"] == region_data["name"]
-    assert data["postgres_host"] == region_data["postgres_host"]
-    assert data["litellm_api_url"] == region_data["litellm_api_url"]
-    assert "id" in data
-
-def test_create_region_non_admin(client, test_user, test_token):
-    """Test that non-admin users cannot create regions"""
-    region_data = {
-        "name": "new-region",
-        "postgres_host": "new-host",
-        "postgres_port": 5432,
-        "postgres_admin_user": "new-admin",
-        "postgres_admin_password": "new-password",
-        "litellm_api_url": "https://new-litellm.com",
-        "litellm_api_key": "new-litellm-key"
-    }
-
-    response = client.post(
-        "/regions/",
-        headers={"Authorization": f"Bearer {test_token}"},
-        json=region_data
-    )
-
-    assert response.status_code == 403
-    assert "Only administrators can create regions" in response.json()["detail"]
-
 @patch("app.services.litellm.requests.post")
 def test_create_private_ai_key(mock_post, client, test_token, test_region, mock_litellm_response, test_user):
     """Test creating a private AI key in a specific region"""
@@ -126,30 +80,6 @@ def test_list_private_ai_keys(client, test_token, test_region, db, test_user):
     assert data[0]["database_name"] == "test-db"
     assert data[0]["region"] == test_region.name
     assert data[0]["owner_id"] == test_user.id
-
-def test_delete_region_with_active_keys(client, admin_token, test_region, db, test_admin):
-    """Test that a region with active private AI keys cannot be deleted"""
-    # Create a test private AI key in the region
-    test_key = DBPrivateAIKey(
-        database_name="test-db",
-        database_host="test-host",
-        database_username="test-user",
-        database_password="test-pass",
-        litellm_token="test-token",
-        owner_id=test_admin.id,
-        region_id=test_region.id
-    )
-    db.add(test_key)
-    db.commit()
-
-    response = client.delete(
-        f"/regions/{test_region.id}",
-        headers={"Authorization": f"Bearer {admin_token}"}
-    )
-
-    assert response.status_code == 400
-    assert "Cannot delete region" in response.json()["detail"]
-    assert "database(s) are currently using this region" in response.json()["detail"]
 
 @patch("app.services.litellm.requests.post")
 def test_delete_private_ai_key(mock_post, client, test_token, test_region, db, test_user):

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -1,0 +1,72 @@
+import pytest
+from app.db.models import DBPrivateAIKey
+
+def test_create_region(client, admin_token):
+    """Test creating a new region with private AI key settings"""
+    region_data = {
+        "name": "new-region",
+        "postgres_host": "new-host",
+        "postgres_port": 5432,
+        "postgres_admin_user": "new-admin",
+        "postgres_admin_password": "new-password",
+        "litellm_api_url": "https://new-litellm.com",
+        "litellm_api_key": "new-litellm-key"
+    }
+
+    response = client.post(
+        "/regions/",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json=region_data
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == region_data["name"]
+    assert data["postgres_host"] == region_data["postgres_host"]
+    assert data["litellm_api_url"] == region_data["litellm_api_url"]
+    assert "id" in data
+
+def test_create_region_non_admin(client, test_token):
+    """Test that non-admin users cannot create regions"""
+    region_data = {
+        "name": "new-region",
+        "postgres_host": "new-host",
+        "postgres_port": 5432,
+        "postgres_admin_user": "new-admin",
+        "postgres_admin_password": "new-password",
+        "litellm_api_url": "https://new-litellm.com",
+        "litellm_api_key": "new-litellm-key"
+    }
+
+    response = client.post(
+        "/regions/",
+        headers={"Authorization": f"Bearer {test_token}"},
+        json=region_data
+    )
+
+    assert response.status_code == 403
+    assert "Only administrators can create regions" in response.json()["detail"]
+
+def test_delete_region_with_active_keys(client, admin_token, test_region, db, test_admin):
+    """Test that a region with active private AI keys cannot be deleted"""
+    # Create a test private AI key in the region
+    test_key = DBPrivateAIKey(
+        database_name="test-db",
+        database_host="test-host",
+        database_username="test-user",
+        database_password="test-pass",
+        litellm_token="test-token",
+        owner_id=test_admin.id,
+        region_id=test_region.id
+    )
+    db.add(test_key)
+    db.commit()
+
+    response = client.delete(
+        f"/regions/{test_region.id}",
+        headers={"Authorization": f"Bearer {admin_token}"}
+    )
+
+    assert response.status_code == 400
+    assert "Cannot delete region" in response.json()["detail"]
+    assert "database(s) are currently using this region" in response.json()["detail"]


### PR DESCRIPTION
This refactor splits creation of LLM tokens and vector DBs as well as allowing AI keys to be owned by teams rather than only by users.

The refactor is necessary because in general usage there are expected to be more LLM tokens than Vector DB credentials. This allows us to not create a large number of entirely unused DBs. We maintain the original database table and API route for backwards compatibility since trial users exist. The refactor also cleans up the `private_ai` class, and ensures the `lite_llm` service is used for all downstream calls. Tests have been added (positive and negative) to ensure no functionality has been removed as new functionality is added.