### PR TITLE
add post-rollout task to purge Fastly cache in production

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -15,3 +15,18 @@ environments:
             insecure: Redirect
             hstsEnabled: true
 
+tasks:
+  post-rollout:
+    - run:
+        name: purge fastly
+        command: |
+          # Extract service ID (remove ":true" if present)
+          SERVICE_ID="${LAGOON_FASTLY_SERVICE_ID%%:*}"
+
+          # Purge all cache for the service using Fastly API
+          curl -X POST "https://api.fastly.com/service/$SERVICE_ID/purge_all" \
+            -H "Fastly-Key: $FASTLY_TOKEN" \
+            -H "Accept: application/json"
+        service: backend
+        shell: bash
+        when: ENVIRONMENT == "prod"


### PR DESCRIPTION
- Implemented a new task in `.lagoon.yml` to purge all cache for the Fastly service after deployment.
- The task extracts the service ID and uses the Fastly API to clear the cache, ensuring up-to-date content in production environments.