### PR TITLE
Manual Stripe Subscriptions

### DIFF
--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -331,3 +331,14 @@ class PricingTablesResponse(BaseModel):
     standard: PricingTableResponse | None
     always_free: PricingTableResponse | None
     model_config = ConfigDict(from_attributes=True)
+
+class SubscriptionCreate(BaseModel):
+    product_id: str  # Stripe product ID
+    model_config = ConfigDict(from_attributes=True)
+
+class SubscriptionResponse(BaseModel):
+    subscription_id: str
+    product_id: str
+    team_id: int
+    created_at: datetime
+    model_config = ConfigDict(from_attributes=True)

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -214,3 +214,153 @@ def test_get_pricing_table_session_stripe_error(mock_get_session, client, db, te
     # Assert
     assert response.status_code == 500
     assert response.json()["detail"] == "Error creating customer session"
+
+# Tests for subscription creation endpoint
+@patch('app.api.billing.create_zero_rated_stripe_subscription', new_callable=AsyncMock)
+@patch('app.api.billing.create_stripe_customer', new_callable=AsyncMock)
+def test_create_team_subscription_success_existing_customer(mock_create_customer, mock_create_subscription, client, db, test_team, test_product, admin_token):
+    """Test successful subscription creation for team with existing Stripe customer"""
+    # Arrange
+    test_team.stripe_customer_id = "cus_123"
+    db.add(test_team)
+    db.add(test_product)
+    db.commit()
+
+    mock_subscription_id = "sub_123"
+    mock_create_subscription.return_value = mock_subscription_id
+
+    # Act
+    response = client.post(
+        f"/billing/teams/{test_team.id}/subscriptions",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"product_id": test_product.id}
+    )
+
+    # Assert
+    assert response.status_code == 201
+    data = response.json()
+    assert data["subscription_id"] == mock_subscription_id
+    assert data["product_id"] == test_product.id
+    assert data["team_id"] == test_team.id
+    assert "created_at" in data
+
+    mock_create_subscription.assert_called_once_with(
+        customer_id="cus_123",
+        product_id=test_product.id
+    )
+    mock_create_customer.assert_not_called()
+
+@patch('app.api.billing.create_zero_rated_stripe_subscription', new_callable=AsyncMock)
+@patch('app.api.billing.create_stripe_customer', new_callable=AsyncMock)
+def test_create_team_subscription_success_new_customer(mock_create_customer, mock_create_subscription, client, db, test_team, test_product, admin_token):
+    """Test successful subscription creation for team without existing Stripe customer"""
+    # Arrange
+    test_team.stripe_customer_id = None
+    db.add(test_team)
+    db.add(test_product)
+    db.commit()
+    db.refresh(test_product)
+    product_id = test_product.id
+
+    mock_customer_id = "cus_new_123"
+    mock_subscription_id = "sub_123"
+    mock_create_customer.return_value = mock_customer_id
+    mock_create_subscription.return_value = mock_subscription_id
+
+    # Act
+    response = client.post(
+        f"/billing/teams/{test_team.id}/subscriptions",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"product_id": product_id}
+    )
+
+    # Assert
+    assert response.status_code == 201
+    data = response.json()
+    assert data["subscription_id"] == mock_subscription_id
+    assert data["product_id"] == product_id
+    assert data["team_id"] == test_team.id
+    assert "created_at" in data
+
+    mock_create_customer.assert_called_once_with(test_team)
+    mock_create_subscription.assert_called_once_with(
+        customer_id=mock_customer_id,
+        product_id=product_id
+    )
+
+def test_create_team_subscription_team_not_found(client, db, test_product, admin_token):
+    """Test subscription creation with non-existent team"""
+    # Arrange
+    db.add(test_product)
+    db.commit()
+    non_existent_team_id = 999
+
+    # Act
+    response = client.post(
+        f"/billing/teams/{non_existent_team_id}/subscriptions",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"product_id": test_product.id}
+    )
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Team not found"
+
+def test_create_team_subscription_product_not_found(client, db, test_team, admin_token):
+    """Test subscription creation with non-existent product"""
+    # Arrange
+    db.add(test_team)
+    db.commit()
+    non_existent_product_id = "prod_nonexistent"
+
+    # Act
+    response = client.post(
+        f"/billing/teams/{test_team.id}/subscriptions",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"product_id": non_existent_product_id}
+    )
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json()["detail"] == f"Product with ID {non_existent_product_id} not found in database"
+
+def test_create_team_subscription_unauthorized(client, db, test_team, test_product, team_admin_token):
+    """Test subscription creation without system admin privileges"""
+    # Arrange
+    db.add(test_team)
+    db.add(test_product)
+    db.commit()
+
+    # Act
+    response = client.post(
+        f"/billing/teams/{test_team.id}/subscriptions",
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+        json={"product_id": test_product.id}
+    )
+
+    # Assert
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Not authorized to perform this action"
+
+@patch('app.api.billing.create_zero_rated_stripe_subscription', new_callable=AsyncMock)
+@patch('app.api.billing.create_stripe_customer', new_callable=AsyncMock)
+def test_create_team_subscription_stripe_error(mock_create_customer, mock_create_subscription, client, db, test_team, test_product, admin_token):
+    """Test subscription creation when Stripe API returns an error"""
+    # Arrange
+    test_team.stripe_customer_id = "cus_123"
+    db.add(test_team)
+    db.add(test_product)
+    db.commit()
+
+    mock_create_subscription.side_effect = Exception("Stripe API error")
+
+    # Act
+    response = client.post(
+        f"/billing/teams/{test_team.id}/subscriptions",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"product_id": test_product.id}
+    )
+
+    # Assert
+    assert response.status_code == 500
+    assert "Error creating subscription" in response.json()["detail"]

--- a/tests/test_stripe.py
+++ b/tests/test_stripe.py
@@ -1,0 +1,311 @@
+import pytest
+import asyncio
+from unittest.mock import patch, AsyncMock, MagicMock
+from app.services.stripe import create_zero_rated_stripe_subscription
+from fastapi import HTTPException
+import stripe
+
+"""
+Test cases for create_stripe_subscription function
+
+Given: A Stripe service with create_stripe_subscription function
+When: Creating subscriptions for free products
+Then: Validate business rules and handle various scenarios
+"""
+
+@patch('app.services.stripe.stripe.Price.list')
+@patch('app.services.stripe.stripe.Price.retrieve')
+@patch('app.services.stripe.stripe.Subscription.create')
+def test_create_stripe_subscription_success_no_price_id(
+    mock_subscription_create,
+    mock_price_retrieve,
+    mock_price_list
+):
+    """
+    Given: A customer and product with a single free price
+    When: Creating a subscription without specifying price_id
+    Then: Successfully create the subscription using the default price
+    """
+    # Arrange
+    customer_id = "cus_123456789"
+    product_id = "prod_123456789"
+
+    # Mock price list response
+    mock_response = MagicMock()
+    mock_response.data = [
+        MagicMock(id="price_123456789")
+    ]
+    mock_price_list.return_value = mock_response
+
+    # Mock price retrieve response
+    mock_price = MagicMock()
+    mock_price.unit_amount = 0
+    mock_price.currency = "usd"
+    mock_price_retrieve.return_value = mock_price
+
+    # Mock subscription create response
+    mock_subscription = MagicMock()
+    mock_subscription.id = "sub_123456789"
+    mock_subscription_create.return_value = mock_subscription
+
+    # Act
+    result = asyncio.run(create_zero_rated_stripe_subscription(customer_id, product_id))
+
+    # Assert
+    assert result == "sub_123456789"
+    mock_price_list.assert_called_once_with(product=product_id, active=True)
+    mock_price_retrieve.assert_called_once_with("price_123456789")
+    mock_subscription_create.assert_called_once_with(
+        customer=customer_id,
+        items=[{"price": "price_123456789"}],
+        payment_behavior="allow_incomplete",
+        expand=["latest_invoice"]
+    )
+
+@patch('app.services.stripe.stripe.Price.retrieve')
+@patch('app.services.stripe.stripe.Subscription.create')
+def test_create_stripe_subscription_success_with_price_id(
+    mock_subscription_create,
+    mock_price_retrieve
+):
+    """
+    Given: A customer, product, and specific price_id for a free product
+    When: Creating a subscription with a specific price_id
+    Then: Successfully create the subscription using the specified price
+    """
+    # Arrange
+    customer_id = "cus_123456789"
+    product_id = "prod_123456789"
+    price_id = "price_987654321"
+
+    # Mock price retrieve response
+    mock_price = MagicMock()
+    mock_price.unit_amount = 0
+    mock_price.currency = "usd"
+    mock_price_retrieve.return_value = mock_price
+
+    # Mock subscription create response
+    mock_subscription = MagicMock()
+    mock_subscription.id = "sub_987654321"
+    mock_subscription_create.return_value = mock_subscription
+
+    # Act
+    result = asyncio.run(create_zero_rated_stripe_subscription(customer_id, product_id, price_id))
+
+    # Assert
+    assert result == "sub_987654321"
+    mock_price_retrieve.assert_called_once_with(price_id)
+    mock_subscription_create.assert_called_once_with(
+        customer=customer_id,
+        items=[{"price": price_id}],
+        payment_behavior="allow_incomplete",
+        expand=["latest_invoice"]
+    )
+
+@patch('app.services.stripe.stripe.Price.list')
+def test_create_stripe_subscription_no_active_prices(mock_price_list):
+    """
+    Given: A product with no active prices
+    When: Creating a subscription without specifying price_id
+    Then: Raise HTTPException with appropriate error message
+    """
+    # Arrange
+    customer_id = "cus_123456789"
+    product_id = "prod_123456789"
+
+    # Mock empty price list response
+    mock_response = MagicMock()
+    mock_response.data = []
+    mock_price_list.return_value = mock_response
+
+    # Act & Assert
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(create_zero_rated_stripe_subscription(customer_id, product_id))
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == f"No active prices found for product {product_id}"
+
+@patch('app.services.stripe.stripe.Price.list')
+def test_create_stripe_subscription_multiple_prices(mock_price_list):
+    """
+    Given: A product with multiple active prices
+    When: Creating a subscription without specifying price_id
+    Then: Raise HTTPException indicating free products should have only one price
+    """
+    # Arrange
+    customer_id = "cus_123456789"
+    product_id = "prod_123456789"
+
+    # Mock multiple prices response
+    mock_response = MagicMock()
+    mock_response.data = [
+        MagicMock(id="price_1"),
+        MagicMock(id="price_2")
+    ]
+    mock_price_list.return_value = mock_response
+
+    # Act & Assert
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(create_zero_rated_stripe_subscription(customer_id, product_id))
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == f"Multiple prices found for product {product_id}. Free products should have only one price."
+
+@patch('app.services.stripe.stripe.Price.list')
+@patch('app.services.stripe.stripe.Price.retrieve')
+def test_create_stripe_subscription_non_free_product(mock_price_retrieve, mock_price_list):
+    """
+    Given: A product with a non-zero price
+    When: Creating a subscription
+    Then: Raise HTTPException indicating the product is not free
+    """
+    # Arrange
+    customer_id = "cus_123456789"
+    product_id = "prod_123456789"
+
+    # Mock price list response
+    mock_response = MagicMock()
+    mock_response.data = [
+        MagicMock(id="price_123456789")
+    ]
+    mock_price_list.return_value = mock_response
+
+    # Mock price retrieve response with non-zero amount
+    mock_price = MagicMock()
+    mock_price.unit_amount = 1000  # $10.00
+    mock_price.currency = "usd"
+    mock_price_retrieve.return_value = mock_price
+
+    # Act & Assert
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(create_zero_rated_stripe_subscription(customer_id, product_id))
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == f"Product {product_id} is not free. Price amount: 1000 usd"
+
+@patch('app.services.stripe.stripe.Price.retrieve')
+def test_create_stripe_subscription_with_price_id_non_free(mock_price_retrieve):
+    """
+    Given: A specific price_id with non-zero amount
+    When: Creating a subscription with that price_id
+    Then: Raise HTTPException indicating the product is not free
+    """
+    # Arrange
+    customer_id = "cus_123456789"
+    product_id = "prod_123456789"
+    price_id = "price_987654321"
+
+    # Mock price retrieve response with non-zero amount
+    mock_price = MagicMock()
+    mock_price.unit_amount = 2000  # $20.00
+    mock_price.currency = "usd"
+    mock_price_retrieve.return_value = mock_price
+
+    # Act & Assert
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(create_zero_rated_stripe_subscription(customer_id, product_id, price_id))
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == f"Product {product_id} is not free. Price amount: 2000 usd"
+
+@patch('app.services.stripe.stripe.Price.list')
+@patch('app.services.stripe.stripe.Price.retrieve')
+@patch('app.services.stripe.stripe.Subscription.create')
+def test_create_stripe_subscription_stripe_error(
+    mock_subscription_create,
+    mock_price_retrieve,
+    mock_price_list
+):
+    """
+    Given: Valid free product but Stripe API error during subscription creation
+    When: Creating a subscription
+    Then: Raise HTTPException with Stripe error details
+    """
+    # Arrange
+    customer_id = "cus_123456789"
+    product_id = "prod_123456789"
+
+    # Mock price list response
+    mock_response = MagicMock()
+    mock_response.data = [
+        MagicMock(id="price_123456789")
+    ]
+    mock_price_list.return_value = mock_response
+
+    # Mock price retrieve response
+    mock_price = MagicMock()
+    mock_price.unit_amount = 0
+    mock_price.currency = "usd"
+    mock_price_retrieve.return_value = mock_price
+
+    # Mock Stripe error
+    mock_subscription_create.side_effect = stripe.error.StripeError("Customer not found")
+
+    # Act & Assert
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(create_zero_rated_stripe_subscription(customer_id, product_id))
+
+    assert exc_info.value.status_code == 400
+    assert "Error creating subscription: Customer not found" in exc_info.value.detail
+
+@patch('app.services.stripe.stripe.Price.list')
+@patch('app.services.stripe.stripe.Price.retrieve')
+@patch('app.services.stripe.stripe.Subscription.create')
+def test_create_stripe_subscription_general_exception(
+    mock_subscription_create,
+    mock_price_retrieve,
+    mock_price_list
+):
+    """
+    Given: Valid free product but unexpected error during subscription creation
+    When: Creating a subscription
+    Then: Raise HTTPException with generic error message
+    """
+    # Arrange
+    customer_id = "cus_123456789"
+    product_id = "prod_123456789"
+
+    # Mock price list response
+    mock_response = MagicMock()
+    mock_response.data = [
+        MagicMock(id="price_123456789")
+    ]
+    mock_price_list.return_value = mock_response
+
+    # Mock price retrieve response
+    mock_price = MagicMock()
+    mock_price.unit_amount = 0
+    mock_price.currency = "usd"
+    mock_price_retrieve.return_value = mock_price
+
+    # Mock general exception
+    mock_subscription_create.side_effect = Exception("Unexpected error")
+
+    # Act & Assert
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(create_zero_rated_stripe_subscription(customer_id, product_id))
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "Error creating subscription"
+
+@patch('app.services.stripe.stripe.Price.retrieve')
+def test_create_stripe_subscription_price_retrieve_error(mock_price_retrieve):
+    """
+    Given: A price_id that cannot be retrieved
+    When: Creating a subscription with that price_id
+    Then: Raise HTTPException with Stripe error details
+    """
+    # Arrange
+    customer_id = "cus_123456789"
+    product_id = "prod_123456789"
+    price_id = "price_invalid"
+
+    # Mock Stripe error during price retrieval
+    mock_price_retrieve.side_effect = stripe.error.StripeError("Price not found")
+
+    # Act & Assert
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(create_zero_rated_stripe_subscription(customer_id, product_id, price_id))
+
+    assert exc_info.value.status_code == 400
+    assert "Error creating subscription: Price not found" in exc_info.value.detail


### PR DESCRIPTION
The purpose of this change is to allow an admin user to subscribe a customer to a zero-rated stripe product. This is useful for customers being billed externally from amazee.ai, but for whom we want automated limits and resets in place.