### PR TITLE
feat: enhance API token management for users and admins

### DIFF
--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -46,7 +46,7 @@ class APITokenBase(BaseModel):
     name: str
 
 class APITokenCreate(APITokenBase):
-    pass
+    user_id: Optional[int] = None
 
 class APIToken(APITokenBase):
     id: int


### PR DESCRIPTION
- Updated the create_token endpoint to allow system administrators to create tokens for any user by specifying user_id, while regular users can only create tokens for themselves.
- Enhanced the list_tokens endpoint to enable system administrators to list tokens for any user by specifying user_id, with appropriate authorization checks.
- Added validation to ensure target users exist when creating or listing tokens.
- Modified the APITokenCreate schema to include an optional user_id field.
- Introduced comprehensive tests for various scenarios, including token creation and listing for both regular users and system administrators.