### PR TITLE
chore: update min_capacity for VectorDB clusters and bump PostgreSQL engine version

### DIFF
--- a/terraform/modules/postgres_cluster/main.tf
+++ b/terraform/modules/postgres_cluster/main.tf
@@ -27,7 +27,7 @@ module "aurora" {
   }
 
   engine         = "aurora-postgresql"
-  engine_version = "16.4"
+  engine_version = "16.6"
   engine_mode    = "provisioned"
 
   availability_zones = var.availability_zones

--- a/terraform/vectordb_prod.tf
+++ b/terraform/vectordb_prod.tf
@@ -11,7 +11,7 @@ module "vectordb_prod_eu_central_1" {
   clusters  = {
     amazeeai-de103-vectordb1 = {
       instance_count   = 2
-      min_capacity     = 2
+      min_capacity     = 0.5
       max_capacity     = 16
       backup_window    = "06:42-07:12"
       maintenance_window = "wed:04:35-wed:05:05"
@@ -35,7 +35,7 @@ module "vectordb_prod_eu_central_2" {
   clusters  = {
     amazeeai-ch103-vectordb1 = {
       instance_count   = 2
-      min_capacity     = 2
+      min_capacity     = 0.5
       max_capacity     = 16
       backup_window    = "06:42-07:12"
       maintenance_window = "wed:04:35-wed:05:05"
@@ -58,7 +58,7 @@ module "vectordb_prod_us_east_1" {
   clusters  = {
     amazeeai-us103-vectordb1 = {
       instance_count   = 2
-      min_capacity     = 2
+      min_capacity     = 0.5
       max_capacity     = 16
       backup_window    = "06:42-07:12"
       maintenance_window = "wed:04:35-wed:05:05"
@@ -81,7 +81,7 @@ module "vectordb_prod_eu_west_2" {
   clusters  = {
     amazeeai-uk103-vectordb1 = {
       instance_count   = 2
-      min_capacity     = 2
+      min_capacity     = 0.5
       max_capacity     = 16
       backup_window    = "06:42-07:12"
       maintenance_window = "wed:04:35-wed:05:05"
@@ -105,7 +105,7 @@ module "vectordb_prod_ap_southeast_2" {
   clusters  = {
     amazeeai-au103-vectordb1 = {
       instance_count   = 2
-      min_capacity     = 2
+      min_capacity     = 0.5
       max_capacity     = 16
       backup_window    = "06:42-07:12"
       maintenance_window = "wed:04:35-wed:05:05"


### PR DESCRIPTION
- Changed min_capacity from 2 to 0.5 for all VectorDB clusters in vectordb_prod.tf.
- Updated PostgreSQL engine version from 16.4 to 16.6 in the postgres_cluster module.