### PR TITLE
Update public paths and enhance Prometheus middleware handling

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -19,7 +19,7 @@ class Settings(BaseSettings):
         "http://localhost:8800"
     ]
     ALLOWED_HOSTS: list[str] = ["*"]  # In production, restrict this
-    PUBLIC_PATHS: list[str] = ["/health", "/docs", "/openapi.json", "/metrics"]
+    PUBLIC_PATHS: list[str] = ["/health", "/docs", "/openapi.json"]
 
     AWS_ACCESS_KEY_ID: str = "AKIATEST"
     AWS_SECRET_ACCESS_KEY: str = "sk-string"

--- a/app/middleware/prometheus.py
+++ b/app/middleware/prometheus.py
@@ -44,6 +44,10 @@ class PrometheusMiddleware(BaseHTTPMiddleware):
         if request.url.path in settings.PUBLIC_PATHS:
             return await call_next(request)
 
+        # Skip processing for the /metrics endpoint itself
+        if request.url.path == "/metrics":
+            return await call_next(request)
+
         # Track auth requests for specific endpoints
         is_auth_endpoint = request.url.path in [
             "/auth/login",


### PR DESCRIPTION
- Removed the "/metrics" endpoint from the PUBLIC_PATHS list in the settings.
- Added logic in PrometheusMiddleware to skip processing for the "/metrics" endpoint itself, ensuring proper request handling.