### PR TITLE
Add Prometheus API key support and enhance metrics authorization handling

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -33,6 +33,7 @@ class Settings(BaseSettings):
     STRIPE_PUBLISHABLE_KEY: str = os.getenv("STRIPE_PUBLISHABLE_KEY", "pk_test_string")
     WEBHOOK_SIG: str = os.getenv("WEBHOOK_SIG", "whsec_test_1234567890")
     ENABLE_METRICS: bool = os.getenv("ENABLE_METRICS", "false") == "true"
+    PROMETHEUS_API_KEY: str = os.getenv("PROMETHEUS_API_KEY", "")
 
     model_config = ConfigDict(env_file=".env")
     main_route: str = os.getenv("LAGOON_ROUTE", "http://localhost:8800")

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -8,3 +8,6 @@ scrape_configs:
       - targets: ['backend:8800']
     metrics_path: '/metrics'
     scheme: 'http'
+    authorization:
+      type: 'Bearer'
+      credentials: 'test-key'


### PR DESCRIPTION
- Introduced a new environment variable for PROMETHEUS_API_KEY in the settings.
- Updated AuthMiddleware to validate Bearer tokens for the /metrics endpoint, returning a 404 response if validation fails.
- Modified Prometheus configuration to include Bearer token authorization for metrics scraping.