### PR TITLE
Async Calls and double counting bugfix

### DIFF
--- a/app/core/resource_limits.py
+++ b/app/core/resource_limits.py
@@ -28,7 +28,7 @@ def check_team_user_limit(db: Session, team_id: int) -> None:
     """
     # Get current user count and max allowed users in a single query
     result = db.query(
-        func.count(DBUser.id).label('current_user_count'),
+        func.count(func.distinct(DBUser.id)).label('current_user_count'),
         func.coalesce(func.max(DBProduct.user_count), DEFAULT_USER_COUNT).label('max_users')
     ).select_from(DBUser).filter(
         DBUser.team_id == team_id
@@ -64,14 +64,14 @@ def check_key_limits(db: Session, team_id: int, owner_id: Optional[int] = None) 
         func.coalesce(func.max(DBProduct.total_key_count), DEFAULT_TOTAL_KEYS).label('max_total_keys'),
         func.coalesce(func.max(DBProduct.keys_per_user), DEFAULT_KEYS_PER_USER).label('max_keys_per_user'),
         func.coalesce(func.max(DBProduct.service_key_count), DEFAULT_SERVICE_KEYS).label('max_service_keys'),
-        func.count(DBPrivateAIKey.id).filter(
+        func.count(func.distinct(DBPrivateAIKey.id)).filter(
             DBPrivateAIKey.litellm_token.isnot(None)
         ).label('current_team_keys'),
-        func.count(DBPrivateAIKey.id).filter(
+        func.count(func.distinct(DBPrivateAIKey.id)).filter(
             DBPrivateAIKey.owner_id == owner_id,
             DBPrivateAIKey.litellm_token.isnot(None)
         ).label('current_user_keys') if owner_id else None,
-        func.count(DBPrivateAIKey.id).filter(
+        func.count(func.distinct(DBPrivateAIKey.id)).filter(
             DBPrivateAIKey.owner_id.is_(None),
             DBPrivateAIKey.litellm_token.isnot(None)
         ).label('current_service_keys')
@@ -126,7 +126,7 @@ def check_vector_db_limits(db: Session, team_id: int) -> None:
     # Get vector DB limits and current count in a single query
     result = db.query(
         func.coalesce(func.max(DBProduct.vector_db_count), DEFAULT_VECTOR_DB_COUNT).label('max_vector_db_count'),
-        func.count(DBPrivateAIKey.id).filter(
+        func.count(func.distinct(DBPrivateAIKey.id)).filter(
             DBPrivateAIKey.database_name.isnot(None)
         ).label('current_vector_db_count')
     ).select_from(DBTeam).filter(

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ prometheus-fastapi-instrumentator==7.0.0
 stripe==12.1.0
 six==1.17.0
 apscheduler==3.10.4
+httpx==0.28.1

--- a/scripts/add_test_data.py
+++ b/scripts/add_test_data.py
@@ -4,14 +4,16 @@ import os
 import sys
 from datetime import datetime, timedelta, UTC
 import random
+import asyncio
 
 # Add the parent directory to the Python path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from sqlalchemy.orm import sessionmaker, Session
 from app.db.database import engine
-from app.db.models import DBTeam, DBUser, DBProduct, DBTeamProduct
+from app.db.models import DBTeam, DBUser, DBProduct, DBTeamProduct, DBRegion, DBPrivateAIKey
 from app.core.security import get_password_hash
+from app.services.litellm import LiteLLMService
 
 def create_test_data():
     """Create test data for teams, users, and products"""
@@ -264,10 +266,49 @@ def create_test_data():
     finally:
         db.close()
 
+async def create_test_keys(count: int):
+    # Create database session
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = SessionLocal()
+
+    try:
+        team = db.query(DBTeam).first()
+        region = db.query(DBRegion).filter(DBRegion.is_active == True).first()
+        if not region:
+            print(f"No active regions, not creating test keys")
+            return
+        litellm = LiteLLMService(region.litellm_api_url, region.litellm_api_key)
+        team_id = team.id
+        for i in range(0, count):
+            key_name = f"auto_test_{i}"
+            litellm_token = await litellm.create_key(
+                email=team.admin_email,
+                name=key_name,
+                user_id=team_id,
+                team_id=LiteLLMService.format_team_id(region.name, team_id),
+            )
+
+            # Create response object
+            db_token = DBPrivateAIKey(
+                litellm_token=litellm_token,
+                litellm_api_url=region.litellm_api_url,
+                owner_id=None,
+                team_id=None if team_id is None else team_id,
+                name=key_name,
+                region_id = region.id
+            )
+            db.add(db_token)
+            db.commit()
+            print(f"Created LLM token {key_name} int team {team.name}")
+
+    except Exception as e:
+        print(f"failed to create test keys {str(e)}")
+
 def main():
     """Main function to run the script"""
     try:
         create_test_data()
+        asyncio.run(create_test_keys(50))
     except Exception as e:
         print(f"Script failed: {str(e)}")
         sys.exit(1)

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -1,8 +1,5 @@
 import pytest
-from unittest.mock import Mock, patch, AsyncMock
-from app.api.billing import handle_stripe_event_background
-from app.db.models import DBTeamProduct
-from stripe._customer_session import CustomerSession
+from unittest.mock import patch, AsyncMock
 
 @patch('app.api.billing.create_portal_session', new_callable=AsyncMock)
 def test_get_portal_existing_customer(mock_create_portal, client, db, test_team, team_admin_token):

--- a/tests/test_litellm_service.py
+++ b/tests/test_litellm_service.py
@@ -1,15 +1,32 @@
 import pytest
 import asyncio
-import requests
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock, Mock
 from fastapi import HTTPException
 from app.services.litellm import LiteLLMService
-from requests.exceptions import HTTPError
-
+from httpx import HTTPStatusError
 
 @pytest.fixture
 def mock_litellm_response():
     return {"key": "test-private-key-123"}
+
+
+@pytest.fixture
+def mock_httpx_failure_client():
+    """Mock httpx.AsyncClient for operations that should fail"""
+    def _create_failure_client(status_code, error_message):
+        mock_response = Mock()
+        mock_response.status_code = status_code
+        mock_response.raise_for_status.side_effect = HTTPStatusError(error_message, request=None, response=None)
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_client.get.return_value = mock_response
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+
+        return mock_client
+
+    return _create_failure_client
 
 
 def test_init_with_valid_parameters(test_region):
@@ -34,12 +51,10 @@ def test_init_with_empty_api_key():
         LiteLLMService(api_url="https://test.com", api_key="")
 
 
-@patch("app.services.litellm.requests.post")
-def test_create_key_success(mock_post, test_region, mock_litellm_response):
+@patch("httpx.AsyncClient")
+def test_create_key_success(mock_client_class, test_region, mock_httpx_post_client):
     """Test successful key creation"""
-    mock_post.return_value.status_code = 200
-    mock_post.return_value.json.return_value = mock_litellm_response
-    mock_post.return_value.raise_for_status.return_value = None
+    mock_client_class.return_value = mock_httpx_post_client
 
     service = LiteLLMService(
         api_url=test_region.litellm_api_url,
@@ -54,14 +69,13 @@ def test_create_key_success(mock_post, test_region, mock_litellm_response):
     ))
 
     assert result == "test-private-key-123"
-    mock_post.assert_called_once()
+    mock_httpx_post_client.post.assert_called_once()
 
 
-@patch("app.services.litellm.requests.post")
-def test_create_key_failure(mock_post, test_region):
+@patch("httpx.AsyncClient")
+def test_create_key_failure(mock_client_class, test_region, mock_httpx_failure_client):
     """Test key creation failure"""
-    mock_post.return_value.status_code = 500
-    mock_post.return_value.raise_for_status.side_effect = HTTPError("Internal Server Error")
+    mock_client_class.return_value = mock_httpx_failure_client(500, "Internal Server Error")
 
     service = LiteLLMService(
         api_url=test_region.litellm_api_url,
@@ -80,11 +94,10 @@ def test_create_key_failure(mock_post, test_region):
     assert "Failed to create LiteLLM key" in exc_info.value.detail
 
 
-@patch("app.services.litellm.requests.post")
-def test_delete_key_success(mock_post, test_region):
+@patch("httpx.AsyncClient")
+def test_delete_key_success(mock_client_class, test_region, mock_httpx_post_client):
     """Test successful key deletion"""
-    mock_post.return_value.status_code = 200
-    mock_post.return_value.raise_for_status.return_value = None
+    mock_client_class.return_value = mock_httpx_post_client
 
     service = LiteLLMService(
         api_url=test_region.litellm_api_url,
@@ -94,17 +107,17 @@ def test_delete_key_success(mock_post, test_region):
     result = asyncio.run(service.delete_key("test-token"))
 
     assert result is True
-    mock_post.assert_called_once_with(
+    mock_httpx_post_client.post.assert_called_once_with(
         f"{test_region.litellm_api_url}/key/delete",
         json={"keys": ["test-token"]},
         headers={"Authorization": f"Bearer {test_region.litellm_api_key}"}
     )
 
 
-@patch("app.services.litellm.requests.post")
-def test_delete_key_not_found(mock_post, test_region):
+@patch("httpx.AsyncClient")
+def test_delete_key_not_found(mock_client_class, test_region, mock_httpx_failure_client):
     """Test key deletion when key not found (should return True)"""
-    mock_post.return_value.status_code = 404
+    mock_client_class.return_value = mock_httpx_failure_client(404, "Not Found")
 
     service = LiteLLMService(
         api_url=test_region.litellm_api_url,
@@ -116,11 +129,10 @@ def test_delete_key_not_found(mock_post, test_region):
     assert result is True
 
 
-@patch("app.services.litellm.requests.post")
-def test_delete_key_failure(mock_post, test_region):
+@patch("httpx.AsyncClient")
+def test_delete_key_failure(mock_client_class, test_region, mock_httpx_failure_client):
     """Test key deletion failure"""
-    mock_post.return_value.status_code = 500
-    mock_post.return_value.raise_for_status.side_effect = HTTPError("Internal Server Error")
+    mock_client_class.return_value = mock_httpx_failure_client(500, "Internal Server Error")
 
     service = LiteLLMService(
         api_url=test_region.litellm_api_url,
@@ -134,19 +146,10 @@ def test_delete_key_failure(mock_post, test_region):
     assert "Failed to delete LiteLLM key" in exc_info.value.detail
 
 
-@patch("app.services.litellm.requests.get")
-def test_get_key_info_success(mock_get, test_region):
+@patch("httpx.AsyncClient")
+def test_get_key_info_success(mock_client_class, test_region, mock_httpx_get_client):
     """Test successful key info retrieval"""
-    mock_response = {
-        "info": {
-            "key_name": "Test Key",
-            "spend": 10.5,
-            "expires": "2024-12-31T23:59:59Z"
-        }
-    }
-    mock_get.return_value.status_code = 200
-    mock_get.return_value.json.return_value = mock_response
-    mock_get.return_value.raise_for_status.return_value = None
+    mock_client_class.return_value = mock_httpx_get_client
 
     service = LiteLLMService(
         api_url=test_region.litellm_api_url,
@@ -155,19 +158,29 @@ def test_get_key_info_success(mock_get, test_region):
 
     result = asyncio.run(service.get_key_info("test-token"))
 
-    assert result == mock_response
-    mock_get.assert_called_once_with(
+    expected_response = {
+        "info": {
+            "spend": 10.5,
+            "expires": "2024-12-31T23:59:59Z",
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-02T00:00:00Z",
+            "max_budget": 100.0,
+            "budget_duration": "monthly",
+            "budget_reset_at": "2024-02-01T00:00:00Z"
+        }
+    }
+    assert result == expected_response
+    mock_httpx_get_client.get.assert_called_once_with(
         f"{test_region.litellm_api_url}/key/info",
         headers={"Authorization": f"Bearer {test_region.litellm_api_key}"},
         params={"key": "test-token"}
     )
 
 
-@patch("app.services.litellm.requests.get")
-def test_get_key_info_failure(mock_get, test_region):
+@patch("httpx.AsyncClient")
+def test_get_key_info_failure(mock_client_class, test_region, mock_httpx_failure_client):
     """Test key info retrieval failure"""
-    mock_get.return_value.status_code = 404
-    mock_get.return_value.raise_for_status.side_effect = HTTPError("Not Found")
+    mock_client_class.return_value = mock_httpx_failure_client(404, "Not Found")
 
     service = LiteLLMService(
         api_url=test_region.litellm_api_url,
@@ -181,11 +194,10 @@ def test_get_key_info_failure(mock_get, test_region):
     assert "Failed to get LiteLLM key information" in exc_info.value.detail
 
 
-@patch("app.services.litellm.requests.post")
-def test_update_budget_success(mock_post, test_region):
+@patch("httpx.AsyncClient")
+def test_update_budget_success(mock_client_class, test_region, mock_httpx_post_client):
     """Test successful budget update"""
-    mock_post.return_value.status_code = 200
-    mock_post.return_value.raise_for_status.return_value = None
+    mock_client_class.return_value = mock_httpx_post_client
 
     service = LiteLLMService(
         api_url=test_region.litellm_api_url,
@@ -195,7 +207,7 @@ def test_update_budget_success(mock_post, test_region):
     # This should not raise an exception
     asyncio.run(service.update_budget("test-token", "monthly", 100.0))
 
-    mock_post.assert_called_once_with(
+    mock_httpx_post_client.post.assert_called_once_with(
         f"{test_region.litellm_api_url}/key/update",
         headers={"Authorization": f"Bearer {test_region.litellm_api_key}"},
         json={
@@ -207,11 +219,10 @@ def test_update_budget_success(mock_post, test_region):
     )
 
 
-@patch("app.services.litellm.requests.post")
-def test_update_budget_failure(mock_post, test_region):
+@patch("httpx.AsyncClient")
+def test_update_budget_failure(mock_client_class, test_region, mock_httpx_failure_client):
     """Test budget update failure"""
-    mock_post.return_value.status_code = 400
-    mock_post.return_value.raise_for_status.side_effect = HTTPError("Bad Request")
+    mock_client_class.return_value = mock_httpx_failure_client(400, "Bad Request")
 
     service = LiteLLMService(
         api_url=test_region.litellm_api_url,
@@ -225,11 +236,10 @@ def test_update_budget_failure(mock_post, test_region):
     assert "Failed to update LiteLLM budget" in exc_info.value.detail
 
 
-@patch("app.services.litellm.requests.post")
-def test_update_key_duration_success(mock_post, test_region):
+@patch("httpx.AsyncClient")
+def test_update_key_duration_success(mock_client_class, test_region, mock_httpx_post_client):
     """Test successful key duration update"""
-    mock_post.return_value.status_code = 200
-    mock_post.return_value.raise_for_status.return_value = None
+    mock_client_class.return_value = mock_httpx_post_client
 
     service = LiteLLMService(
         api_url=test_region.litellm_api_url,
@@ -239,7 +249,7 @@ def test_update_key_duration_success(mock_post, test_region):
     # This should not raise an exception
     asyncio.run(service.update_key_duration("test-token", "30d"))
 
-    mock_post.assert_called_once_with(
+    mock_httpx_post_client.post.assert_called_once_with(
         f"{test_region.litellm_api_url}/key/update",
         headers={"Authorization": f"Bearer {test_region.litellm_api_key}"},
         json={
@@ -249,11 +259,10 @@ def test_update_key_duration_success(mock_post, test_region):
     )
 
 
-@patch("app.services.litellm.requests.post")
-def test_update_key_duration_failure(mock_post, test_region):
+@patch("httpx.AsyncClient")
+def test_update_key_duration_failure(mock_client_class, test_region, mock_httpx_failure_client):
     """Test key duration update failure"""
-    mock_post.return_value.status_code = 400
-    mock_post.return_value.raise_for_status.side_effect = HTTPError("Bad Request")
+    mock_client_class.return_value = mock_httpx_failure_client(400, "Bad Request")
 
     service = LiteLLMService(
         api_url=test_region.litellm_api_url,
@@ -267,11 +276,10 @@ def test_update_key_duration_failure(mock_post, test_region):
     assert "Failed to update LiteLLM key duration" in exc_info.value.detail
 
 
-@patch("app.services.litellm.requests.post")
-def test_set_key_restrictions_success(mock_post, test_region):
+@patch("httpx.AsyncClient")
+def test_set_key_restrictions_success(mock_client_class, test_region, mock_httpx_post_client):
     """Test successful key restrictions setting"""
-    mock_post.return_value.status_code = 200
-    mock_post.return_value.raise_for_status.return_value = None
+    mock_client_class.return_value = mock_httpx_post_client
 
     service = LiteLLMService(
         api_url=test_region.litellm_api_url,
@@ -283,7 +291,7 @@ def test_set_key_restrictions_success(mock_post, test_region):
         "test-token", "30d", 100.0, 1000, "monthly"
     ))
 
-    mock_post.assert_called_once_with(
+    mock_httpx_post_client.post.assert_called_once_with(
         f"{test_region.litellm_api_url}/key/update",
         headers={"Authorization": f"Bearer {test_region.litellm_api_key}"},
         json={
@@ -296,11 +304,10 @@ def test_set_key_restrictions_success(mock_post, test_region):
     )
 
 
-@patch("app.services.litellm.requests.post")
-def test_set_key_restrictions_failure(mock_post, test_region):
+@patch("httpx.AsyncClient")
+def test_set_key_restrictions_failure(mock_client_class, test_region, mock_httpx_failure_client):
     """Test key restrictions setting failure"""
-    mock_post.return_value.status_code = 400
-    mock_post.return_value.raise_for_status.side_effect = HTTPError("Bad Request")
+    mock_client_class.return_value = mock_httpx_failure_client(400, "Bad Request")
 
     service = LiteLLMService(
         api_url=test_region.litellm_api_url,
@@ -316,15 +323,14 @@ def test_set_key_restrictions_failure(mock_post, test_region):
     assert "Failed to set LiteLLM key restrictions" in exc_info.value.detail
 
 
-@patch("app.services.litellm.requests.post")
-def test_update_key_team_association_success(mock_post, test_region):
+@patch("httpx.AsyncClient")
+def test_update_key_team_association_success(mock_client_class, test_region, mock_httpx_post_client):
     """
     Given a LiteLLM service and valid token
     When updating key team association
     Then the request should succeed
     """
-    mock_post.return_value.status_code = 200
-    mock_post.return_value.raise_for_status.return_value = None
+    mock_client_class.return_value = mock_httpx_post_client
 
     service = LiteLLMService(
         api_url=test_region.litellm_api_url,
@@ -334,23 +340,21 @@ def test_update_key_team_association_success(mock_post, test_region):
     # This should not raise an exception
     asyncio.run(service.update_key_team_association("test-token", "new-team-id"))
 
-    mock_post.assert_called_once_with(
+    mock_httpx_post_client.post.assert_called_once_with(
         f"{test_region.litellm_api_url}/key/update",
         headers={"Authorization": f"Bearer {test_region.litellm_api_key}"},
         json={"key": "test-token", "team_id": "new-team-id"}
     )
 
 
-@patch("app.services.litellm.requests.post")
-def test_update_key_team_association_failure(mock_post, test_region):
+@patch("httpx.AsyncClient")
+def test_update_key_team_association_failure(mock_client_class, test_region, mock_httpx_failure_client):
     """
     Given a LiteLLM service and invalid token
     When updating key team association
     Then an HTTPException should be raised
     """
-    mock_post.return_value.status_code = 404
-    mock_post.return_value.json.return_value = {"error": "Key not found"}
-    mock_post.return_value.raise_for_status.side_effect = requests.exceptions.HTTPError("404")
+    mock_client_class.return_value = mock_httpx_failure_client(404, "Key not found")
 
     service = LiteLLMService(
         api_url=test_region.litellm_api_url,

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi import HTTPException
 from app.db.models import DBTeam, DBRegion
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
 
 @patch("app.api.regions.validate_litellm_endpoint")
 @patch("app.api.regions.validate_database_connection")
@@ -419,13 +419,11 @@ def test_delete_non_existent_region(client, admin_token):
     assert response.status_code == 404
     assert "Region not found" in response.json()["detail"]
 
-@patch("app.services.litellm.requests.post")
-def test_delete_region_with_active_keys(mock_post, client, admin_token, test_region, db, test_admin):
+@patch("httpx.AsyncClient")
+def test_delete_region_with_active_keys(mock_client_class, client, admin_token, test_region, db, test_admin, mock_httpx_post_client):
     """Test that a region with active private AI keys cannot be deleted"""
-    # Mock the LiteLLM API response
-    mock_post.return_value.status_code = 200
-    mock_post.return_value.json.return_value = {"key": "test-private-key-123"}
-    mock_post.return_value.raise_for_status.return_value = None
+    # Use the httpx POST client fixture
+    mock_client_class.return_value = mock_httpx_post_client
 
     # Create a test private AI key in the region via API
     response = client.post(
@@ -449,13 +447,11 @@ def test_delete_region_with_active_keys(mock_post, client, admin_token, test_reg
     assert "Cannot delete region" in response.json()["detail"]
     assert "keys(s) are currently using this region" in response.json()["detail"]
 
-@patch("app.services.litellm.requests.post")
-def test_delete_region_with_active_vector_db(mock_post, client, admin_token, test_region, db, test_admin):
+@patch("httpx.AsyncClient")
+def test_delete_region_with_active_vector_db(mock_client_class, client, admin_token, test_region, db, test_admin, mock_httpx_post_client):
     """Test that a region with an active vector database cannot be deleted"""
-    # Mock the LiteLLM API response
-    mock_post.return_value.status_code = 200
-    mock_post.return_value.json.return_value = {"key": "test-private-key-123"}
-    mock_post.return_value.raise_for_status.return_value = None
+    # Use the httpx POST client fixture
+    mock_client_class.return_value = mock_httpx_post_client
 
     # Create a test vector database in the region via API
     response = client.post(


### PR DESCRIPTION
- Ensure network calls to LiteLLM are _actually_ async
- Fix double counting bug in product based limits