### PR TITLE
Fix product recon

### DIFF
--- a/app/core/limit_service.py
+++ b/app/core/limit_service.py
@@ -344,9 +344,6 @@ class LimitService:
             if existing_limit.limited_by == LimitSource.MANUAL and limited_resource.limited_by != LimitSource.MANUAL:
                 raise ValueError("Cannot override manual limit with non-manual limit")
 
-            if existing_limit.limited_by == LimitSource.PRODUCT and limited_resource.limited_by == LimitSource.DEFAULT:
-                raise ValueError("Cannot override product limit with default limit")
-
             # Update existing limit
             existing_limit.limit_type = limited_resource.limit_type
             existing_limit.unit = limited_resource.unit

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -47,6 +47,12 @@ team_expired_metric = Counter(
     ["team_id", "team_name"]
 )
 
+team_monitoring_failed_metric = Counter(
+    "team_monitoring_failed_total",
+    "Total number of teams that failed to be monitored due to errors",
+    ["team_id", "team_name", "error_type"]
+)
+
 key_spend_percentage = Gauge(
     "key_spend_percentage",
     "Percentage of budget used for each key",
@@ -580,6 +586,62 @@ def _send_expiry_notification(db: Session, team: DBTeam, has_products: bool, sho
                 team_name=team.name
             ).inc()
 
+async def reconcile_team_product_associations(db: Session, team: DBTeam):
+    """
+    Reconcile team product associations with Stripe subscriptions.
+
+    This function ensures that the team's product associations in the database
+    match what they are actually subscribed to in Stripe.
+
+    Args:
+        db: Database session
+        team: The team to reconcile
+    """
+    if not team.stripe_customer_id:
+        logger.info(f"Team {team.id} has no stripe_customer_id, skipping product reconciliation")
+        return
+
+    try:
+        # Get current subscriptions from Stripe
+        stripe_subscriptions = await get_subscribed_products_for_customer(team.stripe_customer_id)
+        stripe_product_ids = {product_id for _, product_id in stripe_subscriptions}
+
+        # Get current product associations in database
+        current_associations = db.query(DBTeamProduct).filter(
+            DBTeamProduct.team_id == team.id
+        ).all()
+        current_product_ids = {assoc.product_id for assoc in current_associations}
+
+        logger.info(f"Team {team.id}: Stripe products {stripe_product_ids}, DB products {current_product_ids}")
+
+        # Add missing products (in Stripe but not in DB)
+        for product_id in stripe_product_ids - current_product_ids:
+            # Verify the product exists in our database
+            product = db.query(DBProduct).filter(DBProduct.id == product_id).first()
+            if product:
+                team_product = DBTeamProduct(
+                    team_id=team.id,
+                    product_id=product_id
+                )
+                db.add(team_product)
+                logger.info(f"Added product {product_id} to team {team.id}")
+            else:
+                logger.warning(f"Product {product_id} found in Stripe but not in database for team {team.id}")
+
+        # Remove extra products (in DB but not in Stripe)
+        for assoc in current_associations:
+            if assoc.product_id not in stripe_product_ids:
+                db.delete(assoc)
+                logger.info(f"Removed product {assoc.product_id} from team {team.id}")
+
+        # Commit the changes
+        db.commit()
+
+    except Exception as e:
+        logger.error(f"Error reconciling product associations for team {team.id}: {str(e)}")
+        db.rollback()
+        raise e
+
 
 @monitor_teams_duration.time()
 async def monitor_teams(db: Session):
@@ -607,89 +669,102 @@ async def monitor_teams(db: Session):
 
         logger.info(f"Found {len(teams)} teams to track")
         for team in teams:
-            team_label = (str(team.id), team.name)
-            current_team_labels.add(team_label)
+            try:
+                team_label = (str(team.id), team.name)
+                current_team_labels.add(team_label)
 
-            # Check if team has any products
-            has_products = db.query(DBTeamProduct).filter(
-                DBTeamProduct.team_id == team.id
-            ).first() is not None
+                # Reconcile product associations with Stripe before any other processing
+                await reconcile_team_product_associations(db, team)
 
-            team_freshness = _monitor_team_freshness(team)
-            days_remaining = TRIAL_OVER_DAYS - team_freshness
-
-            # Check if team was monitored within 24 hours
-            should_send_notifications = settings.ENABLE_LIMITS
-            if team.last_monitored:
-                hours_since_monitored = (current_time - team.last_monitored.replace(tzinfo=UTC)).total_seconds() / 3600
-                should_send_notifications = hours_since_monitored >= 24
-
-            _send_expiry_notification(db, team, has_products, should_send_notifications, days_remaining, ses_service)
-
-            # Get all keys for the team grouped by region
-            keys_by_region = get_team_keys_by_region(db, team.id)
-            expire_keys = False
-            # If the team has a product, expiry will be handled by a Stripe cancellation
-            if not has_products and days_remaining <= 0 and should_send_notifications:
-                logger.info(f"Team {team.id} has {days_remaining} days remaining, expiring keys")
-                expire_keys = True
-
-            # Determine if we should check for renewal period updates
-            renewal_period_days = None
-            max_budget_amount = None
-            if has_products and team.last_payment:
-                # Get the product with the longest renewal period
-                active_products = db.query(DBTeamProduct).filter(
+                # Check if team has any products
+                has_products = db.query(DBTeamProduct).filter(
                     DBTeamProduct.team_id == team.id
-                ).all()
-                product_ids = [tp.product_id for tp in active_products]
-                products = db.query(DBProduct).filter(DBProduct.id.in_(product_ids)).all()
+                ).first() is not None
 
-                if products:
-                    max_renewal_product = max(products, key=lambda product: product.renewal_period_days)
-                    renewal_period_days = max_renewal_product.renewal_period_days
-                    max_budget_amount = max(products, key=lambda product: product.max_budget_per_key).max_budget_per_key
+                team_freshness = _monitor_team_freshness(team)
+                days_remaining = TRIAL_OVER_DAYS - team_freshness
 
-            # Monitor keys and get total spend (includes renewal period updates if applicable)
-            team_total = await reconcile_team_keys(db, team, keys_by_region, expire_keys, renewal_period_days, max_budget_amount)
+                # Check if team was monitored within 24 hours
+                should_send_notifications = settings.ENABLE_LIMITS
+                if team.last_monitored:
+                    hours_since_monitored = (current_time - team.last_monitored.replace(tzinfo=UTC)).total_seconds() / 3600
+                    should_send_notifications = hours_since_monitored >= 24
 
-            # Set the total spend metric for the team (always emit metrics)
-            team_total_spend.labels(
-                team_id=str(team.id),
-                team_name=team.name
-            ).set(team_total)
+                _send_expiry_notification(db, team, has_products, should_send_notifications, days_remaining, ses_service)
 
-            # Update or create team metrics record
-            regions_list = list(keys_by_region.keys())
-            region_names = [region.name for region in regions_list]
+                # Get all keys for the team grouped by region
+                keys_by_region = get_team_keys_by_region(db, team.id)
+                expire_keys = False
+                # If the team has a product, expiry will be handled by a Stripe cancellation
+                if not has_products and days_remaining <= 0 and should_send_notifications:
+                    logger.info(f"Team {team.id} has {days_remaining} days remaining, expiring keys")
+                    expire_keys = True
 
-            # Check if metrics record exists
-            team_metrics = db.query(DBTeamMetrics).filter(DBTeamMetrics.team_id == team.id).first()
+                # Determine if we should check for renewal period updates
+                renewal_period_days = None
+                max_budget_amount = None
+                if has_products and team.last_payment:
+                    # Get the product with the longest renewal period
+                    active_products = db.query(DBTeamProduct).filter(
+                        DBTeamProduct.team_id == team.id
+                    ).all()
+                    product_ids = [tp.product_id for tp in active_products]
+                    products = db.query(DBProduct).filter(DBProduct.id.in_(product_ids)).all()
 
-            if team_metrics:
-                logger.info(f"metrics last updated at {team_metrics.last_updated}, curent time is {current_time}")
-                # Update existing metrics
-                team_metrics.total_spend = team_total
-                team_metrics.last_spend_calculation = current_time
-                team_metrics.regions = region_names
-                team_metrics.last_updated = current_time
-            else:
-                # Create new metrics record
-                team_metrics = DBTeamMetrics(
-                    team_id=team.id,
-                    total_spend=team_total,
-                    last_spend_calculation=current_time,
-                    regions=region_names,
-                    last_updated=current_time
-                )
-                db.add(team_metrics)
+                    if products:
+                        max_renewal_product = max(products, key=lambda product: product.renewal_period_days)
+                        renewal_period_days = max_renewal_product.renewal_period_days
+                        max_budget_amount = max(products, key=lambda product: product.max_budget_per_key).max_budget_per_key
 
-            # Ensure all limits are correct - will not override MANUAL limits
-            set_team_and_user_limits(db, team)
+                # Monitor keys and get total spend (includes renewal period updates if applicable)
+                team_total = await reconcile_team_keys(db, team, keys_by_region, expire_keys, renewal_period_days, max_budget_amount)
 
-            # Update last_monitored timestamp only if notifications were sent
-            if should_send_notifications:
-                team.last_monitored = current_time
+                # Set the total spend metric for the team (always emit metrics)
+                team_total_spend.labels(
+                    team_id=str(team.id),
+                    team_name=team.name
+                ).set(team_total)
+
+                # Update or create team metrics record
+                regions_list = list(keys_by_region.keys())
+                region_names = [region.name for region in regions_list]
+
+                # Check if metrics record exists
+                team_metrics = db.query(DBTeamMetrics).filter(DBTeamMetrics.team_id == team.id).first()
+
+                if team_metrics:
+                    logger.info(f"metrics last updated at {team_metrics.last_updated}, curent time is {current_time}")
+                    # Update existing metrics
+                    team_metrics.total_spend = team_total
+                    team_metrics.last_spend_calculation = current_time
+                    team_metrics.regions = region_names
+                    team_metrics.last_updated = current_time
+                else:
+                    # Create new metrics record
+                    team_metrics = DBTeamMetrics(
+                        team_id=team.id,
+                        total_spend=team_total,
+                        last_spend_calculation=current_time,
+                        regions=region_names,
+                        last_updated=current_time
+                    )
+                    db.add(team_metrics)
+
+                # Ensure all limits are correct - will not override MANUAL limits
+                set_team_and_user_limits(db, team)
+
+                # Update last_monitored timestamp only if notifications were sent
+                if should_send_notifications:
+                    team.last_monitored = current_time
+            except Exception as error:
+                logger.error(f"Unable to process team {team.id} due to {str(error)}, continuing with next team.")
+                # Record the monitoring failure metric
+                error_type = type(error).__name__
+                team_monitoring_failed_metric.labels(
+                    team_id=str(team.id),
+                    team_name=team.name,
+                    error_type=error_type
+                ).inc()
 
         # Commit the database changes
         db.commit()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -551,8 +551,9 @@ async def test_monitor_teams_calls_limit_service(mock_litellm, mock_ses, mock_li
 @patch('app.core.worker.LimitService')
 @patch('app.core.worker.SESService')
 @patch('app.core.worker.LiteLLMService')
+@patch('app.core.worker.get_subscribed_products_for_customer')
 @patch('app.core.config.settings.ENABLE_LIMITS', True)
-async def test_monitor_teams_basic_metrics(mock_litellm, mock_ses, mock_limit_service, db, test_team, test_product):
+async def test_monitor_teams_basic_metrics(mock_get_subscriptions, mock_litellm, mock_ses, mock_limit_service, db, test_team, test_product):
     """
     Test basic team monitoring metrics for teams with and without products.
     """
@@ -586,6 +587,9 @@ async def test_monitor_teams_basic_metrics(mock_litellm, mock_ses, mock_limit_se
     # Setup mock limit service
     mock_limit_instance = mock_limit_service.return_value
     mock_limit_instance.set_team_limits = Mock()
+
+    # Setup mock Stripe function
+    mock_get_subscriptions.return_value = [("sub_123", test_product.id)]
 
     # Run monitoring
     await monitor_teams(db)
@@ -2571,4 +2575,237 @@ async def test_remove_product_removes_when_subscription_inactive(mock_get_subscr
         DBTeamProduct.product_id == test_product.id
     ).first()
     assert remaining_association is None, "Product should be removed when subscription is inactive"
+
+
+@pytest.mark.asyncio
+@patch('app.core.worker.SESService')
+@patch('app.core.worker.reconcile_team_keys', new_callable=AsyncMock)
+@patch('app.core.worker.get_subscribed_products_for_customer')
+async def test_monitor_teams_reconciles_product_customer_associations(
+    mock_get_subscriptions, mock_reconcile, mock_ses, db, test_team, test_product
+):
+    """
+    Test that monitor_teams reconciles product-customer associations with Stripe.
+
+    GIVEN: A team with a stripe_customer_id and mismatched product associations
+    WHEN: monitor_teams is called
+    THEN: The system should reconcile the associations to match Stripe subscriptions
+    """
+    # Arrange - team has stripe customer ID but no products in system
+    test_team.stripe_customer_id = "cus_123"
+    db.add(test_team)
+    db.commit()
+
+    # Mock Stripe to return a subscription for the product
+    mock_get_subscriptions.return_value = [("sub_123", test_product.id)]
+    mock_reconcile.return_value = 0.0
+    mock_ses.return_value = None
+
+    # Act
+    await monitor_teams(db)
+
+    # Assert
+    # Check that the product was added to the team
+    team_product = db.query(DBTeamProduct).filter(
+        DBTeamProduct.team_id == test_team.id,
+        DBTeamProduct.product_id == test_product.id
+    ).first()
+    assert team_product is not None, "Product should be added to team when found in Stripe"
+
+
+@pytest.mark.asyncio
+@patch('app.core.worker.SESService')
+@patch('app.core.worker.reconcile_team_keys', new_callable=AsyncMock)
+@patch('app.core.worker.get_subscribed_products_for_customer')
+async def test_monitor_teams_removes_extra_products_not_in_stripe(
+    mock_get_subscriptions, mock_reconcile, mock_ses, db, test_team, test_product
+):
+    """
+    Test that monitor_teams removes products not found in Stripe subscriptions.
+
+    GIVEN: A team with a stripe_customer_id and products not in Stripe
+    WHEN: monitor_teams is called
+    THEN: The extra products should be removed from the team
+    """
+    # Arrange - team has stripe customer ID and a product association
+    test_team.stripe_customer_id = "cus_123"
+    db.add(test_team)
+
+    # Add a product association that shouldn't exist
+    team_product = DBTeamProduct(
+        team_id=test_team.id,
+        product_id=test_product.id
+    )
+    db.add(team_product)
+    db.commit()
+
+    # Mock Stripe to return no subscriptions
+    mock_get_subscriptions.return_value = []
+    mock_reconcile.return_value = 0.0
+    mock_ses.return_value = None
+
+    # Act
+    await monitor_teams(db)
+
+    # Assert
+    # Check that the product was removed from the team
+    team_product = db.query(DBTeamProduct).filter(
+        DBTeamProduct.team_id == test_team.id,
+        DBTeamProduct.product_id == test_product.id
+    ).first()
+    assert team_product is None, "Product should be removed when not found in Stripe"
+
+
+@pytest.mark.asyncio
+@patch('app.core.worker.SESService')
+@patch('app.core.worker.reconcile_team_keys', new_callable=AsyncMock)
+@patch('app.core.worker.get_subscribed_products_for_customer')
+async def test_monitor_teams_skips_teams_without_customer_id(
+    mock_get_subscriptions, mock_reconcile, mock_ses, db, test_team, test_product
+):
+    """
+    Test that monitor_teams skips teams without stripe_customer_id.
+
+    GIVEN: A team without a stripe_customer_id
+    WHEN: monitor_teams is called
+    THEN: No Stripe API calls should be made for that team
+    """
+    # Arrange - team has no stripe customer ID
+    test_team.stripe_customer_id = None
+    db.add(test_team)
+    db.commit()
+
+    # Mock the reconcile_team_keys function to avoid actual key processing
+    mock_reconcile.return_value = 0.0
+    mock_ses.return_value = None
+
+    # Act
+    await monitor_teams(db)
+
+    # Assert
+    mock_get_subscriptions.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch('app.core.worker.reconcile_team_product_associations', new_callable=AsyncMock)
+@patch('app.core.worker.SESService')
+@patch('app.core.worker.reconcile_team_keys', new_callable=AsyncMock)
+@patch('app.core.worker.get_subscribed_products_for_customer')
+async def test_monitor_teams_handles_individual_team_errors_gracefully(
+    mock_get_subscriptions, mock_reconcile, mock_ses, mock_reconcile_products, db, test_team, test_product
+):
+    """
+    Test that monitor_teams handles individual team errors gracefully and continues processing.
+
+    GIVEN: Multiple teams where one fails to process
+    WHEN: monitor_teams is called
+    THEN: The failing team should be logged and skipped, but other teams should continue processing
+    """
+    # Create a second team
+    second_team = DBTeam(
+        name="Second Team",
+        admin_email="second@example.com"
+    )
+    db.add(second_team)
+    db.commit()
+
+    # Mock Stripe function
+    mock_get_subscriptions.return_value = []
+    mock_reconcile.return_value = 0.0
+    mock_ses.return_value = None
+
+    # Mock reconcile_team_product_associations to raise an error for the first team
+    mock_reconcile_products.side_effect = [Exception("Test error for team 1"), None]
+
+    # Act
+    await monitor_teams(db)
+
+    # Assert
+    # Both teams should have been processed (first one failed, second succeeded)
+    assert mock_reconcile_products.call_count == 2
+    # The reconcile_team_keys should have been called for the second team only
+    assert mock_reconcile.call_count == 1
+
+
+@pytest.mark.asyncio
+@patch('app.core.worker.reconcile_team_product_associations', new_callable=AsyncMock)
+@patch('app.core.worker.SESService')
+@patch('app.core.worker.reconcile_team_keys', new_callable=AsyncMock)
+@patch('app.core.worker.get_subscribed_products_for_customer')
+async def test_monitor_teams_records_failure_metric_on_error(
+    mock_get_subscriptions, mock_reconcile, mock_ses, mock_reconcile_products, db, test_team, test_product
+):
+    """
+    Test that monitor_teams records a failure metric when a team fails to process.
+
+    GIVEN: A team that fails to process
+    WHEN: monitor_teams is called
+    THEN: A failure metric should be recorded for that team
+    """
+    # Mock Stripe function
+    mock_get_subscriptions.return_value = []
+    mock_reconcile.return_value = 0.0
+    mock_ses.return_value = None
+
+    # Mock reconcile_team_product_associations to raise an error
+    mock_reconcile_products.side_effect = Exception("Test error")
+
+    # Act
+    await monitor_teams(db)
+
+    # Assert
+    # The metric should have been called with the correct labels
+    # We can't easily test the exact metric value, but we can verify the function was called
+    assert mock_reconcile_products.call_count == 1
+
+
+@pytest.mark.asyncio
+@patch('app.core.worker.reconcile_team_product_associations', new_callable=AsyncMock)
+@patch('app.core.worker.SESService')
+@patch('app.core.worker.reconcile_team_keys', new_callable=AsyncMock)
+@patch('app.core.worker.get_subscribed_products_for_customer')
+async def test_monitor_teams_continues_processing_after_error(
+    mock_get_subscriptions, mock_reconcile, mock_ses, mock_reconcile_products, db, test_team, test_product
+):
+    """
+    Test that monitor_teams continues processing other teams after one fails.
+
+    GIVEN: Multiple teams where one fails
+    WHEN: monitor_teams is called
+    THEN: All teams should be attempted, and successful ones should complete processing
+    """
+    # Create additional teams
+    teams = []
+    for team_index in range(3):
+        team = DBTeam(
+            name=f"Team {team_index+2}",
+            admin_email=f"team{team_index+2}@example.com"
+        )
+        db.add(team)
+        teams.append(team)
+    db.commit()
+
+    # Mock Stripe function
+    mock_get_subscriptions.return_value = []
+    mock_reconcile.return_value = 0.0
+    mock_ses.return_value = None
+
+    # Mock reconcile_team_product_associations to raise an error for the second team only
+    def side_effect(*args, **kwargs):
+        # Get the team from the args
+        team = args[1]  # Second argument is the team
+        if team.id == teams[1].id:  # Second team fails
+            raise Exception("Test error for second team")
+        return None
+
+    mock_reconcile_products.side_effect = side_effect
+
+    # Act
+    await monitor_teams(db)
+
+    # Assert
+    # All teams should have been processed
+    assert mock_reconcile_products.call_count == 4  # test_team + 3 new teams
+    # reconcile_team_keys should have been called for all teams except the failing one
+    assert mock_reconcile.call_count == 3  # 4 teams - 1 failing = 3 successful
 


### PR DESCRIPTION
- Ensures subscriptions are no longer active before removing a product
- Reconciles products treating Stripe as the source of truth
- Will continue with the next team if recon for one fails