### PR TITLE
chore: add rate limiter and redis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@ test-redis: test-network
 	docker run -d \
 		--name amazee-test-redis \
 		--network amazeeai_default \
-		-p 6379:6379 \
 		redis:alpine && \
 	sleep 2
 

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -6,6 +6,7 @@ import time
 import uuid
 from datetime import datetime
 import email_validator
+from fastapi_limiter.depends import RateLimiter
 
 from typing import Optional, List, Union
 
@@ -14,6 +15,10 @@ from sqlalchemy.orm import Session
 from sqlalchemy import func
 from urllib.parse import urlparse
 from jose import JWTError, jwt
+
+from app.api.teams import register_team
+from app.api.users import _create_user_in_db, get_user_by_email
+from app.api.private_ai_keys import create_private_ai_key
 
 from app.core.config import settings
 from app.core.dependencies import get_limit_service
@@ -59,14 +64,9 @@ from app.schemas.models import (
     BudgetType,
 )
 
-from app.api.teams import register_team
-from app.api.users import _create_user_in_db, get_user_by_email
-from app.api.private_ai_keys import create_private_ai_key
-
 auth_logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["auth"])
-
 
 def get_cookie_domain():
     """Extract domain from COOKIE_DOMAIN or LAGOON_ROUTES for cookie settings."""
@@ -467,6 +467,9 @@ async def validate_email(
     email_data: Optional[EmailValidation] = None,
     email: Optional[str] = Form(None),
     db: Session = Depends(get_db),
+    _: None = Depends(
+        RateLimiter(times=settings.RATE_LIMIT_VALIDATE_EMAIL, seconds=60)
+    ),
 ):
     """
     Validate an email address and generate a validation code.

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -71,8 +71,7 @@ router = APIRouter(tags=["auth"])
 def get_cookie_domain():
     """Extract domain from COOKIE_DOMAIN or LAGOON_ROUTES for cookie settings."""
     # First check for explicit cookie domain setting
-    cookie_domain = os.getenv("COOKIE_DOMAIN")
-    if cookie_domain:
+    if (cookie_domain := os.getenv("COOKIE_DOMAIN")):
         return cookie_domain
 
     # Fall back to extracting from LAGOON_ROUTES
@@ -141,7 +140,6 @@ def create_and_set_access_token(
     access_token = create_access_token(data={"sub": user_email.lower()})
 
     # Get cookie domain from LAGOON_ROUTES
-    cookie_domain = get_cookie_domain()
 
     # Set cookie expiration based on user role
     # System administrators get 8 hours (28800 seconds), regular users get 30 minutes (1800 seconds)
@@ -160,7 +158,7 @@ def create_and_set_access_token(
     }
 
     # Only set domain if we got one from LAGOON_ROUTES
-    if cookie_domain:
+    if (cookie_domain := get_cookie_domain()):
         cookie_settings["domain"] = cookie_domain
 
     # Set cookie with appropriate settings

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -56,6 +56,11 @@ class Settings(BaseSettings):
     DEDICATED_DEFAULT_SERVICE_KEYS: float | None = None
     DEDICATED_DEFAULT_VECTOR_DB_COUNT: float | None = None
     DEDICATED_DEFAULT_RPM_PER_KEY: float | None = None
+    REDIS_URL: str = os.getenv(
+        "REDIS_URL",
+        f"redis://{os.getenv('REDIS_HOST', 'localhost')}:{os.getenv('REDIS_PORT', '6379')}/0",
+    )
+    RATE_LIMIT_VALIDATE_EMAIL: int = int(os.getenv("RATE_LIMIT_VALIDATE_EMAIL", "5"))
 
     model_config = ConfigDict(env_file=".env", extra="ignore")
     main_route: str = os.getenv("LAGOON_ROUTE", "http://localhost:8800")

--- a/app/main.py
+++ b/app/main.py
@@ -121,34 +121,41 @@ async def lifespan(app: FastAPI):
 
     # Hard delete job for teams that have been soft-deleted for 60+ days
     async def hard_delete_teams_job():
-        db = next(get_db())
         lock_name = "hard_delete_teams"
         lock_acquired = False
 
         try:
-            # Try to acquire the lock
-            if try_acquire_lock(lock_name, db, lock_timeout=10):
-                lock_acquired = True
+            # Try to acquire the lock using a dedicated short-lived session
+            lock_db = next(get_db())
+            try:
+                lock_acquired = try_acquire_lock(lock_name, lock_db, lock_timeout=10)
+            finally:
+                lock_db.close()
+
+            if lock_acquired:
                 logger.info("Acquired hard_delete_teams lock, executing job")
+                job_db = next(get_db())
                 try:
-                    await hard_delete_expired_teams(db)
+                    await hard_delete_expired_teams(job_db)
                 except Exception as e:
+                    job_db.rollback()
                     logger.error(f"Error in hard_delete_expired_teams background task: {str(e)}")
                 finally:
-                    # Always release the lock when done
-                    release_lock(lock_name, db)
+                    job_db.close()
             else:
                 logger.info("Another process has the hard_delete_teams lock, skipping execution")
         except Exception as e:
             logger.error(f"Error in hard_delete_teams job: {str(e)}")
-            # Only release lock if it was acquired by this process
+        finally:
+            # Always release the lock when it was acquired, using a separate session
             if lock_acquired:
+                release_db = next(get_db())
                 try:
-                    release_lock(lock_name, db)
+                    release_lock(lock_name, release_db)
                 except Exception as release_error:
                     logger.error(f"Error releasing lock: {str(release_error)}")
-        finally:
-            db.close()
+                finally:
+                    release_db.close()
 
     # Set schedule based on environment for hard delete job
     if settings.ENV_SUFFIX == "local":

--- a/app/main.py
+++ b/app/main.py
@@ -71,10 +71,12 @@ async def lifespan(app: FastAPI):
     async def monitor_teams_job():
         db = next(get_db())
         lock_name = "monitor_teams"
+        lock_acquired = False
 
         try:
             # Try to acquire the lock
             if try_acquire_lock(lock_name, db, lock_timeout=10):
+                lock_acquired = True
                 logger.info("Acquired monitor_teams lock, executing job")
                 try:
                     await monitor_teams(db)
@@ -87,11 +89,12 @@ async def lifespan(app: FastAPI):
                 logger.info("Another process has the monitor_teams lock, skipping execution")
         except Exception as e:
             logger.error(f"Error in monitor_teams job: {str(e)}")
-            # Try to release lock in case of error
-            try:
-                release_lock(lock_name, db)
-            except Exception as release_error:
-                logger.error(f"Error releasing lock: {str(release_error)}")
+            # Only release lock if it was acquired by this process
+            if lock_acquired:
+                try:
+                    release_lock(lock_name, db)
+                except Exception as release_error:
+                    logger.error(f"Error releasing lock: {str(release_error)}")
         finally:
             db.close()
 
@@ -113,10 +116,12 @@ async def lifespan(app: FastAPI):
     async def hard_delete_teams_job():
         db = next(get_db())
         lock_name = "hard_delete_teams"
+        lock_acquired = False
 
         try:
             # Try to acquire the lock
             if try_acquire_lock(lock_name, db, lock_timeout=10):
+                lock_acquired = True
                 logger.info("Acquired hard_delete_teams lock, executing job")
                 try:
                     await hard_delete_expired_teams(db)
@@ -129,11 +134,12 @@ async def lifespan(app: FastAPI):
                 logger.info("Another process has the hard_delete_teams lock, skipping execution")
         except Exception as e:
             logger.error(f"Error in hard_delete_teams job: {str(e)}")
-            # Try to release lock in case of error
-            try:
-                release_lock(lock_name, db)
-            except Exception as release_error:
-                logger.error(f"Error releasing lock: {str(release_error)}")
+            # Only release lock if it was acquired by this process
+            if lock_acquired:
+                try:
+                    release_lock(lock_name, db)
+                except Exception as release_error:
+                    logger.error(f"Error releasing lock: {str(release_error)}")
         finally:
             db.close()
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from contextlib import asynccontextmanager
+from datetime import UTC
 
 from app.__version__ import __version__
 from app.api import (
@@ -18,17 +19,24 @@ from app.api import (
     teams,
     users,
 )
+from app.core.locking import release_lock, try_acquire_lock
 from app.core.config import settings
+from app.core.worker import hard_delete_expired_teams, monitor_teams
+from app.db.database import get_db
 from app.middleware.audit import AuditLogMiddleware
 from app.middleware.auth import AuthMiddleware
 from app.middleware.caching import CacheControlMiddleware
 from app.middleware.prometheus import PrometheusMiddleware
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
 from fastapi import FastAPI
+from fastapi_limiter import FastAPILimiter
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.openapi.docs import get_swagger_ui_html
 from fastapi.openapi.utils import get_openapi
 from prometheus_fastapi_instrumentator import Instrumentator, metrics
+from redis.asyncio import Redis as AsyncRedis
 from starlette.middleware.base import BaseHTTPMiddleware
 
 # Set timezone environment variable to prevent tzlocal warning
@@ -52,8 +60,108 @@ class HTTPSRedirectMiddleware(BaseHTTPMiddleware):
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # Initialize rate limiter
+    await FastAPILimiter.init(
+        redis=AsyncRedis.from_url(settings.REDIS_URL, decode_responses=True)
+    )
+
+    # Create scheduler
+    scheduler = AsyncIOScheduler()
+
+    async def monitor_teams_job():
+        db = next(get_db())
+        lock_name = "monitor_teams"
+
+        try:
+            # Try to acquire the lock
+            if try_acquire_lock(lock_name, db, lock_timeout=10):
+                logger.info("Acquired monitor_teams lock, executing job")
+                try:
+                    await monitor_teams(db)
+                except Exception as e:
+                    logger.error(f"Error in monitor_teams background task: {str(e)}")
+                finally:
+                    # Always release the lock when done
+                    release_lock(lock_name, db)
+            else:
+                logger.info("Another process has the monitor_teams lock, skipping execution")
+        except Exception as e:
+            logger.error(f"Error in monitor_teams job: {str(e)}")
+            # Try to release lock in case of error
+            try:
+                release_lock(lock_name, db)
+            except Exception as release_error:
+                logger.error(f"Error releasing lock: {str(release_error)}")
+        finally:
+            db.close()
+
+    # Set schedule based on environment
+    if settings.ENV_SUFFIX == "local":
+        cron_trigger = CronTrigger(minute='*/10', timezone=UTC, jitter=180)
+    else:
+        # Run every hour in other environments with jitter
+        cron_trigger = CronTrigger(hour='*', minute=0, timezone=UTC, jitter=60)
+
+    scheduler.add_job(
+        monitor_teams_job,
+        trigger=cron_trigger,
+        id='monitor_teams',
+        replace_existing=True
+    )
+
+    # Hard delete job for teams that have been soft-deleted for 60+ days
+    async def hard_delete_teams_job():
+        db = next(get_db())
+        lock_name = "hard_delete_teams"
+
+        try:
+            # Try to acquire the lock
+            if try_acquire_lock(lock_name, db, lock_timeout=10):
+                logger.info("Acquired hard_delete_teams lock, executing job")
+                try:
+                    await hard_delete_expired_teams(db)
+                except Exception as e:
+                    logger.error(f"Error in hard_delete_expired_teams background task: {str(e)}")
+                finally:
+                    # Always release the lock when done
+                    release_lock(lock_name, db)
+            else:
+                logger.info("Another process has the hard_delete_teams lock, skipping execution")
+        except Exception as e:
+            logger.error(f"Error in hard_delete_teams job: {str(e)}")
+            # Try to release lock in case of error
+            try:
+                release_lock(lock_name, db)
+            except Exception as release_error:
+                logger.error(f"Error releasing lock: {str(release_error)}")
+        finally:
+            db.close()
+
+    # Set schedule based on environment for hard delete job
+    if settings.ENV_SUFFIX == "local":
+        # In local env, run every hour at :30 for testing
+        hard_delete_trigger = CronTrigger(hour='*', minute=30, timezone=UTC)
+    else:
+        # In production, run daily at 3 AM
+        hard_delete_trigger = CronTrigger(hour=3, minute=0, timezone=UTC)
+
+    scheduler.add_job(
+        hard_delete_teams_job,
+        trigger=hard_delete_trigger,
+        id='hard_delete_teams',
+        replace_existing=True
+    )
+
+    # Start the scheduler
+    scheduler.start()
+
     yield
 
+    # Shutdown the rate limiter
+    await FastAPILimiter.close()
+
+    # Shutdown the scheduler
+    scheduler.shutdown()
 
 app = FastAPI(
     title="Private AI Keys as a Service",

--- a/app/main.py
+++ b/app/main.py
@@ -69,34 +69,41 @@ async def lifespan(app: FastAPI):
     scheduler = AsyncIOScheduler()
 
     async def monitor_teams_job():
-        db = next(get_db())
         lock_name = "monitor_teams"
         lock_acquired = False
 
         try:
-            # Try to acquire the lock
-            if try_acquire_lock(lock_name, db, lock_timeout=10):
-                lock_acquired = True
+            # Try to acquire the lock using a dedicated short-lived session
+            lock_db = next(get_db())
+            try:
+                lock_acquired = try_acquire_lock(lock_name, lock_db, lock_timeout=10)
+            finally:
+                lock_db.close()
+
+            if lock_acquired:
                 logger.info("Acquired monitor_teams lock, executing job")
+                job_db = next(get_db())
                 try:
-                    await monitor_teams(db)
+                    await monitor_teams(job_db)
                 except Exception as e:
+                    job_db.rollback()
                     logger.error(f"Error in monitor_teams background task: {str(e)}")
                 finally:
-                    # Always release the lock when done
-                    release_lock(lock_name, db)
+                    job_db.close()
             else:
                 logger.info("Another process has the monitor_teams lock, skipping execution")
         except Exception as e:
             logger.error(f"Error in monitor_teams job: {str(e)}")
-            # Only release lock if it was acquired by this process
+        finally:
+            # Always release the lock when it was acquired, using a separate session
             if lock_acquired:
+                release_db = next(get_db())
                 try:
-                    release_lock(lock_name, db)
+                    release_lock(lock_name, release_db)
                 except Exception as release_error:
                     logger.error(f"Error releasing lock: {str(release_error)}")
-        finally:
-            db.close()
+                finally:
+                    release_db.close()
 
     # Set schedule based on environment
     if settings.ENV_SUFFIX == "local":

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,13 @@ services:
     labels:
       lagoon.type: postgres
 
+  redis:
+    image: uselagoon/redis-7
+    labels:
+      lagoon.type: redis
+    ports:
+      - "6379:6379"
+
   backend:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,11 @@ services:
       lagoon.type: redis
     ports:
       - "6379:6379"
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   backend:
     build:
@@ -33,12 +38,15 @@ services:
       AMAZEEAI_JWT_SECRET: ${AMAZEEAI_JWT_SECRET}
       ENABLE_METRICS: "true"  # Enable Prometheus metrics
       AI_TRIAL_REGION: ${AI_TRIAL_REGION:-eu-west}
+      REDIS_URL: "redis://redis:6379/0"
     ports:
       - "8800:8800"
     volumes:
       - ./app:/app/app
     depends_on:
       postgres:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     labels:
       lagoon.type: python

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,6 @@ services:
     image: uselagoon/redis-7
     labels:
       lagoon.type: redis
-    ports:
-      - "6379:6379"
     healthcheck:
       test: [ "CMD", "redis-cli", "ping" ]
       interval: 5s

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,5 +21,4 @@ stripe==14.4.0
 six==1.17.0
 httpx==0.28.1
 fastapi-limiter==0.1.6
-pyrate-limiter==3.9.0
 redis==4.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ six==1.17.0
 httpx==0.28.1
 fastapi-limiter==0.1.6
 redis==4.6.0
+apscheduler==3.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,6 @@ prometheus-fastapi-instrumentator==7.1.0
 stripe==14.4.0
 six==1.17.0
 httpx==0.28.1
+fastapi-limiter==0.1.6
+pyrate-limiter==3.9.0
+redis==4.6.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,8 +35,8 @@ def mock_rate_limiting(request):
             _rate_limit_counts[key] = 0
         _rate_limit_counts[key] += 1
 
-        # For rate limit tests, actually enforce the limit after 5 requests
-        if is_rate_limit_test and _rate_limit_counts[key] > 5:
+        # For rate limit tests, actually enforce the limit based on the configured 'times' value
+        if is_rate_limit_test and _rate_limit_counts[key] > times:
             # Return a value that indicates rate limiting (simulating Redis response)
             return 1000  # Return positive value indicating wait time in ms
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,60 @@ from app.core.security import get_password_hash
 from datetime import datetime, UTC, timedelta
 from unittest.mock import patch, MagicMock, Mock, AsyncMock
 
+# Track rate limit counts per key for testing
+_rate_limit_counts = {}
+
+# Mock FastAPILimiter and RateLimiter to bypass Redis rate limiting in tests
+@pytest.fixture(autouse=True)
+def mock_rate_limiting(request):
+    """Fixture to mock rate limiting for all tests - tracks calls but doesn't block"""
+    # Check if this is a rate limit test - if so, don't mock the blocking behavior
+    # Match both 'rate_limit' and 'ratelimit' patterns
+    nodeid = request.node.nodeid.lower()
+    is_rate_limit_test = 'rate_limit' in nodeid or 'ratelimit' in nodeid
+
+    _rate_limit_counts.clear()
+
+    # Create a mock Redis that supports async operations and tracks calls
+    async def mock_evalsha(sha, numkeys, key, times, milliseconds):
+        # Track how many times each key has been called
+        if key not in _rate_limit_counts:
+            _rate_limit_counts[key] = 0
+        _rate_limit_counts[key] += 1
+
+        # For rate limit tests, actually enforce the limit after 5 requests
+        if is_rate_limit_test and _rate_limit_counts[key] > 5:
+            # Return a value that indicates rate limiting (simulating Redis response)
+            return 1000  # Return positive value indicating wait time in ms
+
+        # Return 0 to indicate not rate limited (allow request)
+        return 0
+
+    mock_redis = AsyncMock()
+    mock_redis.evalsha = mock_evalsha
+
+    # Patch FastAPILimiter in main module (for lifespan)
+    with patch('app.main.FastAPILimiter') as mock_main_fl:
+        mock_main_fl.redis = mock_redis
+        mock_main_fl.init = AsyncMock()
+        mock_main_fl.close = AsyncMock()
+        mock_main_fl.lua_sha = "mock_sha"
+        mock_main_fl.prefix = "test"
+        mock_main_fl.identifier = AsyncMock(return_value="test-key")
+        mock_main_fl.http_callback = AsyncMock()
+
+        # Patch FastAPILimiter in depends module (for RateLimiter class)
+        with patch('fastapi_limiter.depends.FastAPILimiter') as mock_depends_fl:
+            mock_depends_fl.redis = mock_redis
+            mock_depends_fl.init = AsyncMock()
+            mock_depends_fl.close = AsyncMock()
+            mock_depends_fl.lua_sha = "mock_sha"
+            mock_depends_fl.prefix = "test"
+            mock_depends_fl.identifier = AsyncMock(return_value="test-key")
+            mock_depends_fl.http_callback = AsyncMock()
+
+            yield _rate_limit_counts
+
 # Get database URL from environment
 DATABASE_URL = os.getenv(
     "DATABASE_URL",
@@ -361,6 +415,13 @@ def mock_httpx_combined_client():
     mock_client.__aexit__.return_value = None
 
     return mock_client
+
+
+@pytest.fixture
+def mock_client_class():
+    """Mock httpx.AsyncClient class for patching"""
+    with patch('httpx.AsyncClient') as mock_class:
+        yield mock_class
 
 
 # Helper function for soft-deleting teams in tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,11 @@ import os
 os.environ["AMAZEEAI_JWT_SECRET"] = "test-secret-key-for-tests"
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from starlette.status import HTTP_429_TOO_MANY_REQUESTS
 from app.main import app
 from app.db.database import get_db
 from app.db.models import Base, DBRegion, DBUser, DBTeam, DBProduct
@@ -36,12 +38,16 @@ def mock_rate_limiting(request):
         _rate_limit_counts[key] += 1
 
         # For rate limit tests, actually enforce the limit based on the configured 'times' value
-        if is_rate_limit_test and _rate_limit_counts[key] > times:
+        # Note: fastapi_limiter passes times as a string, so convert to int for comparison
+        if is_rate_limit_test and _rate_limit_counts[key] > int(times):
             # Return a value that indicates rate limiting (simulating Redis response)
             return 1000  # Return positive value indicating wait time in ms
 
         # Return 0 to indicate not rate limited (allow request)
         return 0
+
+    async def mock_http_callback(request, response, pexpire):
+        raise HTTPException(status_code=HTTP_429_TOO_MANY_REQUESTS, detail="Too Many Requests")
 
     mock_redis = AsyncMock()
     mock_redis.evalsha = mock_evalsha
@@ -54,7 +60,7 @@ def mock_rate_limiting(request):
         mock_main_fl.lua_sha = "mock_sha"
         mock_main_fl.prefix = "test"
         mock_main_fl.identifier = AsyncMock(return_value="test-key")
-        mock_main_fl.http_callback = AsyncMock()
+        mock_main_fl.http_callback = mock_http_callback
 
         # Patch FastAPILimiter in depends module (for RateLimiter class)
         with patch('fastapi_limiter.depends.FastAPILimiter') as mock_depends_fl:
@@ -64,7 +70,7 @@ def mock_rate_limiting(request):
             mock_depends_fl.lua_sha = "mock_sha"
             mock_depends_fl.prefix = "test"
             mock_depends_fl.identifier = AsyncMock(return_value="test-key")
-            mock_depends_fl.http_callback = AsyncMock()
+            mock_depends_fl.http_callback = mock_http_callback
 
             yield _rate_limit_counts
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -696,7 +696,6 @@ def test_login_cookie_expiration_regular_user(client, test_user):
     set_cookie_header = response.headers.get("set-cookie", "")
     assert "Max-Age=1800" in set_cookie_header or "max-age=1800" in set_cookie_header
 
-
 def test_login_cookie_expiration_system_admin(client, test_admin):
     """
     Given a system administrator

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -266,6 +266,25 @@ def test_validate_email_invalid_format(client, mock_dynamodb):
         mock_dynamodb.write_validation_code.assert_not_called()
 
 
+def test_validate_email_rate_limit(client, mock_dynamodb, mock_ses):
+    """Test that /auth/validate-email returns HTTP 429 after exceeding the rate limit."""
+    from app.core.config import settings
+
+    email = "ratelimit@example.com"
+    limit = settings.RATE_LIMIT_VALIDATE_EMAIL
+
+    # Requests up to the limit should succeed
+    for attempt in range(limit):
+        response = client.post("/auth/validate-email", json={"email": email})
+        assert response.status_code == 200, (
+            f"Request {attempt + 1} of {limit} should succeed, got {response.status_code}"
+        )
+
+    # The next request should be rate limited
+    response = client.post("/auth/validate-email", json={"email": email})
+    assert response.status_code == 429
+
+
 def test_sign_in_success(client, test_user, mock_dynamodb):
     # First, generate a validation code
     email = test_user.email

--- a/tests/test_team_keys_policy.py
+++ b/tests/test_team_keys_policy.py
@@ -1,4 +1,3 @@
-import pytest
 from unittest.mock import patch
 
 @patch("httpx.AsyncClient")

--- a/tests/test_team_keys_policy.py
+++ b/tests/test_team_keys_policy.py
@@ -1,5 +1,5 @@
+import pytest
 from unittest.mock import patch
-
 
 @patch("httpx.AsyncClient")
 def test_create_key_force_user_keys_enabled(
@@ -78,7 +78,6 @@ def test_create_key_force_user_keys_enabled(
 
     assert found_generate_call
 
-
 @patch("httpx.AsyncClient")
 def test_create_token_force_user_keys_enabled(
     mock_client_class,
@@ -121,7 +120,6 @@ def test_create_token_force_user_keys_enabled(
     # The API returns LiteLLMToken model which has owner_id
     assert data["owner_id"] == user_id
     assert data["team_id"] is None
-
 
 @patch("httpx.AsyncClient")
 def test_create_vector_db_force_user_keys_enabled(


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces Redis-backed rate limiting via `fastapi-limiter` on the `/auth/validate-email` endpoint (5 requests/60 s) and migrates the existing `monitor_teams` / `hard_delete_teams` background work from ad-hoc execution into an APScheduler with distributed locking. Redis is wired in through `docker-compose.yml`, Makefile test targets, and a new `REDIS_URL` config setting.

- **Rate limiting on `/auth/validate-email`**: `RateLimiter(times=5, seconds=60)` is added as a FastAPI dependency; tests are mocked via a new `autouse` fixture that emulates the Redis Lua-script return value and enforces limits in test names containing `rate_limit`.
- **APScheduler jobs in lifespan**: `monitor_teams_job` and `hard_delete_teams_job` are scheduled with environment-aware cron triggers and distributed DB locks to prevent duplicate execution across replicas.
- **Infrastructure**: Redis service added to `docker-compose.yml` with healthcheck; `backend` now declares `depends_on: redis: condition: service_healthy`.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The rate limiting on /auth/validate-email can be bypassed by any client that spoofs X-Forwarded-For, defeating the primary protection the feature is meant to provide.

The rate limit identifier trusts a client-controlled header, making it trivially bypassable. Redis is also now a hard startup dependency with no degraded-mode fallback.

app/api/auth.py and app/main.py need the most attention — the rate-limiter identifier and the hard Redis startup dependency.
</details>

<details open><summary><h3>Security Review</h3></summary>

- **`X-Forwarded-For` spoofing on rate-limited endpoint** (`app/api/auth.py`): The `fastapi-limiter` default identifier reads `X-Forwarded-For` and uses `split(\",\")[0]`. If the upstream proxy appends rather than replaces this header, an attacker can pre-set an arbitrary IP value on each request and bypass the 5-request-per-minute limit on `/auth/validate-email`, enabling unlimited validation-code email delivery to arbitrary addresses or email enumeration.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/main.py | Adds FastAPILimiter Redis init, APScheduler with monitor_teams and hard_delete_teams jobs in the lifespan; Redis is now a hard startup dependency with no fallback if unavailable |
| app/api/auth.py | Applies RateLimiter(5 req/60s) to /auth/validate-email; import reorder and walrus-operator refactor; rate limit bypassable via X-Forwarded-For spoofing with default identifier |
| app/core/config.py | Adds REDIS_URL (with REDIS_HOST/REDIS_PORT fallback) and RATE_LIMIT_VALIDATE_EMAIL settings; straightforward additions with correct Pydantic BaseSettings pattern |
| tests/conftest.py | Adds autouse mock_rate_limiting fixture that bypasses Redis for all tests and enforces limits in rate-limit-named tests; mock correctly patches both app.main and fastapi_limiter.depends namespaces |
| tests/test_auth.py | Adds test_validate_email_rate_limit covering the happy path (N requests succeed) and the 429 on N+1; test logic aligns correctly with mock_evalsha counting logic |
| docker-compose.yml | Adds redis service (uselagoon/redis-7) with healthcheck; backend gains REDIS_URL env var and depends_on redis:service_healthy — startup dependency properly guarded |
| requirements.txt | Adds fastapi-limiter==0.1.6, redis==4.6.0, and apscheduler==3.11.2 with pinned versions |
| Makefile | Adds test-redis target, includes REDIS_URL in all backend-test targets, and cleans up redis container in test-clean |
| tests/test_team_keys_policy.py | Minor cleanup: removes blank lines between test functions, no logic changes |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Proxy
    participant FastAPI
    participant RateLimiter
    participant Redis
    participant ValidateEmail

    Client->>Proxy: POST /auth/validate-email
    Proxy->>FastAPI: forward request (X-Forwarded-For: client_ip)
    FastAPI->>RateLimiter: resolve dependency
    RateLimiter->>Redis: EVALSHA lua_sha 1 ip:path times ms
    alt under limit
        Redis-->>RateLimiter: 0 (allowed)
        RateLimiter-->>FastAPI: continue
        FastAPI->>ValidateEmail: execute handler
        ValidateEmail-->>Client: 200 OK
    else limit exceeded
        Redis-->>RateLimiter: pexpire ms remaining
        RateLimiter-->>Client: 429 Too Many Requests
    end

    Note over FastAPI: lifespan startup
    FastAPI->>Redis: FastAPILimiter.init script_load
    FastAPI->>APScheduler: scheduler.start
    APScheduler-->>FastAPI: jobs registered monitor_teams hard_delete_teams
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add apscheduler==3.11.2 to requirem..."](https://github.com/amazeeio/amazee.ai/commit/45c0da6403af9443dc0c8c74acbcec91320bfff4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31919012)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->