### PR TITLE
Add team_id filter to keys-by-region endpoint

### DIFF
--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -545,10 +545,15 @@ async def list_private_ai_keys_by_region(
 
     if current_user.is_admin:
         if team_id is not None:
-            team_users = db.query(DBUser).filter(DBUser.team_id == team_id).all()
-            team_user_ids = [user.id for user in team_users]
+            # Check team exists and is not soft-deleted
+            team = db.query(DBTeam).filter(DBTeam.id == team_id, DBTeam.deleted_at.is_(None)).first()
+            if team is None:
+                return []
+
+            # Use subquery instead of loading users into memory
+            team_user_ids_subq = db.query(DBUser.id).filter(DBUser.team_id == team_id).subquery()
             query = query.filter(
-                (DBPrivateAIKey.owner_id.in_(team_user_ids)) |
+                (DBPrivateAIKey.owner_id.in_(db.query(team_user_ids_subq))) |
                 (DBPrivateAIKey.team_id == team_id)
             )
     else:

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -2059,3 +2059,44 @@ def test_list_private_ai_keys_by_region_team_filter_ignored_for_non_admin(client
     returned_db_names = {key["database_name"] for key in data}
     assert "region-user-own-db" in returned_db_names
     assert "region-team-filter-db" not in returned_db_names
+
+
+def test_list_private_ai_keys_by_region_soft_deleted_team_returns_empty(client, admin_token, test_region, db):
+    """Test that filtering by a soft-deleted team returns empty results"""
+    # Create a team and soft-delete it
+    deleted_team = DBTeam(
+        name="Deleted Team For Region Filter",
+        admin_email="deletedregionteam@example.com",
+        phone="9998887777",
+        billing_address="000 Deleted St, City, 00000",
+        is_active=True,
+        created_at=datetime.now(UTC),
+        deleted_at=datetime.now(UTC)
+    )
+    db.add(deleted_team)
+    db.commit()
+    db.refresh(deleted_team)
+
+    # Create a key owned by the soft-deleted team
+    key = DBPrivateAIKey(
+        database_name="region-deleted-team-db",
+        database_host="test-host",
+        database_username="deleted-user",
+        database_password="test-pass",
+        litellm_token="region-deleted-team-token",
+        team_id=deleted_team.id,
+        region_id=test_region.id
+    )
+    db.add(key)
+    db.commit()
+
+    # Admin queries by region with soft-deleted team_id filter
+    response = client.get(
+        f"/private-ai-keys/region/{test_region.id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        params={"team_id": deleted_team.id}
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 0


### PR DESCRIPTION
## Summary
- Add optional `team_id` query param to `GET /private-ai-keys/region/{region_id}` for admins
- Filters keys by team ownership (via owner's team or direct team_id on key)
- Non-admin users: param is ignored, existing scoping applies
- Tests cover both admin filtering and non-admin ignore behavior

## Test plan
- [x] `test_list_private_ai_keys_by_region_with_team_filter` — admin sees only target team's keys
- [x] `test_list_private_ai_keys_by_region_team_filter_ignored_for_non_admin` — non-admin unaffected by param
- [ ] Manual: verify existing non-filtered behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)