### PR TITLE
feat(api): preserve DB team_id when merging LiteLLM info in keys

### DIFF
--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -712,7 +712,13 @@ async def get_private_ai_key(
 
         # Combine database key info with LiteLLM info
         key_data = private_ai_key.to_dict()
-        key_data.update(info)
+        # Keep ownership identifiers from our DB authoritative.
+        # LiteLLM `team_id` is region-scoped string (e.g. "ap-southeast-1_12"),
+        # while our API schema expects integer `team_id`.
+        info_without_ownership = {
+            k: v for k, v in info.items() if k not in {"id", "owner_id", "team_id"}
+        }
+        key_data.update(info_without_ownership)
 
         return PrivateAIKeyDetail.model_validate(key_data)
     except Exception as e:

--- a/app/migrations/versions/20260317_134500_7f2b1d9c4eaa_repair_pool_purchases_drift.py
+++ b/app/migrations/versions/20260317_134500_7f2b1d9c4eaa_repair_pool_purchases_drift.py
@@ -67,7 +67,9 @@ def downgrade() -> None:
     bind = op.get_bind()
     if _table_exists(bind, "pool_purchases"):
         if _index_exists(bind, "pool_purchases", "ix_pool_purchases_stripe_payment_id"):
-            op.drop_index("ix_pool_purchases_stripe_payment_id", table_name="pool_purchases")
+            op.drop_index(
+                "ix_pool_purchases_stripe_payment_id", table_name="pool_purchases"
+            )
         if _index_exists(bind, "pool_purchases", "ix_pool_purchases_region_id"):
             op.drop_index("ix_pool_purchases_region_id", table_name="pool_purchases")
         if _index_exists(bind, "pool_purchases", "ix_pool_purchases_team_id"):

--- a/tests/test_litellm_alias_sanitization.py
+++ b/tests/test_litellm_alias_sanitization.py
@@ -19,8 +19,10 @@ def test_sanitize_alias_email():
     # The combination of email and name as used in create_key
     email = "test@example.com"
     name = "my-key"
-    assert LiteLLMService.sanitize_alias(f"{email} - {name}") == "test_at_example.com_-_my-key"
-
+    assert (
+        LiteLLMService.sanitize_alias(f"{email} - {name}")
+        == "test_at_example.com_-_my-key"
+    )
 
 
 def test_sanitize_alias_special_chars():

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -1510,6 +1510,65 @@ def test_get_private_ai_key_success(
 
 
 @patch("httpx.AsyncClient")
+def test_get_private_ai_key_preserves_db_team_id_when_litellm_team_id_is_string(
+    mock_client_class,
+    client,
+    admin_token,
+    test_region,
+    db,
+    test_team,
+    mock_httpx_get_client,
+):
+    """Ensure LiteLLM string team_id does not override DB integer team_id."""
+    db.refresh(test_team)
+    test_key = DBPrivateAIKey(
+        database_name="test-db-get-team-id",
+        name="Test Key Team ID Merge",
+        database_host="test-host",
+        database_username="test-user",
+        database_password="test-pass",
+        litellm_token="test-token-get-team-id",
+        litellm_api_url="https://test-litellm.com",
+        team_id=test_team.id,
+        region_id=test_region.id,
+    )
+    db.add(test_key)
+    db.commit()
+    db.refresh(test_key)
+
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {
+        "info": {
+            "team_id": f"{test_region.name}_-1",
+            "spend": 10.5,
+            "expires": "2024-12-31T23:59:59Z",
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-02T00:00:00Z",
+            "max_budget": 100.0,
+            "budget_duration": "monthly",
+            "budget_reset_at": "2024-02-01T00:00:00Z",
+        }
+    }
+    mock_httpx_get_client.get.return_value = mock_response
+    mock_client_class.return_value = mock_httpx_get_client
+
+    response = client.get(
+        f"/private-ai-keys/{test_key.id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["team_id"] == test_team.id
+    assert data["spend"] == 10.5
+
+    db.delete(test_key)
+    db.commit()
+
+
+@patch("httpx.AsyncClient")
 def test_get_private_ai_key_not_found(
     mock_client_class, client, admin_token, mock_httpx_get_client
 ):


### PR DESCRIPTION
## PR Report

### What was failing
`GET /private-ai-keys/{id}` failed with a Pydantic validation error because `team_id` was expected as an integer but got a LiteLLM-formatted string (for example `ap-southeast-1_-1`).

### Root cause
In `get_private_ai_key`, we merged LiteLLM key info directly into DB key data with `key_data.update(info)`.  
That allowed LiteLLM `team_id` (string) to overwrite DB `team_id` (int/null), causing response model validation to fail.

### Fix implemented
- Updated merge logic in [app/api/private_ai_keys.py](/Users/dimitris.spachos/Sites/amazee.ai/app/api/private_ai_keys.py:712):
  - Preserve DB ownership fields as authoritative (`id`, `owner_id`, `team_id`)
  - Merge all other LiteLLM fields as before (`spend`, budget/expires fields, etc.)

### Regression test added
- Added test in [tests/test_private_ai.py](/Users/dimitris.spachos/Sites/amazee.ai/tests/test_private_ai.py:1512):
  - `test_get_private_ai_key_preserves_db_team_id_when_litellm_team_id_is_string`
  - Verifies that LiteLLM string `team_id` does not override DB `team_id`.

### Validation
- Ran backend suite per README: `make backend-test`
- Result: `694 passed, 1 skipped, 4 warnings`
- New regression test passed

### Cleanup
- Ran `make test-clean`
- Confirmed no leftover test Docker container/image/network artifacts.