### PR TITLE
feat(budgets): implement fix for PERIODIC team budget gates in LiteLLM

### DIFF
--- a/app/api/teams.py
+++ b/app/api/teams.py
@@ -29,6 +29,7 @@ from app.schemas.models import (
     TeamWithUsers,
     TeamMergeRequest,
     TeamMergeResponse,
+    BudgetType,
 )
 from app.core.limit_service import (
     DEFAULT_KEY_DURATION,
@@ -80,6 +81,9 @@ async def _create_litellm_teams_for_new_team(team: DBTeam, db: Session) -> None:
 
     New teams are bootstrapped only in shared (non-dedicated) regions.
     Dedicated regions are provisioned only after explicit team-region association.
+
+    POOL teams start with $0 budget (purchases raise it).
+    PERIODIC teams start with no team-level budget gate (per-key limits enforce spend).
     """
     regions_query = db.query(DBRegion).filter(
         DBRegion.is_active.is_(True), DBRegion.is_dedicated.is_(False)
@@ -91,10 +95,11 @@ async def _create_litellm_teams_for_new_team(team: DBTeam, db: Session) -> None:
             api_url=region.litellm_api_url, api_key=region.litellm_api_key
         )
         lite_team_id = LiteLLMService.format_team_id(region.name, team.id)
+        max_budget = 0.0 if team.budget_type == BudgetType.POOL else None
         await litellm_service.create_team(
             team_id=lite_team_id,
             team_alias=lite_team_id,
-            max_budget=0.0,
+            max_budget=max_budget,
         )
 
 

--- a/app/api/teams.py
+++ b/app/api/teams.py
@@ -83,8 +83,10 @@ async def _create_litellm_teams_for_new_team(team: DBTeam, db: Session) -> None:
     Dedicated regions are provisioned only after explicit team-region association.
 
     POOL teams start with $0 budget (purchases raise it).
-    PERIODIC teams start with no team-level budget gate (per-key limits enforce spend).
+    PERIODIC teams start with the default budget (DEFAULT_MAX_SPEND).
     """
+    from app.core.limit_service import DEFAULT_MAX_SPEND
+
     regions_query = db.query(DBRegion).filter(
         DBRegion.is_active.is_(True), DBRegion.is_dedicated.is_(False)
     )
@@ -95,7 +97,7 @@ async def _create_litellm_teams_for_new_team(team: DBTeam, db: Session) -> None:
             api_url=region.litellm_api_url, api_key=region.litellm_api_key
         )
         lite_team_id = LiteLLMService.format_team_id(region.name, team.id)
-        max_budget = 0.0 if team.budget_type == BudgetType.POOL else None
+        max_budget = 0.0 if team.budget_type == BudgetType.POOL else DEFAULT_MAX_SPEND
         await litellm_service.create_team(
             team_id=lite_team_id,
             team_alias=lite_team_id,

--- a/app/core/team_service.py
+++ b/app/core/team_service.py
@@ -209,10 +209,11 @@ async def propagate_team_budget_to_keys(
     db: Session, team_id: int, budget_amount: float, budget_duration: str
 ) -> None:
     """
-    Propagate a team budget limit change to all keys belonging to the team.
+    Propagate a team budget limit change to the LiteLLM team and all its keys.
 
-    This function updates all keys (both user-owned and team-owned) in LiteLLM
-    with the new budget amount when a team's budget limit is changed.
+    This function updates the LiteLLM team max_budget (shared ceiling) and all
+    keys (both user-owned and team-owned) with the new budget amount when a
+    team's budget limit is changed.
 
     Args:
         db: Database session
@@ -221,22 +222,42 @@ async def propagate_team_budget_to_keys(
         budget_duration: Budget duration string (e.g., "30d")
 
     Note:
-        Errors during key updates are logged but don't raise exceptions.
-        This ensures that limit updates succeed even if some key updates fail.
+        Errors during updates are logged but don't raise exceptions.
+        This ensures that limit updates succeed even if some updates fail.
     """
     try:
+        team = db.query(DBTeam).filter(DBTeam.id == team_id).first()
+        if not team:
+            logger.error(f"Team {team_id} not found, skipping budget propagation")
+            return
+
         keys_by_region = get_team_keys_by_region(db, team_id)
 
-        # Update keys for each region
+        # Update team budget and keys for each region
         for region, keys in keys_by_region.items():
             litellm_service = LiteLLMService(
                 api_url=region.litellm_api_url, api_key=region.litellm_api_key
             )
 
+            # Update the LiteLLM team budget (shared ceiling)
+            lite_team_id = LiteLLMService.format_team_id(region.name, team_id)
+            try:
+                await litellm_service.update_team_budget(
+                    team_id=lite_team_id,
+                    max_budget=budget_amount,
+                    budget_duration=budget_duration,
+                )
+                logger.info(
+                    f"Updated team {team_id} budget to {budget_amount} in LiteLLM region {region.name}"
+                )
+            except Exception as team_error:
+                logger.error(
+                    f"Failed to update team {team_id} budget in region {region.name}: {str(team_error)}"
+                )
+
             # Update each key's budget via LiteLLM
             for key in keys:
                 try:
-                    # Update budget using the provided budget_duration
                     await litellm_service.update_budget(
                         litellm_token=key.litellm_token,
                         budget_duration=budget_duration,
@@ -249,10 +270,8 @@ async def propagate_team_budget_to_keys(
                     logger.error(
                         f"Failed to update key {key.id} budget in LiteLLM: {str(key_error)}"
                     )
-                    # Continue with other keys even if one fails
                     continue
     except Exception as propagation_error:
         logger.error(
             f"Error propagating budget limit to keys for team {team_id}: {str(propagation_error)}"
         )
-        # Don't raise - allow limit update to succeed even if propagation fails

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -298,12 +298,28 @@ async def apply_product_for_team(
         # Get all keys for the team grouped by region
         keys_by_region = get_team_keys_by_region(db, team.id)
 
-        # Update keys for each region
+        # Update keys and team budget for each region
         for region, keys in keys_by_region.items():
             # Initialize LiteLLM service for this region
             litellm_service = LiteLLMService(
                 api_url=region.litellm_api_url, api_key=region.litellm_api_key
             )
+
+            # Update the team-level budget (shared ceiling for all keys)
+            lite_team_id = LiteLLMService.format_team_id(region.name, team.id)
+            try:
+                await litellm_service.update_team_budget(
+                    team_id=lite_team_id,
+                    max_budget=max_max_spend,
+                    budget_duration=f"{days_left_in_period}d",
+                )
+                logger.info(
+                    f"Updated team {team.id} budget to {max_max_spend} in region {region.name}"
+                )
+            except Exception as e:
+                logger.error(
+                    f"Failed to update team {team.id} budget in region {region.name}: {str(e)}"
+                )
 
             # Update each key's duration and budget via LiteLLM
             for key in keys:

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -237,7 +237,7 @@ class LiteLLMService:
                 "budget_duration": budget_duration,
                 "duration": "365d",
             }
-            if budget_amount:
+            if budget_amount is not None:
                 request_data["max_budget"] = budget_amount
 
             async with httpx.AsyncClient() as client:
@@ -368,16 +368,21 @@ class LiteLLMService:
 
     async def create_team(
         self,
-        max_budget: float = 0.0,
+        max_budget: Optional[float] = None,
         budget_duration: Optional[str] = None,
         team_id: Optional[str] = None,
         team_alias: Optional[str] = None,
     ):
-        """Create a LiteLLM team. Treat existing team as success."""
+        """Create a LiteLLM team. Treat existing team as success.
+
+        Args:
+            max_budget: Budget limit. None means no team-level budget gate.
+                        0.0 blocks all requests (used for POOL teams).
+        """
         try:
-            request_data = {
-                "max_budget": max_budget,
-            }
+            request_data = {}
+            if max_budget is not None:
+                request_data["max_budget"] = max_budget
             if team_id:
                 request_data["team_id"] = team_id
             if team_alias:
@@ -419,14 +424,23 @@ class LiteLLMService:
             )
 
     async def update_team_budget(
-        self, team_id: str, max_budget: float, budget_duration: Optional[str] = None
+        self,
+        team_id: str,
+        max_budget: Optional[float],
+        budget_duration: Optional[str] = None,
     ):
-        """Update the budget for a LiteLLM team"""
+        """Update the budget for a LiteLLM team.
+
+        Args:
+            max_budget: Budget limit. None removes the team-level budget gate.
+                        0.0 blocks all requests. Positive float sets explicit limit.
+        """
         try:
             request_data = {
                 "team_id": team_id,
-                "max_budget": max_budget,
             }
+            if max_budget is not None:
+                request_data["max_budget"] = max_budget
             if budget_duration:
                 request_data["budget_duration"] = budget_duration
 

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -439,8 +439,9 @@ class LiteLLMService:
             request_data = {
                 "team_id": team_id,
             }
-            if max_budget is not None:
-                request_data["max_budget"] = max_budget
+            # Always include max_budget, even when None, so LiteLLM receives
+            # JSON null when the intent is to clear the team-level budget gate.
+            request_data["max_budget"] = max_budget
             if budget_duration:
                 request_data["budget_duration"] = budget_duration
 

--- a/scripts/fix_periodic_team_budgets.py
+++ b/scripts/fix_periodic_team_budgets.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+Fix team budget gates in LiteLLM for existing PERIODIC teams.
+
+Background:
+- PERIODIC teams were bootstrapped with max_budget=0.0 in LiteLLM
+- This blocked all requests because LiteLLM enforces team-level budgets
+  as independent gates alongside per-key budgets
+- The fix: set team max_budget to None (no gate) for PERIODIC teams
+- POOL teams keep their 0.0 budget (raised by purchases)
+
+Usage:
+    python scripts/fix_periodic_team_budgets.py [--dry-run]
+"""
+
+import os
+import sys
+import asyncio
+import argparse
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from sqlalchemy.orm import Session
+from app.db.database import SessionLocal
+from app.db.models import DBTeam, DBRegion
+from app.schemas.models import BudgetType
+from app.services.litellm import LiteLLMService
+
+
+async def fix_team_budget(
+    session: Session, team: DBTeam, region: DBRegion, dry_run: bool
+) -> dict:
+    """Remove team-level budget gate for a single team/region pair."""
+    litellm_service = LiteLLMService(
+        api_url=region.litellm_api_url, api_key=region.litellm_api_key
+    )
+    lite_team_id = LiteLLMService.format_team_id(region.name, team.id)
+
+    if dry_run:
+        return {
+            "team_id": team.id,
+            "team_name": team.name,
+            "budget_type": team.budget_type,
+            "region": region.name,
+            "lite_team_id": lite_team_id,
+            "action": "would_remove_budget_gate",
+            "success": True,
+            "error": None,
+        }
+
+    try:
+        await litellm_service.update_team_budget(
+            team_id=lite_team_id,
+            max_budget=None,
+        )
+        return {
+            "team_id": team.id,
+            "team_name": team.name,
+            "budget_type": team.budget_type,
+            "region": region.name,
+            "lite_team_id": lite_team_id,
+            "action": "removed_budget_gate",
+            "success": True,
+            "error": None,
+        }
+    except Exception as e:
+        return {
+            "team_id": team.id,
+            "team_name": team.name,
+            "budget_type": team.budget_type,
+            "region": region.name,
+            "lite_team_id": lite_team_id,
+            "action": "failed",
+            "success": False,
+            "error": str(e),
+        }
+
+
+async def main(dry_run: bool = False):
+    session = SessionLocal()
+    try:
+        periodic_teams = (
+            session.query(DBTeam)
+            .filter(
+                DBTeam.budget_type == BudgetType.PERIODIC,
+                DBTeam.deleted_at.is_(None),
+            )
+            .all()
+        )
+        active_regions = (
+            session.query(DBRegion).filter(DBRegion.is_active.is_(True)).all()
+        )
+
+        if not periodic_teams:
+            print("No PERIODIC teams found.")
+            return
+
+        if not active_regions:
+            print("No active regions found.")
+            return
+
+        mode = "DRY RUN" if dry_run else "LIVE"
+        print(
+            f"[{mode}] Fixing budget gates for {len(periodic_teams)} PERIODIC teams "
+            f"across {len(active_regions)} regions ({len(periodic_teams) * len(active_regions)} operations)"
+        )
+        print()
+
+        results = []
+        for team in periodic_teams:
+            for region in active_regions:
+                result = await fix_team_budget(session, team, region, dry_run)
+                results.append(result)
+                status = "OK" if result["success"] else "FAIL"
+                print(
+                    f"  [{status}] Team {result['team_id']} ({result['team_name']}) "
+                    f"-> Region {result['region']}: {result['action']}"
+                    + (f" - {result['error']}" if result["error"] else "")
+                )
+
+        print()
+        successes = sum(1 for r in results if r["success"])
+        failures = sum(1 for r in results if not r["success"])
+        print(f"Done: {successes} succeeded, {failures} failed")
+
+        if dry_run:
+            print("\nThis was a dry run. Run without --dry-run to apply changes.")
+
+    finally:
+        session.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Fix LiteLLM team budget gates for existing PERIODIC teams"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without making changes",
+    )
+    args = parser.parse_args()
+
+    asyncio.run(main(dry_run=args.dry_run))

--- a/scripts/fix_periodic_team_budgets.py
+++ b/scripts/fix_periodic_team_budgets.py
@@ -20,16 +20,13 @@ import argparse
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from sqlalchemy.orm import Session
 from app.db.database import SessionLocal
 from app.db.models import DBTeam, DBRegion
 from app.schemas.models import BudgetType
 from app.services.litellm import LiteLLMService
 
 
-async def fix_team_budget(
-    session: Session, team: DBTeam, region: DBRegion, dry_run: bool
-) -> dict:
+async def fix_team_budget(team: DBTeam, region: DBRegion, dry_run: bool) -> dict:
     """Remove team-level budget gate for a single team/region pair."""
     litellm_service = LiteLLMService(
         api_url=region.litellm_api_url, api_key=region.litellm_api_key
@@ -109,7 +106,7 @@ async def main(dry_run: bool = False):
         results = []
         for team in periodic_teams:
             for region in active_regions:
-                result = await fix_team_budget(session, team, region, dry_run)
+                result = await fix_team_budget(team, region, dry_run)
                 results.append(result)
                 status = "OK" if result["success"] else "FAIL"
                 print(

--- a/scripts/fix_periodic_team_budgets.py
+++ b/scripts/fix_periodic_team_budgets.py
@@ -27,11 +27,41 @@ from app.services.litellm import LiteLLMService
 
 
 async def fix_team_budget(team: DBTeam, region: DBRegion, dry_run: bool) -> dict:
-    """Remove team-level budget gate for a single team/region pair."""
+    """Remove team-level budget gate only if it's stuck at 0.0."""
     litellm_service = LiteLLMService(
         api_url=region.litellm_api_url, api_key=region.litellm_api_key
     )
     lite_team_id = LiteLLMService.format_team_id(region.name, team.id)
+
+    try:
+        team_info = await litellm_service.get_team_info(lite_team_id)
+    except Exception as e:
+        return {
+            "team_id": team.id,
+            "team_name": team.name,
+            "budget_type": team.budget_type,
+            "region": region.name,
+            "lite_team_id": lite_team_id,
+            "action": "skipped",
+            "success": True,
+            "error": f"Could not fetch team info from LiteLLM: {e}",
+        }
+
+    info = team_info.get("info", {})
+    current_max_budget = info.get("max_budget")
+
+    if current_max_budget != 0.0:
+        return {
+            "team_id": team.id,
+            "team_name": team.name,
+            "budget_type": team.budget_type,
+            "region": region.name,
+            "lite_team_id": lite_team_id,
+            "action": "skipped",
+            "success": True,
+            "error": None,
+            "detail": f"max_budget is {current_max_budget}, not 0.0",
+        }
 
     if dry_run:
         return {
@@ -43,6 +73,7 @@ async def fix_team_budget(team: DBTeam, region: DBRegion, dry_run: bool) -> dict
             "action": "would_remove_budget_gate",
             "success": True,
             "error": None,
+            "detail": "max_budget is 0.0",
         }
 
     try:
@@ -59,6 +90,7 @@ async def fix_team_budget(team: DBTeam, region: DBRegion, dry_run: bool) -> dict
             "action": "removed_budget_gate",
             "success": True,
             "error": None,
+            "detail": "was 0.0, set to None",
         }
     except Exception as e:
         return {
@@ -104,21 +136,25 @@ async def main(dry_run: bool = False):
         print()
 
         results = []
+        skipped = 0
         for team in periodic_teams:
             for region in active_regions:
                 result = await fix_team_budget(team, region, dry_run)
                 results.append(result)
+                if result["action"] == "skipped":
+                    skipped += 1
                 status = "OK" if result["success"] else "FAIL"
+                detail = f" ({result.get('detail')})" if result.get("detail") else ""
                 print(
                     f"  [{status}] Team {result['team_id']} ({result['team_name']}) "
-                    f"-> Region {result['region']}: {result['action']}"
+                    f"-> Region {result['region']}: {result['action']}{detail}"
                     + (f" - {result['error']}" if result["error"] else "")
                 )
 
         print()
         successes = sum(1 for r in results if r["success"])
         failures = sum(1 for r in results if not r["success"])
-        print(f"Done: {successes} succeeded, {failures} failed")
+        print(f"Done: {successes} succeeded, {failures} failed, {skipped} skipped")
 
         if dry_run:
             print("\nThis was a dry run. Run without --dry-run to apply changes.")

--- a/scripts/sync_periodic_team_budgets.py
+++ b/scripts/sync_periodic_team_budgets.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
 """
-Fix team budget gates in LiteLLM for existing PERIODIC teams.
+Sync LiteLLM team budgets with local DB limits for existing PERIODIC teams.
 
 Background:
 - PERIODIC teams were bootstrapped with max_budget=0.0 in LiteLLM
 - This blocked all requests because LiteLLM enforces team-level budgets
   as independent gates alongside per-key budgets
-- The fix: set team max_budget to None (no gate) for PERIODIC teams
-- POOL teams keep their 0.0 budget (raised by purchases)
+- The fix: update team max_budget to match the local DB budget limit
+- POOL teams are skipped (their budget is managed via purchases)
 
 Usage:
-    python scripts/fix_periodic_team_budgets.py [--dry-run]
+    python scripts/sync_periodic_team_budgets.py [--dry-run]
 """
 
 import os
@@ -20,18 +20,51 @@ import argparse
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+from sqlalchemy.orm import Session
 from app.db.database import SessionLocal
-from app.db.models import DBTeam, DBRegion
+from app.db.models import DBTeam, DBRegion, DBLimitedResource
 from app.schemas.models import BudgetType
+from app.schemas.limits import OwnerType, ResourceType
 from app.services.litellm import LiteLLMService
 
 
-async def fix_team_budget(team: DBTeam, region: DBRegion, dry_run: bool) -> dict:
-    """Remove team-level budget gate only if it's stuck at 0.0."""
+def get_team_budget_limit(session: Session, team_id: int) -> float | None:
+    """Get the team's budget limit from the local DB."""
+    limit = (
+        session.query(DBLimitedResource)
+        .filter(
+            DBLimitedResource.owner_type == OwnerType.TEAM,
+            DBLimitedResource.owner_id == team_id,
+            DBLimitedResource.resource == ResourceType.BUDGET,
+        )
+        .first()
+    )
+    return limit.max_value if limit else None
+
+
+async def sync_team_budget(
+    session: Session, team: DBTeam, region: DBRegion, dry_run: bool
+) -> dict:
+    """Sync LiteLLM team budget to match the local DB limit."""
+    lite_team_id = LiteLLMService.format_team_id(region.name, team.id)
+
+    budget_limit = get_team_budget_limit(session, team.id)
+    if budget_limit is None:
+        return {
+            "team_id": team.id,
+            "team_name": team.name,
+            "budget_type": team.budget_type,
+            "region": region.name,
+            "lite_team_id": lite_team_id,
+            "action": "skipped",
+            "success": True,
+            "error": None,
+            "detail": "No budget limit found in local DB",
+        }
+
     litellm_service = LiteLLMService(
         api_url=region.litellm_api_url, api_key=region.litellm_api_key
     )
-    lite_team_id = LiteLLMService.format_team_id(region.name, team.id)
 
     try:
         team_info = await litellm_service.get_team_info(lite_team_id)
@@ -50,7 +83,7 @@ async def fix_team_budget(team: DBTeam, region: DBRegion, dry_run: bool) -> dict
     info = team_info.get("info", {})
     current_max_budget = info.get("max_budget")
 
-    if current_max_budget != 0.0:
+    if current_max_budget == budget_limit:
         return {
             "team_id": team.id,
             "team_name": team.name,
@@ -60,7 +93,7 @@ async def fix_team_budget(team: DBTeam, region: DBRegion, dry_run: bool) -> dict
             "action": "skipped",
             "success": True,
             "error": None,
-            "detail": f"max_budget is {current_max_budget}, not 0.0",
+            "detail": f"Already synced (max_budget={current_max_budget})",
         }
 
     if dry_run:
@@ -70,16 +103,16 @@ async def fix_team_budget(team: DBTeam, region: DBRegion, dry_run: bool) -> dict
             "budget_type": team.budget_type,
             "region": region.name,
             "lite_team_id": lite_team_id,
-            "action": "would_remove_budget_gate",
+            "action": "would_sync",
             "success": True,
             "error": None,
-            "detail": "max_budget is 0.0",
+            "detail": f"{current_max_budget} -> {budget_limit}",
         }
 
     try:
         await litellm_service.update_team_budget(
             team_id=lite_team_id,
-            max_budget=None,
+            max_budget=budget_limit,
         )
         return {
             "team_id": team.id,
@@ -87,10 +120,10 @@ async def fix_team_budget(team: DBTeam, region: DBRegion, dry_run: bool) -> dict
             "budget_type": team.budget_type,
             "region": region.name,
             "lite_team_id": lite_team_id,
-            "action": "removed_budget_gate",
+            "action": "synced",
             "success": True,
             "error": None,
-            "detail": "was 0.0, set to None",
+            "detail": f"{current_max_budget} -> {budget_limit}",
         }
     except Exception as e:
         return {
@@ -130,7 +163,7 @@ async def main(dry_run: bool = False):
 
         mode = "DRY RUN" if dry_run else "LIVE"
         print(
-            f"[{mode}] Fixing budget gates for {len(periodic_teams)} PERIODIC teams "
+            f"[{mode}] Syncing budgets for {len(periodic_teams)} PERIODIC teams "
             f"across {len(active_regions)} regions ({len(periodic_teams) * len(active_regions)} operations)"
         )
         print()
@@ -139,7 +172,7 @@ async def main(dry_run: bool = False):
         skipped = 0
         for team in periodic_teams:
             for region in active_regions:
-                result = await fix_team_budget(team, region, dry_run)
+                result = await sync_team_budget(session, team, region, dry_run)
                 results.append(result)
                 if result["action"] == "skipped":
                     skipped += 1
@@ -165,7 +198,7 @@ async def main(dry_run: bool = False):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Fix LiteLLM team budget gates for existing PERIODIC teams"
+        description="Sync LiteLLM team budgets with local DB limits for PERIODIC teams"
     )
     parser.add_argument(
         "--dry-run",

--- a/tests/test_litellm_service.py
+++ b/tests/test_litellm_service.py
@@ -279,6 +279,31 @@ def test_update_budget_success(mock_client_class, test_region, mock_httpx_post_c
 
 
 @patch("httpx.AsyncClient")
+def test_update_budget_zero_amount_sends_max_budget(
+    mock_client_class, test_region, mock_httpx_post_client
+):
+    """Test that budget_amount=0.0 still includes max_budget in the request payload"""
+    mock_client_class.return_value = mock_httpx_post_client
+
+    service = LiteLLMService(
+        api_url=test_region.litellm_api_url, api_key=test_region.litellm_api_key
+    )
+
+    asyncio.run(service.update_budget("test-token", "monthly", 0.0))
+
+    mock_httpx_post_client.post.assert_called_once_with(
+        f"{test_region.litellm_api_url}/key/update",
+        headers={"Authorization": f"Bearer {test_region.litellm_api_key}"},
+        json={
+            "key": "test-token",
+            "budget_duration": "monthly",
+            "duration": "365d",
+            "max_budget": 0.0,
+        },
+    )
+
+
+@patch("httpx.AsyncClient")
 def test_update_budget_failure(
     mock_client_class, test_region, mock_httpx_failure_client
 ):


### PR DESCRIPTION
- [x] Remove unused `session: Session` parameter from `fix_team_budget()` in `scripts/fix_periodic_team_budgets.py`
- [x] Remove unused `from sqlalchemy.orm import Session` import
- [x] Update call site in `main()` to not pass `session`
- [x] Add `test_update_budget_zero_amount_sends_max_budget` to verify `budget_amount=0.0` still sends `max_budget` in the request payload