### PR TITLE
Feature/ai 274 public endpoint model availability

### DIFF
--- a/app/api/public.py
+++ b/app/api/public.py
@@ -18,7 +18,10 @@ router = APIRouter(tags=["public"])
 
 _CACHE_TTL = timedelta(hours=1)
 _cache_lock = asyncio.Lock()
-_models_cache: dict[str, Any] = {"expires_at": datetime.min.replace(tzinfo=UTC), "data": []}
+_models_cache: dict[str, Any] = {
+    "expires_at": datetime.min.replace(tzinfo=UTC),
+    "data": [],
+}
 
 
 def _infer_provider(item: dict[str, Any]) -> str:
@@ -36,7 +39,9 @@ def _infer_provider(item: dict[str, Any]) -> str:
 
 def _to_display_name(model_id: str) -> str:
     words = re.split(r"[-_]+", model_id)
-    return " ".join(word.upper() if word.isupper() else word.capitalize() for word in words if word)
+    return " ".join(
+        word.upper() if word.isupper() else word.capitalize() for word in words if word
+    )
 
 
 def _extract_model_data(item: dict[str, Any], fallback_region: str) -> PublicModel:
@@ -92,7 +97,9 @@ async def list_public_models(db: Session = Depends(get_db)):
                     all_models.append(_extract_model_data(item, region.name))
             except Exception as exc:
                 logger.warning(
-                    "Region %s unavailable for /public/models: %s", region.name, str(exc)
+                    "Region %s unavailable for /public/models: %s",
+                    region.name,
+                    str(exc),
                 )
                 all_models.append(
                     PublicModel(

--- a/app/api/public.py
+++ b/app/api/public.py
@@ -4,7 +4,8 @@ import re
 from datetime import datetime, timedelta, UTC
 from typing import Any
 
-from fastapi import APIRouter, Depends
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from app.db.database import get_db
@@ -17,6 +18,8 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["public"])
 
 _CACHE_TTL = timedelta(hours=1)
+_REGION_TIMEOUT = 10.0  # seconds per-region request
+_REGION_SEMAPHORE = asyncio.Semaphore(10)  # max concurrent region requests
 _cache_lock = asyncio.Lock()
 _models_cache: dict[str, Any] = {
     "expires_at": datetime.min.replace(tzinfo=UTC),
@@ -66,6 +69,37 @@ def _extract_model_data(item: dict[str, Any], fallback_region: str) -> PublicMod
     )
 
 
+async def _fetch_region_models(
+    service: LiteLLMService, region_name: str
+) -> list[PublicModel]:
+    async with _REGION_SEMAPHORE:
+        try:
+            model_info = await asyncio.wait_for(
+                service.get_model_info(), timeout=_REGION_TIMEOUT
+            )
+            return [
+                _extract_model_data(item, region_name)
+                for item in model_info.get("data", [])
+            ]
+        except (httpx.RequestError, HTTPException, asyncio.TimeoutError) as exc:
+            logger.warning(
+                "Region %s unavailable for /public/models: %s",
+                region_name,
+                str(exc),
+            )
+            return [
+                PublicModel(
+                    model_id="unavailable",
+                    display_name=f"{region_name} unavailable",
+                    provider="other",
+                    region=region_name,
+                    type="other",
+                    context_length=None,
+                    status="unavailable",
+                )
+            ]
+
+
 @router.get("/models", response_model=list[PublicModel])
 @router.get("/models/", response_model=list[PublicModel])
 async def list_public_models(db: Session = Depends(get_db)):
@@ -85,33 +119,17 @@ async def list_public_models(db: Session = Depends(get_db)):
             .all()
         )
 
-        all_models: list[PublicModel] = []
-
-        for region in regions:
-            try:
-                service = LiteLLMService(
+        tasks = [
+            _fetch_region_models(
+                LiteLLMService(
                     api_url=region.litellm_api_url, api_key=region.litellm_api_key
-                )
-                model_info = await service.get_model_info()
-                for item in model_info.get("data", []):
-                    all_models.append(_extract_model_data(item, region.name))
-            except Exception as exc:
-                logger.warning(
-                    "Region %s unavailable for /public/models: %s",
-                    region.name,
-                    str(exc),
-                )
-                all_models.append(
-                    PublicModel(
-                        model_id="unavailable",
-                        display_name=f"{region.name} unavailable",
-                        provider="other",
-                        region=region.name,
-                        type="other",
-                        context_length=None,
-                        status="unavailable",
-                    )
-                )
+                ),
+                region.name,
+            )
+            for region in regions
+        ]
+        results = await asyncio.gather(*tasks)
+        all_models = [model for region_models in results for model in region_models]
 
         _models_cache["data"] = all_models
         _models_cache["expires_at"] = datetime.now(UTC) + _CACHE_TTL

--- a/app/api/public.py
+++ b/app/api/public.py
@@ -1,0 +1,112 @@
+import asyncio
+import logging
+import re
+from datetime import datetime, timedelta, UTC
+from typing import Any
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.db.database import get_db
+from app.db.models import DBRegion
+from app.schemas.models import PublicModel
+from app.services.litellm import LiteLLMService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["public"])
+
+_CACHE_TTL = timedelta(hours=1)
+_cache_lock = asyncio.Lock()
+_models_cache: dict[str, Any] = {"expires_at": datetime.min.replace(tzinfo=UTC), "data": []}
+
+
+def _infer_provider(item: dict[str, Any]) -> str:
+    provider = item.get("model_info", {}).get("litellm_provider")
+    if provider and isinstance(provider, str):
+        lowered = provider.lower()
+        if "bedrock" in lowered or "aws" in lowered:
+            return "aws"
+        if "azure" in lowered:
+            return "azure"
+        if "gcp" in lowered or "vertex" in lowered or "google" in lowered:
+            return "gcp"
+    return "other"
+
+
+def _to_display_name(model_id: str) -> str:
+    words = re.split(r"[-_]+", model_id)
+    return " ".join(word.upper() if word.isupper() else word.capitalize() for word in words if word)
+
+
+def _extract_model_data(item: dict[str, Any], fallback_region: str) -> PublicModel:
+    model_info = item.get("model_info", {})
+    litellm_params = item.get("litellm_params", {})
+
+    model_id = item.get("model_name") or model_info.get("key") or "unknown"
+    display_name = _to_display_name(model_id)
+    provider = _infer_provider(item)
+    region = litellm_params.get("aws_region_name") or fallback_region
+    model_type = model_info.get("mode") or "other"
+    context_length = model_info.get("max_input_tokens")
+
+    return PublicModel(
+        model_id=model_id,
+        display_name=display_name,
+        provider=provider,
+        region=region,
+        type=model_type,
+        context_length=context_length,
+        status="ga",
+    )
+
+
+@router.get("/models", response_model=list[PublicModel])
+@router.get("/models/", response_model=list[PublicModel])
+async def list_public_models(db: Session = Depends(get_db)):
+    now = datetime.now(UTC)
+
+    if _models_cache["expires_at"] > now:
+        return _models_cache["data"]
+
+    async with _cache_lock:
+        now = datetime.now(UTC)
+        if _models_cache["expires_at"] > now:
+            return _models_cache["data"]
+
+        regions = (
+            db.query(DBRegion)
+            .filter(DBRegion.is_active.is_(True), DBRegion.is_dedicated.is_(False))
+            .all()
+        )
+
+        all_models: list[PublicModel] = []
+
+        for region in regions:
+            try:
+                service = LiteLLMService(
+                    api_url=region.litellm_api_url, api_key=region.litellm_api_key
+                )
+                model_info = await service.get_model_info()
+                for item in model_info.get("data", []):
+                    all_models.append(_extract_model_data(item, region.name))
+            except Exception as exc:
+                logger.warning(
+                    "Region %s unavailable for /public/models: %s", region.name, str(exc)
+                )
+                all_models.append(
+                    PublicModel(
+                        model_id="unavailable",
+                        display_name=f"{region.name} unavailable",
+                        provider="other",
+                        region=region.name,
+                        type="other",
+                        context_length=None,
+                        status="unavailable",
+                    )
+                )
+
+        _models_cache["data"] = all_models
+        _models_cache["expires_at"] = datetime.now(UTC) + _CACHE_TTL
+
+    return _models_cache["data"]

--- a/app/api/public.py
+++ b/app/api/public.py
@@ -101,7 +101,6 @@ async def _fetch_region_models(
 
 
 @router.get("/models", response_model=list[PublicModel])
-@router.get("/models/", response_model=list[PublicModel])
 async def list_public_models(db: Session = Depends(get_db)):
     now = datetime.now(UTC)
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -23,7 +23,13 @@ class Settings(BaseSettings):
         "http://localhost:8800",
     ]
     ALLOWED_HOSTS: list[str] = ["*"]  # In production, restrict this
-    PUBLIC_PATHS: list[str] = ["/health", "/docs", "/openapi.json"]
+    PUBLIC_PATHS: list[str] = [
+        "/health",
+        "/docs",
+        "/openapi.json",
+        "/public/models",
+        "/public/models/",
+    ]
 
     AWS_ACCESS_KEY_ID: str = "AKIATEST"
     AWS_SECRET_ACCESS_KEY: str = "sk-string"

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from app.api import (
     private_ai_keys,
     users,
     regions,
+    public,
     audit,
     teams,
     billing,
@@ -311,6 +312,7 @@ app.include_router(
 )
 app.include_router(users.router, prefix="/users", tags=["users"])
 app.include_router(regions.router, prefix="/regions", tags=["regions"])
+app.include_router(public.router, prefix="/public", tags=["public"])
 app.include_router(audit.router, prefix="/audit", tags=["audit"])
 app.include_router(teams.router, prefix="/teams", tags=["teams"])
 app.include_router(billing.router, prefix="/billing", tags=["billing"])
@@ -398,6 +400,8 @@ def custom_openapi():
                 "/auth/register",
                 "/health",
                 "/auth/generate-trial-access",
+                "/public/models",
+                "/public/models/",
             ]:
                 if "security" in operation:
                     del operation["security"]

--- a/app/middleware/caching.py
+++ b/app/middleware/caching.py
@@ -6,10 +6,14 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         response = await call_next(request)
 
-        # Add Cache-Control headers to all responses to prevent caching of sensitive data
-        response.headers["Cache-Control"] = (
-            "no-store, no-cache, must-revalidate, private"
-        )
+        # Public models endpoint is intentionally cacheable for 1 hour.
+        if request.url.path in {"/public/models", "/public/models/"}:
+            response.headers["Cache-Control"] = "public, max-age=3600"
+        else:
+            # Add Cache-Control headers to all responses to prevent caching of sensitive data
+            response.headers["Cache-Control"] = (
+                "no-store, no-cache, must-revalidate, private"
+            )
 
         # Add security headers to all responses
         response.headers["X-Frame-Options"] = "DENY"

--- a/app/middleware/caching.py
+++ b/app/middleware/caching.py
@@ -6,9 +6,12 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         response = await call_next(request)
 
-        # Public models endpoint is intentionally cacheable for 1 hour.
+        # Public models endpoint is intentionally cacheable for 1 hour on success.
         if request.url.path in {"/public/models", "/public/models/"}:
-            response.headers["Cache-Control"] = "public, max-age=3600"
+            if response.status_code < 400:
+                response.headers["Cache-Control"] = "public, max-age=3600"
+            else:
+                response.headers["Cache-Control"] = "no-store"
         else:
             # Add Cache-Control headers to all responses to prevent caching of sensitive data
             response.headers["Cache-Control"] = (

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -185,6 +185,16 @@ class Region(RegionBase):
     model_config = ConfigDict(from_attributes=True)
 
 
+class PublicModel(BaseModel):
+    model_id: str
+    display_name: str
+    provider: str
+    region: str
+    type: str
+    context_length: Optional[int] = None
+    status: Optional[str] = None
+
+
 class PrivateAIKeyBase(BaseModel):
     id: int
     database_name: Optional[str] = None

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -366,6 +366,29 @@ class LiteLLMService:
                 detail=f"Failed to get LiteLLM team info: {error_msg}",
             )
 
+    async def get_model_info(self) -> dict:
+        """Get LiteLLM model info for this region."""
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"{self.api_url}/v1/model/info",
+                    headers={"Authorization": f"Bearer {self.master_key}"},
+                )
+                response.raise_for_status()
+                return response.json()
+        except httpx.HTTPStatusError as e:
+            error_msg = str(e)
+            if hasattr(e, "response") and e.response is not None:
+                try:
+                    error_details = e.response.json()
+                    error_msg = f"Status {e.response.status_code}: {error_details}"
+                except ValueError:
+                    error_msg = f"Status {e.response.status_code}: {e.response.text}"
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to get LiteLLM model info: {error_msg}",
+            )
+
     async def create_team(
         self,
         max_budget: float = 0.0,

--- a/tests/test_cache_headers.py
+++ b/tests/test_cache_headers.py
@@ -62,3 +62,9 @@ def test_security_headers_on_api_endpoint(client: TestClient, test_token):
     assert response.headers["X-Content-Type-Options"] == "nosniff"
     assert "Referrer-Policy" in response.headers
     assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+
+
+def test_public_models_cache_header(client: TestClient):
+    response = client.get("/public/models")
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "public, max-age=3600"

--- a/tests/test_public_models.py
+++ b/tests/test_public_models.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, patch
 
 from app.api import public as public_api
+from app.db.models import DBRegion
 
 
 def _clear_public_models_cache():
@@ -12,6 +13,19 @@ def _clear_public_models_cache():
 
 def test_public_models_returns_aggregated_data(client, db):
     _clear_public_models_cache()
+    region = DBRegion(
+        name="eu-central-1",
+        postgres_host="host",
+        postgres_port=5432,
+        postgres_admin_user="user",
+        postgres_admin_password="pass",
+        litellm_api_url="https://litellm.example",
+        litellm_api_key="key",
+        is_active=True,
+        is_dedicated=False,
+    )
+    db.add(region)
+    db.commit()
     with patch("app.api.public.LiteLLMService") as mock_service_cls:
         mock_service = mock_service_cls.return_value
         mock_service.get_model_info = AsyncMock(
@@ -46,6 +60,19 @@ def test_public_models_returns_aggregated_data(client, db):
 
 def test_public_models_includes_unavailable_region(client, db):
     _clear_public_models_cache()
+    region = DBRegion(
+        name="us-east-1",
+        postgres_host="host",
+        postgres_port=5432,
+        postgres_admin_user="user",
+        postgres_admin_password="pass",
+        litellm_api_url="https://litellm.example",
+        litellm_api_key="key",
+        is_active=True,
+        is_dedicated=False,
+    )
+    db.add(region)
+    db.commit()
     with patch("app.api.public.LiteLLMService") as mock_service_cls:
         mock_service = mock_service_cls.return_value
         mock_service.get_model_info = AsyncMock(side_effect=Exception("timeout"))

--- a/tests/test_public_models.py
+++ b/tests/test_public_models.py
@@ -1,3 +1,4 @@
+import httpx
 from unittest.mock import AsyncMock, patch
 
 from app.api import public as public_api
@@ -75,7 +76,9 @@ def test_public_models_includes_unavailable_region(client, db):
     db.commit()
     with patch("app.api.public.LiteLLMService") as mock_service_cls:
         mock_service = mock_service_cls.return_value
-        mock_service.get_model_info = AsyncMock(side_effect=Exception("timeout"))
+        mock_service.get_model_info = AsyncMock(
+            side_effect=httpx.ConnectError("connection refused")
+        )
 
         response = client.get("/public/models")
         assert response.status_code == 200

--- a/tests/test_public_models.py
+++ b/tests/test_public_models.py
@@ -1,0 +1,57 @@
+from unittest.mock import AsyncMock, patch
+
+from app.api import public as public_api
+
+
+def _clear_public_models_cache():
+    public_api._models_cache["data"] = []
+    public_api._models_cache["expires_at"] = public_api.datetime.min.replace(
+        tzinfo=public_api.UTC
+    )
+
+
+def test_public_models_returns_aggregated_data(client, db):
+    _clear_public_models_cache()
+    with patch("app.api.public.LiteLLMService") as mock_service_cls:
+        mock_service = mock_service_cls.return_value
+        mock_service.get_model_info = AsyncMock(
+            return_value={
+                "data": [
+                    {
+                        "model_name": "claude-3-5-sonnet-20241022",
+                        "litellm_params": {"aws_region_name": "eu-central-1"},
+                        "model_info": {
+                            "max_input_tokens": 200000,
+                            "litellm_provider": "bedrock_converse",
+                            "mode": "chat",
+                        },
+                    }
+                ]
+            }
+        )
+
+        response = client.get("/public/models")
+        assert response.status_code == 200
+        assert response.headers["Cache-Control"] == "public, max-age=3600"
+        data = response.json()
+        assert len(data) >= 1
+        first = data[0]
+        assert first["model_id"] == "claude-3-5-sonnet-20241022"
+        assert first["provider"] == "aws"
+        assert first["region"] == "eu-central-1"
+        assert first["type"] == "chat"
+        assert first["context_length"] == 200000
+        assert first["status"] == "ga"
+
+
+def test_public_models_includes_unavailable_region(client, db):
+    _clear_public_models_cache()
+    with patch("app.api.public.LiteLLMService") as mock_service_cls:
+        mock_service = mock_service_cls.return_value
+        mock_service.get_model_info = AsyncMock(side_effect=Exception("timeout"))
+
+        response = client.get("/public/models")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) >= 1
+        assert any(item["status"] == "unavailable" for item in data)


### PR DESCRIPTION
- [x] Fix `app/middleware/caching.py`: only set `public, max-age=3600` for successful responses (status < 400), fall back to `no-store` for errors
- [x] Fix `app/api/public.py`: use `asyncio.gather` with a bounded semaphore (10) and per-region timeout (10 s via `asyncio.wait_for`) for concurrent region fetching
- [x] Fix `app/api/public.py`: narrow `except Exception` to `(httpx.RequestError, HTTPException, asyncio.TimeoutError)`; unexpected bugs propagate as 5xx
- [x] Update tests: use `httpx.ConnectError("connection refused")` instead of bare `Exception("timeout")`
- [x] Lint and CodeQL checks pass