### PR TITLE
feat(api): implement budget propagation for team and keys on expiration

### DIFF
--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -121,6 +121,7 @@ async def purchase_pool_budget(
             team_id,
             new_total_budget,
             f"{settings.POOL_BUDGET_EXPIRATION_DAYS}d",
+            region_id=region_id,
         )
     except Exception as e:
         db.rollback()

--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -16,7 +16,6 @@ from app.schemas.models import (
     PoolRegionPurchaseHistoryResponse,
     BudgetType,
 )
-from app.services.litellm import LiteLLMService
 from app.core.team_service import propagate_team_budget_to_keys
 
 
@@ -233,8 +232,6 @@ async def sync_pool_team_budgets(db: Session) -> dict:
     total_updated = 0
     errors = []
 
-    regions_cache = {}
-
     for team in pool_teams:
         latest_purchases_by_region = (
             db.query(DBPoolPurchase.region_id, func.max(DBPoolPurchase.purchased_at))
@@ -269,49 +266,41 @@ async def sync_pool_team_budgets(db: Session) -> dict:
 
         if all_regions_expired:
             # All regions expired, propagate $0 budget to team and all keys
-            try:
-                await propagate_team_budget_to_keys(
+            team_had_any_update = False
+            for rid in expired_region_ids:
+                result = await propagate_team_budget_to_keys(
                     db,
                     team.id,
                     0.0,
                     f"{settings.POOL_BUDGET_EXPIRATION_DAYS}d",
+                    region_id=rid,
                 )
+                errors.extend(result["errors"])
+                if result["teams_updated"] > 0:
+                    team_had_any_update = True
+            if team_had_any_update:
                 total_updated += 1
                 logger.info(
                     f"Pool team {team.id} budget expired in all regions ({settings.POOL_BUDGET_EXPIRATION_DAYS}d passed), set to $0"
                 )
-            except Exception as e:
-                errors.append(f"Team {team.id}: {str(e)}")
-                logger.error(f"Failed to expire team {team.id} budget: {e}")
         else:
             # Only some regions expired - update only those regions
-            for region_id in expired_region_ids:
-                if region_id not in regions_cache:
-                    regions_cache[region_id] = (
-                        db.query(DBRegion).filter(DBRegion.id == region_id).first()
-                    )
-                region = regions_cache[region_id]
-                if not region:
-                    continue
-
-                litellm_service = LiteLLMService(
-                    api_url=region.litellm_api_url, api_key=region.litellm_api_key
+            team_had_any_update = False
+            for rid in expired_region_ids:
+                result = await propagate_team_budget_to_keys(
+                    db,
+                    team.id,
+                    0.0,
+                    f"{settings.POOL_BUDGET_EXPIRATION_DAYS}d",
+                    region_id=rid,
                 )
-                lite_team_id = LiteLLMService.format_team_id(region.name, team.id)
-
-                try:
-                    await litellm_service.update_team_budget(
-                        team_id=lite_team_id,
-                        max_budget=0.0,
-                        budget_duration=f"{settings.POOL_BUDGET_EXPIRATION_DAYS}d",
-                    )
+                errors.extend(result["errors"])
+                if result["teams_updated"] > 0:
+                    team_had_any_update = True
                     logger.info(
-                        f"Pool team {team.id} budget expired in region {region_id} ({settings.POOL_BUDGET_EXPIRATION_DAYS}d passed), set to $0"
+                        f"Pool team {team.id} budget expired in region {rid} ({settings.POOL_BUDGET_EXPIRATION_DAYS}d passed), set to $0"
                     )
-                except Exception as e:
-                    errors.append(f"Team {team.id}, region {region_id}: {str(e)}")
-                    logger.error(
-                        f"Failed to expire team {team.id} budget in region {region_id}: {e}"
-                    )
+            if team_had_any_update:
+                total_updated += 1
 
     return {"teams_updated": total_updated, "errors": errors}

--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -303,6 +303,7 @@ async def sync_pool_team_budgets(db: Session) -> dict:
                     await litellm_service.update_team_budget(
                         team_id=lite_team_id,
                         max_budget=0.0,
+                        budget_duration=f"{settings.POOL_BUDGET_EXPIRATION_DAYS}d",
                     )
                     logger.info(
                         f"Pool team {team.id} budget expired in region {region_id} ({settings.POOL_BUDGET_EXPIRATION_DAYS}d passed), set to $0"

--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -17,6 +17,7 @@ from app.schemas.models import (
     BudgetType,
 )
 from app.services.litellm import LiteLLMService
+from app.core.team_service import propagate_team_budget_to_keys
 
 
 logger = logging.getLogger(__name__)
@@ -98,12 +99,6 @@ async def purchase_pool_budget(
             detail="A purchase with this stripe_payment_id already exists",
         )
 
-    litellm_service = LiteLLMService(
-        api_url=region.litellm_api_url, api_key=region.litellm_api_key
-    )
-
-    lite_team_id = LiteLLMService.format_team_id(region.name, team_id)
-
     total_purchased_cents = (
         db.query(func.sum(DBPoolPurchase.amount_cents))
         .filter(
@@ -121,14 +116,15 @@ async def purchase_pool_budget(
     new_total_budget = total_purchased_dollars
 
     try:
-        await litellm_service.update_team_budget(
-            team_id=lite_team_id,
-            max_budget=new_total_budget,
-            budget_duration=f"{settings.POOL_BUDGET_EXPIRATION_DAYS}d",
+        await propagate_team_budget_to_keys(
+            db,
+            team_id,
+            new_total_budget,
+            f"{settings.POOL_BUDGET_EXPIRATION_DAYS}d",
         )
     except Exception as e:
         db.rollback()
-        logger.error(f"Failed to update LiteLLM team budget: {e}")
+        logger.error(f"Failed to propagate budget to keys: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to update team budget in LiteLLM: {str(e)}",
@@ -248,7 +244,9 @@ async def sync_pool_team_budgets(db: Session) -> dict:
         if not latest_purchases_by_region:
             continue
 
-        team_had_successful_expiration = False
+        # Check if ALL regions have expired
+        all_regions_expired = True
+        expired_region_ids = []
 
         for region_id, latest_purchase_at in latest_purchases_by_region:
             if not region_id or not latest_purchase_at:
@@ -261,37 +259,57 @@ async def sync_pool_team_budgets(db: Session) -> dict:
 
             days_since_last_purchase = (datetime.now(UTC) - last_purchase).days
             if days_since_last_purchase < settings.POOL_BUDGET_EXPIRATION_DAYS:
-                continue
+                all_regions_expired = False
+            else:
+                expired_region_ids.append(region_id)
 
-            if region_id not in regions_cache:
-                regions_cache[region_id] = (
-                    db.query(DBRegion).filter(DBRegion.id == region_id).first()
-                )
-            region = regions_cache[region_id]
-            if not region:
-                continue
+        if not expired_region_ids:
+            continue
 
-            litellm_service = LiteLLMService(
-                api_url=region.litellm_api_url, api_key=region.litellm_api_key
-            )
-            lite_team_id = LiteLLMService.format_team_id(region.name, team.id)
-
+        if all_regions_expired:
+            # All regions expired, propagate $0 budget to team and all keys
             try:
-                await litellm_service.update_team_budget(
-                    team_id=lite_team_id,
-                    max_budget=0.0,
+                await propagate_team_budget_to_keys(
+                    db,
+                    team.id,
+                    0.0,
+                    f"{settings.POOL_BUDGET_EXPIRATION_DAYS}d",
                 )
-                team_had_successful_expiration = True
+                total_updated += 1
                 logger.info(
-                    f"Pool team {team.id} budget expired in region {region.id} ({settings.POOL_BUDGET_EXPIRATION_DAYS}d passed), set to $0"
+                    f"Pool team {team.id} budget expired in all regions ({settings.POOL_BUDGET_EXPIRATION_DAYS}d passed), set to $0"
                 )
             except Exception as e:
-                errors.append(f"Team {team.id}, region {region_id}: {str(e)}")
-                logger.error(
-                    f"Failed to expire team {team.id} budget in region {region_id}: {e}"
-                )
+                errors.append(f"Team {team.id}: {str(e)}")
+                logger.error(f"Failed to expire team {team.id} budget: {e}")
+        else:
+            # Only some regions expired - update only those regions
+            for region_id in expired_region_ids:
+                if region_id not in regions_cache:
+                    regions_cache[region_id] = (
+                        db.query(DBRegion).filter(DBRegion.id == region_id).first()
+                    )
+                region = regions_cache[region_id]
+                if not region:
+                    continue
 
-        if team_had_successful_expiration:
-            total_updated += 1
+                litellm_service = LiteLLMService(
+                    api_url=region.litellm_api_url, api_key=region.litellm_api_key
+                )
+                lite_team_id = LiteLLMService.format_team_id(region.name, team.id)
+
+                try:
+                    await litellm_service.update_team_budget(
+                        team_id=lite_team_id,
+                        max_budget=0.0,
+                    )
+                    logger.info(
+                        f"Pool team {team.id} budget expired in region {region_id} ({settings.POOL_BUDGET_EXPIRATION_DAYS}d passed), set to $0"
+                    )
+                except Exception as e:
+                    errors.append(f"Team {team.id}, region {region_id}: {str(e)}")
+                    logger.error(
+                        f"Failed to expire team {team.id} budget in region {region_id}: {e}"
+                    )
 
     return {"teams_updated": total_updated, "errors": errors}

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -403,8 +403,8 @@ async def create_llm_token(
             owner = current_user
 
     # Pool budget teams use purchase_pool_budget to set the team-level
-    # max_budget in LiteLLM. Per-key limits are meaningless there — the team
-    # budget is the sole ceiling. Skip limit resolution entirely for pool teams.
+    # max_budget in LiteLLM. Per-key limits are also set to match the team
+    # budget so that LiteLLM's dual-gate enforcement applies consistently.
     # Reuse the already-fetched team when team_id was provided. Fall back to
     # owner's team only when no team_id was provided.
     effective_team = team
@@ -459,6 +459,27 @@ async def create_llm_token(
             rpm_limit=max_rpm_limit,
             apply_limits=not is_pool_team,
         )
+
+        # For POOL teams, fetch the team's current budget from LiteLLM and
+        # apply it to the newly created key so both gates have the same limit.
+        if is_pool_team:
+            try:
+                lite_team_id = LiteLLMService.format_team_id(region.name, litellm_team)
+                team_info = await litellm_service.get_team_info(lite_team_id)
+                team_budget = team_info.get("max_budget")
+                if team_budget is not None:
+                    await litellm_service.update_budget(
+                        litellm_token=litellm_token,
+                        budget_duration=f"{settings.POOL_BUDGET_EXPIRATION_DAYS}d",
+                        budget_amount=team_budget,
+                    )
+                    logger.info(
+                        f"Set pool key {litellm_token[:10]}... budget to ${team_budget}"
+                    )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to set pool key budget (key will still work via team budget): {e}"
+                )
 
         # Create response object
         db_token = DBPrivateAIKey(

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -465,17 +465,29 @@ async def create_llm_token(
         if is_pool_team:
             try:
                 lite_team_id = LiteLLMService.format_team_id(region.name, litellm_team)
-                team_info = await litellm_service.get_team_info(lite_team_id)
-                team_budget = team_info.get("max_budget")
-                if team_budget is not None:
-                    await litellm_service.update_budget(
-                        litellm_token=litellm_token,
-                        budget_duration=f"{settings.POOL_BUDGET_EXPIRATION_DAYS}d",
-                        budget_amount=team_budget,
-                    )
-                    logger.info(
-                        f"Set pool key {litellm_token[:10]}... budget to ${team_budget}"
-                    )
+                team_info_response = await litellm_service.get_team_info(lite_team_id)
+                # Normalize response: some variants return {"team_info": {...}}
+                if isinstance(team_info_response, dict):
+                    team_info = team_info_response.get("team_info", team_info_response)
+                else:
+                    team_info = {}
+                team_budget_raw = team_info.get("max_budget") if isinstance(team_info, dict) else None
+                if team_budget_raw is not None:
+                    try:
+                        team_budget = float(team_budget_raw)
+                    except (TypeError, ValueError):
+                        logger.warning(
+                            f"Received non-numeric max_budget for team {lite_team_id}: {team_budget_raw}"
+                        )
+                    else:
+                        await litellm_service.update_budget(
+                            litellm_token=litellm_token,
+                            budget_duration=f"{settings.POOL_BUDGET_EXPIRATION_DAYS}d",
+                            budget_amount=team_budget,
+                        )
+                        logger.info(
+                            f"Set pool key {litellm_token[:10]}... budget to ${team_budget}"
+                        )
             except Exception as e:
                 logger.warning(
                     f"Failed to set pool key budget (key will still work via team budget): {e}"

--- a/app/core/team_service.py
+++ b/app/core/team_service.py
@@ -244,10 +244,9 @@ async def propagate_team_budget_to_keys(
             logger.error(f"Team {team_id} not found, skipping budget propagation")
             return {"teams_updated": 0, "errors": [f"Team {team_id} not found"]}
 
-        all_keys_by_region = get_team_keys_by_region(db, team_id)
-
         if region_id is not None:
-            # Update only the specified region, even if it currently has no keys
+            # Update only the specified region, even if it currently has no keys.
+            # Query keys for this region directly rather than loading all regions.
             region = db.query(DBRegion).filter(DBRegion.id == region_id).first()
             if not region:
                 logger.error(
@@ -257,15 +256,31 @@ async def propagate_team_budget_to_keys(
                     "teams_updated": 0,
                     "errors": [f"Region {region_id} not found"],
                 }
-            region_keys = next(
-                (keys for r, keys in all_keys_by_region.items() if r.id == region_id),
-                [],
+            team_user_ids = (
+                db.execute(
+                    select(DBUser.id).filter(DBUser.team_id == team_id)
+                )
+                .scalars()
+                .all()
             )
+            region_keys = [
+                key
+                for key in (
+                    db.query(DBPrivateAIKey)
+                    .filter(
+                        (DBPrivateAIKey.owner_id.in_(team_user_ids))
+                        | (DBPrivateAIKey.team_id == team_id),
+                        DBPrivateAIKey.region_id == region_id,
+                    )
+                    .all()
+                )
+                if key.litellm_token
+            ]
             keys_by_region: Dict[DBRegion, List[DBPrivateAIKey]] = {
                 region: region_keys
             }
         else:
-            keys_by_region = all_keys_by_region
+            keys_by_region = get_team_keys_by_region(db, team_id)
 
         # Update team budget and keys for each region
         for region_obj, keys in keys_by_region.items():

--- a/app/core/team_service.py
+++ b/app/core/team_service.py
@@ -4,7 +4,7 @@ Team service for centralized team operations including soft-delete and restore.
 
 import logging
 from datetime import datetime, UTC
-from typing import Dict, List
+from typing import Dict, List, Optional
 from collections import defaultdict
 from sqlalchemy.orm import Session
 from sqlalchemy import select
@@ -206,8 +206,12 @@ async def restore_soft_deleted_team(db: Session, team: DBTeam) -> None:
 
 
 async def propagate_team_budget_to_keys(
-    db: Session, team_id: int, budget_amount: float, budget_duration: str
-) -> None:
+    db: Session,
+    team_id: int,
+    budget_amount: float,
+    budget_duration: str,
+    region_id: Optional[int] = None,
+) -> dict:
     """
     Propagate a team budget limit change to the LiteLLM team and all its keys.
 
@@ -220,39 +224,73 @@ async def propagate_team_budget_to_keys(
         team_id: ID of the team whose keys should be updated
         budget_amount: New budget amount to set for all keys
         budget_duration: Budget duration string (e.g., "30d")
+        region_id: Optional region ID to restrict updates to a single region.
+            When provided the LiteLLM team for that region is updated even if
+            the team currently has no keys there.
+
+    Returns:
+        dict with "teams_updated" (number of LiteLLM teams successfully updated)
+        and "errors" (list of error message strings).
 
     Note:
         Errors during updates are logged but don't raise exceptions.
         This ensures that limit updates succeed even if some updates fail.
     """
+    teams_updated = 0
+    errors: List[str] = []
     try:
         team = db.query(DBTeam).filter(DBTeam.id == team_id).first()
         if not team:
             logger.error(f"Team {team_id} not found, skipping budget propagation")
-            return
+            return {"teams_updated": 0, "errors": [f"Team {team_id} not found"]}
 
-        keys_by_region = get_team_keys_by_region(db, team_id)
+        all_keys_by_region = get_team_keys_by_region(db, team_id)
+
+        if region_id is not None:
+            # Update only the specified region, even if it currently has no keys
+            region = db.query(DBRegion).filter(DBRegion.id == region_id).first()
+            if not region:
+                logger.error(
+                    f"Region {region_id} not found, skipping budget propagation"
+                )
+                return {
+                    "teams_updated": 0,
+                    "errors": [f"Region {region_id} not found"],
+                }
+            region_keys = next(
+                (keys for r, keys in all_keys_by_region.items() if r.id == region_id),
+                [],
+            )
+            keys_by_region: Dict[DBRegion, List[DBPrivateAIKey]] = {
+                region: region_keys
+            }
+        else:
+            keys_by_region = all_keys_by_region
 
         # Update team budget and keys for each region
-        for region, keys in keys_by_region.items():
+        for region_obj, keys in keys_by_region.items():
             litellm_service = LiteLLMService(
-                api_url=region.litellm_api_url, api_key=region.litellm_api_key
+                api_url=region_obj.litellm_api_url, api_key=region_obj.litellm_api_key
             )
 
             # Update the LiteLLM team budget (shared ceiling)
-            lite_team_id = LiteLLMService.format_team_id(region.name, team_id)
+            lite_team_id = LiteLLMService.format_team_id(region_obj.name, team_id)
             try:
                 await litellm_service.update_team_budget(
                     team_id=lite_team_id,
                     max_budget=budget_amount,
                     budget_duration=budget_duration,
                 )
+                teams_updated += 1
                 logger.info(
-                    f"Updated team {team_id} budget to {budget_amount} in LiteLLM region {region.name}"
+                    f"Updated team {team_id} budget to {budget_amount} in LiteLLM region {region_obj.name}"
                 )
             except Exception as team_error:
+                errors.append(
+                    f"Team {team_id}, region {region_obj.name}: {str(team_error)}"
+                )
                 logger.error(
-                    f"Failed to update team {team_id} budget in region {region.name}: {str(team_error)}"
+                    f"Failed to update team {team_id} budget in region {region_obj.name}: {str(team_error)}"
                 )
 
             # Update each key's budget via LiteLLM
@@ -267,11 +305,14 @@ async def propagate_team_budget_to_keys(
                         f"Updated key {key.id} budget to {budget_amount} in LiteLLM after team budget limit change"
                     )
                 except Exception as key_error:
+                    errors.append(f"Key {key.id}: {str(key_error)}")
                     logger.error(
                         f"Failed to update key {key.id} budget in LiteLLM: {str(key_error)}"
                     )
-                    continue
     except Exception as propagation_error:
+        errors.append(str(propagation_error))
         logger.error(
             f"Error propagating budget limit to keys for team {team_id}: {str(propagation_error)}"
         )
+
+    return {"teams_updated": teams_updated, "errors": errors}

--- a/tests/test_pool_purchases.py
+++ b/tests/test_pool_purchases.py
@@ -410,7 +410,8 @@ async def test_sync_pool_team_budgets_expires_stale_pool_team(
     expected_lite_team_id = f"{test_region.name}_{test_team.id}"
 
     with patch(
-        "app.api.budgets.LiteLLMService.update_team_budget", new_callable=AsyncMock
+        "app.core.team_service.LiteLLMService.update_team_budget",
+        new_callable=AsyncMock,
     ) as mock_update_budget:
         result = await sync_pool_team_budgets(db)
 
@@ -419,6 +420,7 @@ async def test_sync_pool_team_budgets_expires_stale_pool_team(
     mock_update_budget.assert_awaited_once_with(
         team_id=expected_lite_team_id,
         max_budget=0.0,
+        budget_duration="365d",
     )
 
 
@@ -489,7 +491,8 @@ async def test_sync_pool_team_budgets_expires_all_team_regions(
     expected_lite_team_id = f"{test_region.name}_{test_team.id}"
 
     with patch(
-        "app.api.budgets.LiteLLMService.update_team_budget", new_callable=AsyncMock
+        "app.core.team_service.LiteLLMService.update_team_budget",
+        new_callable=AsyncMock,
     ) as mock_update_budget:
         result = await sync_pool_team_budgets(db)
 
@@ -498,4 +501,5 @@ async def test_sync_pool_team_budgets_expires_all_team_regions(
     mock_update_budget.assert_awaited_once_with(
         team_id=expected_lite_team_id,
         max_budget=0.0,
+        budget_duration="365d",
     )


### PR DESCRIPTION
- [x] Understand the feedback: `propagate_team_budget_to_keys` should return counts/errors so callers can accurately report `teams_updated`
- [x] Update `propagate_team_budget_to_keys` in `team_service.py`:
  - Add `region_id: Optional[int] = None` parameter to update a specific region even with no keys
  - Change return type from `None` to `dict` with `teams_updated` (int) and `errors` (list[str])
  - When `region_id` is provided, query keys for that region directly (efficient — no full cross-region load)
  - Track LiteLLM team update successes/failures per region
- [x] Update "all regions expired" branch in `budgets.py`:
  - Iterate over `expired_region_ids`, calling `propagate_team_budget_to_keys` with each `region_id`
  - Only increment `total_updated` when `result["teams_updated"] > 0`
  - Extend outer `errors` list with per-call errors
- [x] Unify "only some regions expired" branch to use `propagate_team_budget_to_keys` consistently:
  - Replaces direct `LiteLLMService.update_team_budget` call with the shared helper
  - Now correctly increments `total_updated` (was previously 0 always — root cause of CI failures)
- [x] Remove now-unused `LiteLLMService` import from `budgets.py`
- [x] Remove `regions_cache` dict (no longer needed)
- [x] Update tests to patch `app.core.team_service.LiteLLMService.update_team_budget` and add `budget_duration` to mock assertions