### PR TITLE
chore: move cronjobs / scheduler to lagoon cron

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -2,6 +2,19 @@ docker-compose-yaml: docker-compose.yml
 
 environments:
   prod:
+    cronjobs:
+      - name: monitor-teams
+        schedule: "0 * * * *"
+        command: python scripts/trigger_recon_job.py
+        service: backend
+      - name: hard-delete-teams
+        schedule: "0 3 * * *"
+        command: python scripts/trigger_hard_delete_job.py
+        service: backend
+      - name: sync-pool-budgets
+        schedule: "0 4 * * *"
+        command: python scripts/trigger_sync_pool_budgets_job.py
+        service: backend
     routes:
       - backend:
         - api.amazee.ai:
@@ -14,6 +27,21 @@ environments:
             tls-acme: true
             insecure: Redirect
             hstsEnabled: true
+
+  dev:
+    cronjobs:
+      - name: monitor-teams
+        schedule: "0 * * * *"
+        command: python scripts/trigger_recon_job.py
+        service: backend
+      - name: hard-delete-teams
+        schedule: "0 3 * * *"
+        command: python scripts/trigger_hard_delete_job.py
+        service: backend
+      - name: sync-pool-budgets
+        schedule: "0 4 * * *"
+        command: python scripts/trigger_sync_pool_budgets_job.py
+        service: backend
 
 tasks:
   post-rollout:

--- a/app/main.py
+++ b/app/main.py
@@ -25,7 +25,6 @@ from app.middleware.audit import AuditLogMiddleware
 from app.middleware.caching import CacheControlMiddleware
 from app.middleware.prometheus import PrometheusMiddleware
 from app.middleware.auth import AuthMiddleware
-from app.core.locking import try_acquire_lock, release_lock
 from app.__version__ import __version__
 from contextlib import asynccontextmanager
 import os

--- a/app/main.py
+++ b/app/main.py
@@ -25,15 +25,11 @@ from app.middleware.audit import AuditLogMiddleware
 from app.middleware.caching import CacheControlMiddleware
 from app.middleware.prometheus import PrometheusMiddleware
 from app.middleware.auth import AuthMiddleware
-from app.core.worker import monitor_teams, hard_delete_expired_teams
 from app.core.locking import try_acquire_lock, release_lock
 from app.__version__ import __version__
 from contextlib import asynccontextmanager
-from apscheduler.schedulers.asyncio import AsyncIOScheduler
-from apscheduler.triggers.cron import CronTrigger
 import os
 import logging
-from datetime import UTC
 
 # Set timezone environment variable to prevent tzlocal warning
 if not os.environ.get("TZ"):
@@ -56,144 +52,7 @@ class HTTPSRedirectMiddleware(BaseHTTPMiddleware):
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Create scheduler
-    scheduler = AsyncIOScheduler()
-
-    async def monitor_teams_job():
-        db = next(get_db())
-        lock_name = "monitor_teams"
-
-        try:
-            # Try to acquire the lock
-            if try_acquire_lock(lock_name, db, lock_timeout=10):
-                logger.info("Acquired monitor_teams lock, executing job")
-                try:
-                    await monitor_teams(db)
-                except Exception as e:
-                    logger.error(f"Error in monitor_teams background task: {str(e)}")
-                finally:
-                    # Always release the lock when done
-                    release_lock(lock_name, db)
-            else:
-                logger.info(
-                    "Another process has the monitor_teams lock, skipping execution"
-                )
-        except Exception as e:
-            logger.error(f"Error in monitor_teams job: {str(e)}")
-            # Try to release lock in case of error
-            try:
-                release_lock(lock_name, db)
-            except Exception as release_error:
-                logger.error(f"Error releasing lock: {str(release_error)}")
-        finally:
-            db.close()
-
-    # Set schedule based on environment
-    if settings.ENV_SUFFIX == "local":
-        cron_trigger = CronTrigger(minute="*/10", timezone=UTC, jitter=180)
-    else:
-        # Run every hour in other environments with jitter
-        cron_trigger = CronTrigger(hour="*", minute=0, timezone=UTC, jitter=60)
-
-    scheduler.add_job(
-        monitor_teams_job,
-        trigger=cron_trigger,
-        id="monitor_teams",
-        replace_existing=True,
-    )
-
-    # Hard delete job for teams that have been soft-deleted for 60+ days
-    async def hard_delete_teams_job():
-        db = next(get_db())
-        lock_name = "hard_delete_teams"
-
-        try:
-            # Try to acquire the lock
-            if try_acquire_lock(lock_name, db, lock_timeout=10):
-                logger.info("Acquired hard_delete_teams lock, executing job")
-                try:
-                    await hard_delete_expired_teams(db)
-                except Exception as e:
-                    logger.error(
-                        f"Error in hard_delete_expired_teams background task: {str(e)}"
-                    )
-                finally:
-                    # Always release the lock when done
-                    release_lock(lock_name, db)
-            else:
-                logger.info(
-                    "Another process has the hard_delete_teams lock, skipping execution"
-                )
-        except Exception as e:
-            logger.error(f"Error in hard_delete_teams job: {str(e)}")
-            # Try to release lock in case of error
-            try:
-                release_lock(lock_name, db)
-            except Exception as release_error:
-                logger.error(f"Error releasing lock: {str(release_error)}")
-        finally:
-            db.close()
-
-    # Set schedule based on environment for hard delete job
-    if settings.ENV_SUFFIX == "local":
-        # In local env, run every hour at :30 for testing
-        hard_delete_trigger = CronTrigger(hour="*", minute=30, timezone=UTC)
-    else:
-        # In production, run daily at 3 AM
-        hard_delete_trigger = CronTrigger(hour=3, minute=0, timezone=UTC)
-
-    scheduler.add_job(
-        hard_delete_teams_job,
-        trigger=hard_delete_trigger,
-        id="hard_delete_teams",
-        replace_existing=True,
-    )
-
-    # Sync pool team budgets job - runs daily to ensure LiteLLM budgets match purchases - spend
-    async def sync_pool_budgets_job():
-        db = next(get_db())
-        lock_name = "sync_pool_budgets"
-
-        try:
-            if try_acquire_lock(lock_name, db, lock_timeout=10):
-                logger.info("Acquired sync_pool_budgets lock, executing job")
-                try:
-                    result = await budgets.sync_pool_team_budgets(db)
-                    logger.info(
-                        f"Pool budgets sync complete: {result['teams_updated']} teams updated"
-                    )
-                except Exception as e:
-                    logger.error(f"Error in sync_pool_team_budgets: {str(e)}")
-                finally:
-                    release_lock(lock_name, db)
-            else:
-                logger.info(
-                    "Another process has the sync_pool_budgets lock, skipping execution"
-                )
-        except Exception as e:
-            logger.error(f"Error in sync_pool_budgets job: {str(e)}")
-            try:
-                release_lock(lock_name, db)
-            except Exception as release_error:
-                logger.error(f"Error releasing lock: {release_error}")
-        finally:
-            db.close()
-
-    sync_pool_trigger = CronTrigger(hour=4, minute=0, timezone=UTC)  # Run daily at 4 AM
-    scheduler.add_job(
-        sync_pool_budgets_job,
-        trigger=sync_pool_trigger,
-        id="sync_pool_budgets",
-        replace_existing=True,
-    )
-
-    # Start the scheduler
-    scheduler.start()
-
     yield
-
-    # Shutdown the scheduler
-    scheduler.shutdown()
 
 
 app = FastAPI(

--- a/app/main.py
+++ b/app/main.py
@@ -20,7 +20,6 @@ from app.api import (
     budgets,
 )
 from app.core.config import settings
-from app.db.database import get_db
 from app.middleware.audit import AuditLogMiddleware
 from app.middleware.caching import CacheControlMiddleware
 from app.middleware.prometheus import PrometheusMiddleware

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,4 @@ prometheus-client==0.24.1
 prometheus-fastapi-instrumentator==7.1.0
 stripe==12.5.1
 six==1.17.0
-apscheduler==3.11.2
 httpx==0.28.1

--- a/scripts/trigger_hard_delete_job.py
+++ b/scripts/trigger_hard_delete_job.py
@@ -55,12 +55,6 @@ async def trigger_hard_delete_job():
 
     except Exception as e:
         logger.error(f"Error in hard delete job trigger: {str(e)}")
-        # Try to release lock in case of error
-        try:
-            release_lock(lock_name, db)
-            logger.info("Released lock after error")
-        except Exception as release_error:
-            logger.error(f"Error releasing lock: {str(release_error)}")
         raise
     finally:
         db.close()
@@ -81,7 +75,8 @@ def main():
             logger.info(
                 "⚠️  Hard delete job could not be executed (lock held by another process)"
             )
-            sys.exit(1)
+            # Exiting with status 0 because this is a normal, expected condition (lock held)
+            sys.exit(0)
 
     except Exception as e:
         logger.error(f"❌ Script failed: {str(e)}")

--- a/scripts/trigger_recon_job.py
+++ b/scripts/trigger_recon_job.py
@@ -55,12 +55,6 @@ async def trigger_recon_job():
 
     except Exception as e:
         logger.error(f"Error in recon job trigger: {str(e)}")
-        # Try to release lock in case of error
-        try:
-            release_lock(lock_name, db)
-            logger.info("Released lock after error")
-        except Exception as release_error:
-            logger.error(f"Error releasing lock: {str(release_error)}")
         raise
     finally:
         db.close()
@@ -81,7 +75,8 @@ def main():
             logger.info(
                 "⚠️  Recon job could not be executed (lock held by another process)"
             )
-            sys.exit(1)
+            # Exiting with status 0 because this is a normal, expected condition (lock held)
+            sys.exit(0)
 
     except Exception as e:
         logger.error(f"❌ Script failed: {str(e)}")

--- a/scripts/trigger_sync_pool_budgets_job.py
+++ b/scripts/trigger_sync_pool_budgets_job.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import asyncio
+import logging
+
+# Add the parent directory to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from sqlalchemy.orm import sessionmaker
+from app.db.database import engine
+from app.api import budgets
+from app.core.locking import try_acquire_lock, release_lock
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def trigger_sync_pool_budgets_job():
+    """Manually trigger the sync pool budgets job"""
+
+    # Create database session
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = SessionLocal()
+
+    lock_name = "sync_pool_budgets"
+
+    try:
+        logger.info("Starting manual sync pool budgets job trigger...")
+
+        # Try to acquire the lock
+        if try_acquire_lock(lock_name, db, lock_timeout=10):
+            logger.info("Acquired sync_pool_budgets lock, executing job")
+            try:
+                result = await budgets.sync_pool_team_budgets(db)
+                logger.info(
+                    f"Pool budgets sync complete: {result['teams_updated']} teams updated"
+                )
+            except Exception as e:
+                logger.error(f"Error in sync pool budgets job execution: {str(e)}")
+                raise
+            finally:
+                # Always release the lock when done
+                release_lock(lock_name, db)
+                logger.info("Released sync_pool_budgets lock")
+        else:
+            logger.warning(
+                "Another process has the sync_pool_budgets lock, cannot execute job"
+            )
+            logger.info("This is normal if the scheduled job is currently running")
+            return False
+
+    except Exception as e:
+        logger.error(f"Error in sync pool budgets job trigger: {str(e)}")
+        # Try to release lock in case of error
+        try:
+            release_lock(lock_name, db)
+            logger.info("Released lock after error")
+        except Exception as release_error:
+            logger.error(f"Error releasing lock: {str(release_error)}")
+        raise
+    finally:
+        db.close()
+
+    return True
+
+
+def main():
+    """Main function to run the script"""
+    try:
+        logger.info("Triggering sync pool budgets job manually...")
+        success = asyncio.run(trigger_sync_pool_budgets_job())
+
+        if success:
+            logger.info("✅ Sync pool budgets job completed successfully")
+            sys.exit(0)
+        else:
+            logger.info(
+                "⚠️  Sync pool budgets job could not be executed (lock held by another process)"
+            )
+            sys.exit(1)
+
+    except Exception as e:
+        logger.error(f"❌ Script failed: {str(e)}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/trigger_sync_pool_budgets_job.py
+++ b/scripts/trigger_sync_pool_budgets_job.py
@@ -57,12 +57,6 @@ async def trigger_sync_pool_budgets_job():
 
     except Exception as e:
         logger.error(f"Error in sync pool budgets job trigger: {str(e)}")
-        # Try to release lock in case of error
-        try:
-            release_lock(lock_name, db)
-            logger.info("Released lock after error")
-        except Exception as release_error:
-            logger.error(f"Error releasing lock: {str(release_error)}")
         raise
     finally:
         db.close()

--- a/scripts/trigger_sync_pool_budgets_job.py
+++ b/scripts/trigger_sync_pool_budgets_job.py
@@ -77,7 +77,8 @@ def main():
             logger.info(
                 "⚠️  Sync pool budgets job could not be executed (lock held by another process)"
             )
-            sys.exit(1)
+            # Exiting with status 0 because this is a normal, expected condition (lock held)
+            sys.exit(0)
 
     except Exception as e:
         logger.error(f"❌ Script failed: {str(e)}")


### PR DESCRIPTION
- [x] Remove unused `try_acquire_lock`/`release_lock` imports from `app/main.py`
- [x] Remove unused `get_db` import from `app/main.py` (also left unused after scheduler removal)
- [x] Fix double-release race in `scripts/trigger_sync_pool_budgets_job.py` — removed the outer `except` block's redundant `release_lock` call so the lock is only released in one place (the inner `finally`)
- [x] Exit with status 0 (not 1) in `scripts/trigger_sync_pool_budgets_job.py` when skipping due to lock held by another process