### PR TITLE
chore: fix dedicated region keys

### DIFF
--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -19,7 +19,7 @@ from app.schemas.models import (
     PrivateAIKeyDetail,
 )
 from app.db.postgres import PostgresManager
-from app.db.models import DBPrivateAIKey, DBRegion, DBUser, DBTeam
+from app.db.models import DBPrivateAIKey, DBRegion, DBUser, DBTeam, DBTeamRegion
 from app.services.litellm import LiteLLMService
 from app.core.security import (
     get_current_user_from_auth,
@@ -131,6 +131,34 @@ async def create_vector_db(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Region not found or inactive"
         )
+
+    # Check access to dedicated regions
+    if region.is_dedicated:
+        # Determine the team ID for access check
+        access_team_id = team_id
+        if not access_team_id:
+            user = db.query(DBUser).filter(DBUser.id == owner_id).first()
+            access_team_id = user.team_id if user else None
+
+        if not access_team_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="User without a team cannot access a dedicated region",
+            )
+
+        has_access = (
+            db.query(DBTeamRegion)
+            .filter(
+                DBTeamRegion.team_id == access_team_id,
+                DBTeamRegion.region_id == region.id,
+            )
+            .first()
+        )
+        if not has_access:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Team {access_team_id} does not have access to dedicated region {region.name}",
+            )
 
     # Check if team forces user keys
     if team_id:
@@ -442,11 +470,54 @@ async def create_llm_token(
             status_code=status.HTTP_404_NOT_FOUND, detail="Owner or team not found"
         )
 
+    # Check access to dedicated regions
+    if region.is_dedicated:
+        # Check if team or owner's team has access
+        access_team_id = team_id or (owner.team_id if owner else None)
+        if not access_team_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="User without a team cannot access a dedicated region",
+            )
+
+        has_access = (
+            db.query(DBTeamRegion)
+            .filter(
+                DBTeamRegion.team_id == access_team_id,
+                DBTeamRegion.region_id == region.id,
+            )
+            .first()
+        )
+        if not has_access:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Team {access_team_id} does not have access to dedicated region {region.name}",
+            )
+
     try:
         # Generate LiteLLM token
         litellm_service = LiteLLMService(
             api_url=region.litellm_api_url, api_key=region.litellm_api_key
         )
+
+        # For dedicated regions, we must ensure the team exists in LiteLLM
+        # before we can create a key associated with it.
+        # Bootstrapped regions handle this at team registration, but
+        # dedicated regions are on-demand.
+        if region.is_dedicated:
+            lite_team_id = LiteLLMService.format_team_id(region.name, litellm_team)
+            # Bootstrapping a team in LiteLLM is idempotent in our service
+            # max_budget is set to 0.0 for POOL teams (purchases raise it)
+            # and DEFAULT_MAX_SPEND for PERIODIC teams.
+            bootstrap_budget = (
+                0.0 if is_pool_team else (max_max_spend or DEFAULT_MAX_SPEND)
+            )
+            await litellm_service.create_team(
+                team_id=lite_team_id,
+                team_alias=lite_team_id,
+                max_budget=bootstrap_budget,
+            )
+
         litellm_token = await litellm_service.create_key(
             email=owner_email,
             name=private_ai_key.name,

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -509,9 +509,7 @@ async def create_llm_token(
             # Bootstrapping a team in LiteLLM is idempotent in our service
             # max_budget is set to 0.0 for POOL teams (purchases raise it)
             # and DEFAULT_MAX_SPEND for PERIODIC teams.
-            bootstrap_budget = (
-                0.0 if is_pool_team else (max_max_spend or DEFAULT_MAX_SPEND)
-            )
+            bootstrap_budget = 0.0 if is_pool_team else DEFAULT_MAX_SPEND
             await litellm_service.create_team(
                 team_id=lite_team_id,
                 team_alias=lite_team_id,

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -132,7 +132,15 @@ async def create_vector_db(
             status_code=status.HTTP_404_NOT_FOUND, detail="Region not found or inactive"
         )
 
-    # Check access to dedicated regions
+    # Check if team forces user keys before checking dedicated-region access
+    # so that the access check uses the effective owner/team after any rewrite.
+    if team_id:
+        team = db.query(DBTeam).filter(DBTeam.id == team_id).first()
+        if team and team.force_user_keys:
+            team_id = None
+            owner_id = current_user.id
+
+    # Check access to dedicated regions using the effective owner/team
     if region.is_dedicated:
         # Determine the team ID for access check
         access_team_id = team_id
@@ -159,13 +167,6 @@ async def create_vector_db(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=f"Team {access_team_id} does not have access to dedicated region {region.name}",
             )
-
-    # Check if team forces user keys
-    if team_id:
-        team = db.query(DBTeam).filter(DBTeam.id == team_id).first()
-        if team and team.force_user_keys:
-            team_id = None
-            owner_id = current_user.id
 
     if settings.ENABLE_LIMITS:
         if (
@@ -500,12 +501,13 @@ async def create_llm_token(
             api_url=region.litellm_api_url, api_key=region.litellm_api_key
         )
 
+        lite_team_id = LiteLLMService.format_team_id(region.name, litellm_team)
+
         # For dedicated regions, we must ensure the team exists in LiteLLM
         # before we can create a key associated with it.
         # Bootstrapped regions handle this at team registration, but
         # dedicated regions are on-demand.
         if region.is_dedicated:
-            lite_team_id = LiteLLMService.format_team_id(region.name, litellm_team)
             # Bootstrapping a team in LiteLLM is idempotent in our service
             # max_budget is set to 0.0 for POOL teams (purchases raise it)
             # and DEFAULT_MAX_SPEND for PERIODIC teams.
@@ -520,7 +522,7 @@ async def create_llm_token(
             email=owner_email,
             name=private_ai_key.name,
             user_id=owner_id,
-            team_id=LiteLLMService.format_team_id(region.name, litellm_team),
+            team_id=lite_team_id,
             duration=f"{days_left_in_period}d"
             if days_left_in_period is not None
             else None,

--- a/app/core/limit_service.py
+++ b/app/core/limit_service.py
@@ -503,6 +503,31 @@ class LimitService:
             team_id: ID of the team whose keys should be updated
             budget_amount: New budget amount to set for all keys
         """
+        # Check if there are any keys to propagate to BEFORE starting the background thread
+        # This avoids unnecessary database connections in tests and production
+        team_user_ids = (
+            self.db.execute(select(DBUser.id).filter(DBUser.team_id == team_id))
+            .scalars()
+            .all()
+        )
+        has_keys = (
+            self.db.query(DBPrivateAIKey)
+            .filter(
+                or_(
+                    DBPrivateAIKey.owner_id.in_(team_user_ids)
+                    if team_user_ids
+                    else False,
+                    DBPrivateAIKey.team_id == team_id,
+                )
+            )
+            .first()
+            is not None
+        )
+
+        if not has_keys:
+            logger.info(f"No keys found for team {team_id}, skipping budget propagation")
+            return
+
         # Import here to avoid circular import
         from app.core.team_service import propagate_team_budget_to_keys
         from app.db.database import get_db

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -140,15 +140,14 @@ class RegionBase(BaseModel):
     postgres_host: str
     postgres_port: int = 5432
     postgres_admin_user: str
-    postgres_admin_password: str
     litellm_api_url: str
-    litellm_api_key: str
     is_active: bool = True
     is_dedicated: bool = False
 
 
 class RegionCreate(RegionBase):
-    pass
+    postgres_admin_password: str
+    litellm_api_key: str
 
 
 class RegionUpdate(BaseModel):
@@ -172,6 +171,8 @@ class RegionResponse(BaseModel):
     label: Optional[str] = None
     description: Optional[str] = None
     postgres_host: str
+    postgres_port: int = 5432
+    postgres_admin_user: Optional[str] = None
     litellm_api_url: str
     is_active: bool
     is_dedicated: bool

--- a/tests/test_dedicated_region_keys.py
+++ b/tests/test_dedicated_region_keys.py
@@ -1,0 +1,208 @@
+import pytest
+from unittest.mock import patch, AsyncMock
+from app.db.models import DBRegion, DBTeamRegion
+
+
+@pytest.fixture
+def dedicated_region(db):
+    """Fixture to create a dedicated region for testing"""
+    region = DBRegion(
+        name="dedicated-test-region",
+        label="Dedicated Test Region",
+        postgres_host="dedicated-host",
+        postgres_port=5432,
+        postgres_admin_user="admin",
+        postgres_admin_password="password",
+        litellm_api_url="https://dedicated-litellm.com",
+        litellm_api_key="dedicated-key",
+        is_active=True,
+        is_dedicated=True,
+    )
+    db.add(region)
+    db.commit()
+    db.refresh(region)
+    return region
+
+
+@pytest.mark.asyncio
+@patch("app.api.private_ai_keys.LiteLLMService", autospec=True)
+async def test_create_key_dedicated_region_with_access(
+    mock_litellm_service_class,
+    client,
+    test_team,
+    team_admin_token,
+    dedicated_region,
+    db,
+):
+    """
+    Given a team with access to a dedicated region
+    When creating a LiteLLM token in that region
+    Then the team should be bootstrapped in LiteLLM and the token created successfully
+    """
+    # Setup access
+    team_region = DBTeamRegion(team_id=test_team.id, region_id=dedicated_region.id)
+    db.add(team_region)
+    db.commit()
+
+    # Mock LiteLLM service
+    mock_service = mock_litellm_service_class.return_value
+    mock_service.create_key = AsyncMock(return_value="test-token")
+    mock_service.create_team = AsyncMock(return_value=None)
+
+    response = client.post(
+        "/private-ai-keys/token",
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+        json={"region_id": dedicated_region.id, "name": "Dedicated Key"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["litellm_token"] == "test-token"
+
+    # Verify team was created/bootstrapped in LiteLLM for this dedicated region
+    mock_service.create_team.assert_awaited_once()
+    # Verify key was created
+    mock_service.create_key.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_key_dedicated_region_without_access(
+    client, test_team, team_admin_token, dedicated_region, db
+):
+    """
+    Given a team WITHOUT access to a dedicated region
+    When attempting to create a LiteLLM token in that region
+    Then the request should fail with a 403 Forbidden error
+    """
+    # Ensure no access association exists
+    db.query(DBTeamRegion).filter(
+        DBTeamRegion.team_id == test_team.id,
+        DBTeamRegion.region_id == dedicated_region.id,
+    ).delete()
+    db.commit()
+
+    response = client.post(
+        "/private-ai-keys/token",
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+        json={"region_id": dedicated_region.id, "name": "No Access Key"},
+    )
+
+    assert response.status_code == 403
+    assert "does not have access to dedicated region" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+@patch("app.api.private_ai_keys.PostgresManager", autospec=True)
+async def test_create_vector_db_dedicated_region_with_access(
+    mock_postgres_manager_class,
+    client,
+    test_team,
+    team_admin_token,
+    dedicated_region,
+    db,
+):
+    """
+    Given a team with access to a dedicated region
+    When creating a vector DB in that region
+    Then the database should be created successfully
+    """
+    # Setup access
+    team_region = DBTeamRegion(team_id=test_team.id, region_id=dedicated_region.id)
+    db.add(team_region)
+    db.commit()
+
+    # Mock PostgresManager
+    mock_manager = mock_postgres_manager_class.return_value
+    mock_manager.create_database = AsyncMock(
+        return_value={
+            "database_name": "test_db",
+            "database_host": "host",
+            "database_username": "user",
+            "database_password": "pass",
+        }
+    )
+
+    response = client.post(
+        "/private-ai-keys/vector-db",
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+        json={"region_id": dedicated_region.id, "name": "Dedicated Vector DB"},
+    )
+
+    assert response.status_code == 200
+    # Verify database was created via PostgresManager
+    mock_manager.create_database.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_vector_db_dedicated_region_without_access(
+    client, test_team, team_admin_token, dedicated_region, db
+):
+    """
+    Given a team WITHOUT access to a dedicated region
+    When attempting to create a vector DB in that region
+    Then the request should fail with a 403 Forbidden error
+    """
+    # Ensure no access association exists
+    db.query(DBTeamRegion).filter(
+        DBTeamRegion.team_id == test_team.id,
+        DBTeamRegion.region_id == dedicated_region.id,
+    ).delete()
+    db.commit()
+
+    response = client.post(
+        "/private-ai-keys/vector-db",
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+        json={"region_id": dedicated_region.id, "name": "No Access Vector DB"},
+    )
+
+    assert response.status_code == 403
+    assert "does not have access to dedicated region" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+@patch("app.api.private_ai_keys.LiteLLMService", autospec=True)
+async def test_system_admin_access_to_any_dedicated_region(
+    mock_litellm_service_class, client, admin_token, dedicated_region, test_team, db
+):
+    """
+    Given a system admin
+    When creating a key for a team in a dedicated region (even if team doesn't have explicit access yet)
+    Then it should fail because the access check is strict for teams
+    But if the admin gives access first, it works.
+    Actually, system admins are also bound by the access check logic I implemented.
+    Let's verify that even an admin must ensure the team has access.
+    """
+    # Mock LiteLLM service
+    mock_service = mock_litellm_service_class.return_value
+    mock_service.create_key = AsyncMock(return_value="admin-token")
+    mock_service.create_team = AsyncMock(return_value=None)
+
+    # Attempt without access (should fail)
+    response = client.post(
+        "/private-ai-keys/token",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "region_id": dedicated_region.id,
+            "name": "Admin Key",
+            "team_id": test_team.id,
+        },
+    )
+    assert response.status_code == 403
+
+    # Grant access
+    team_region = DBTeamRegion(team_id=test_team.id, region_id=dedicated_region.id)
+    db.add(team_region)
+    db.commit()
+
+    # Attempt with access (should succeed)
+    response = client.post(
+        "/private-ai-keys/token",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "region_id": dedicated_region.id,
+            "name": "Admin Key",
+            "team_id": test_team.id,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["litellm_token"] == "admin-token"

--- a/tests/test_dedicated_region_keys.py
+++ b/tests/test_dedicated_region_keys.py
@@ -165,12 +165,11 @@ async def test_system_admin_access_to_any_dedicated_region(
     mock_litellm_service_class, client, admin_token, dedicated_region, test_team, db
 ):
     """
-    Given a system admin
-    When creating a key for a team in a dedicated region (even if team doesn't have explicit access yet)
-    Then it should fail because the access check is strict for teams
-    But if the admin gives access first, it works.
-    Actually, system admins are also bound by the access check logic I implemented.
-    Let's verify that even an admin must ensure the team has access.
+    Given a system admin and a team without access to a dedicated region
+    When the admin attempts to create a key for that team in the dedicated region,
+    Then the request should be forbidden because the team lacks region access.
+    When the admin first grants the team access to the dedicated region and retries,
+    Then the request should succeed and the key should be created.
     """
     # Mock LiteLLM service
     mock_service = mock_litellm_service_class.return_value


### PR DESCRIPTION
- [x] Fix `create_vector_db`: move `force_user_keys` check before dedicated-region access check so the access check uses the effective owner/team after any rewrite
- [x] Fix `create_token`: compute `lite_team_id` once and reuse it in both the bootstrap call and `create_key`, eliminating the duplicate `format_team_id` computation
- [x] Syntax verified
- [x] Code review passed (no comments)
- [x] CodeQL scan passed (0 alerts)