### PR TITLE
feat(api): update pricing fields to use model input/output costs

### DIFF
--- a/app/api/public.py
+++ b/app/api/public.py
@@ -70,8 +70,8 @@ def _extract_model_summary(item: dict[str, Any]) -> PublicModelSummary:
             supports_prompt_caching=bool(model_info.get("supports_prompt_caching")),
         ),
         pricing=PublicModelPricing(
-            input_cost_per_token="n/a",
-            output_cost_per_token="n/a",
+            input_cost_per_token=model_info.get("input_cost_per_token"),
+            output_cost_per_token=model_info.get("output_cost_per_token"),
         ),
     )
 

--- a/app/api/public.py
+++ b/app/api/public.py
@@ -45,6 +45,16 @@ def _infer_provider(item: dict[str, Any]) -> str:
     return "other"
 
 
+def _safe_float(value: Any) -> float | None:
+    """Coerce *value* to float, returning None on any parse failure."""
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _to_display_name(model_id: str) -> str:
     words = re.split(r"[-_]+", model_id)
     return " ".join(
@@ -70,8 +80,8 @@ def _extract_model_summary(item: dict[str, Any]) -> PublicModelSummary:
             supports_prompt_caching=bool(model_info.get("supports_prompt_caching")),
         ),
         pricing=PublicModelPricing(
-            input_cost_per_token=model_info.get("input_cost_per_token"),
-            output_cost_per_token=model_info.get("output_cost_per_token"),
+            input_cost_per_token=_safe_float(model_info.get("input_cost_per_token")),
+            output_cost_per_token=_safe_float(model_info.get("output_cost_per_token")),
         ),
     )
 

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -196,8 +196,8 @@ class PublicModel(BaseModel):
 
 
 class PublicModelPricing(BaseModel):
-    input_cost_per_token: str = "n/a"
-    output_cost_per_token: str = "n/a"
+    input_cost_per_token: Optional[float] = None
+    output_cost_per_token: Optional[float] = None
 
 
 class PublicModelCapabilities(BaseModel):

--- a/tests/test_public_models.py
+++ b/tests/test_public_models.py
@@ -96,6 +96,134 @@ def test_public_models_includes_unavailable_region(client, db):
         )
 
 
+def test_public_models_pricing_numeric_values(client, db):
+    """Pricing fields are correctly propagated when LiteLLM returns numeric values."""
+    _clear_public_models_cache()
+    region = DBRegion(
+        name="ap-southeast-1",
+        postgres_host="host",
+        postgres_port=5432,
+        postgres_admin_user="user",
+        postgres_admin_password="pass",
+        litellm_api_url="https://litellm.example",
+        litellm_api_key="key",
+        is_active=True,
+        is_dedicated=False,
+    )
+    db.add(region)
+    db.commit()
+
+    with patch("app.api.public.LiteLLMService") as mock_service_cls:
+        mock_service = mock_service_cls.return_value
+        mock_service.get_model_info = AsyncMock(
+            return_value={
+                "data": [
+                    {
+                        "model_name": "gpt-4o",
+                        "litellm_params": {},
+                        "model_info": {
+                            "mode": "chat",
+                            "input_cost_per_token": 0.000005,
+                            "output_cost_per_token": 0.000015,
+                        },
+                    }
+                ]
+            }
+        )
+
+        response = client.get("/public/models")
+        assert response.status_code == 200
+        data = response.json()
+        region_data = next(r for r in data if r["region"] == "ap-southeast-1")
+        pricing = region_data["models"][0]["pricing"]
+        assert pricing["input_cost_per_token"] == 0.000005
+        assert pricing["output_cost_per_token"] == 0.000015
+
+
+def test_public_models_pricing_missing_values(client, db):
+    """Pricing fields are null when LiteLLM does not return cost info."""
+    _clear_public_models_cache()
+    region = DBRegion(
+        name="ap-northeast-1",
+        postgres_host="host",
+        postgres_port=5432,
+        postgres_admin_user="user",
+        postgres_admin_password="pass",
+        litellm_api_url="https://litellm.example",
+        litellm_api_key="key",
+        is_active=True,
+        is_dedicated=False,
+    )
+    db.add(region)
+    db.commit()
+
+    with patch("app.api.public.LiteLLMService") as mock_service_cls:
+        mock_service = mock_service_cls.return_value
+        mock_service.get_model_info = AsyncMock(
+            return_value={
+                "data": [
+                    {
+                        "model_name": "gpt-4o",
+                        "litellm_params": {},
+                        "model_info": {"mode": "chat"},
+                    }
+                ]
+            }
+        )
+
+        response = client.get("/public/models")
+        assert response.status_code == 200
+        data = response.json()
+        region_data = next(r for r in data if r["region"] == "ap-northeast-1")
+        pricing = region_data["models"][0]["pricing"]
+        assert pricing["input_cost_per_token"] is None
+        assert pricing["output_cost_per_token"] is None
+
+
+def test_public_models_pricing_non_numeric_values(client, db):
+    """Non-numeric pricing values from LiteLLM are coerced to null without raising."""
+    _clear_public_models_cache()
+    region = DBRegion(
+        name="eu-west-1",
+        postgres_host="host",
+        postgres_port=5432,
+        postgres_admin_user="user",
+        postgres_admin_password="pass",
+        litellm_api_url="https://litellm.example",
+        litellm_api_key="key",
+        is_active=True,
+        is_dedicated=False,
+    )
+    db.add(region)
+    db.commit()
+
+    with patch("app.api.public.LiteLLMService") as mock_service_cls:
+        mock_service = mock_service_cls.return_value
+        mock_service.get_model_info = AsyncMock(
+            return_value={
+                "data": [
+                    {
+                        "model_name": "gpt-4o",
+                        "litellm_params": {},
+                        "model_info": {
+                            "mode": "chat",
+                            "input_cost_per_token": "n/a",
+                            "output_cost_per_token": "n/a",
+                        },
+                    }
+                ]
+            }
+        )
+
+        response = client.get("/public/models")
+        assert response.status_code == 200
+        data = response.json()
+        region_data = next(r for r in data if r["region"] == "eu-west-1")
+        pricing = region_data["models"][0]["pricing"]
+        assert pricing["input_cost_per_token"] is None
+        assert pricing["output_cost_per_token"] is None
+
+
 def test_public_models_uses_region_key_for_model_info(client, db):
     _clear_public_models_cache()
     region = DBRegion(


### PR DESCRIPTION
- [x] Review existing code in `app/api/public.py` and `app/schemas/models.py`
- [x] Add `_safe_float()` helper in `app/api/public.py` to safely coerce LiteLLM pricing values to float (returns `None` on `TypeError`/`ValueError`), preventing 500 errors when LiteLLM returns non-numeric strings
- [x] Use `_safe_float()` when populating `PublicModelPricing` fields in `_extract_model_summary()`
- [x] Add 3 new tests in `tests/test_public_models.py`:
  - `test_public_models_pricing_numeric_values` – numeric pricing values are correctly propagated
  - `test_public_models_pricing_missing_values` – absent pricing fields yield `null`
  - `test_public_models_pricing_non_numeric_values` – string values like `"n/a"` are gracefully coerced to `null`