### PR TITLE
fix(delete_private_ai_key): harden SQL identifiers and fix vector-DB-only key deletion

### DIFF
--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -848,20 +848,23 @@ async def delete_private_ai_key(
             status_code=status.HTTP_404_NOT_FOUND, detail="Region not found"
         )
 
-    # Delete LiteLLM token first
-    litellm_service = LiteLLMService(
-        api_url=region.litellm_api_url, api_key=region.litellm_api_key
-    )
-    try:
-        await litellm_service.delete_key(private_ai_key.litellm_token)
-    except HTTPException as e:
-        # Propagate the HTTP exception with its status code
-        raise e
+    # Delete LiteLLM token first when present (vector-db-only keys have no token)
+    if private_ai_key.litellm_token:
+        litellm_service = LiteLLMService(
+            api_url=region.litellm_api_url, api_key=region.litellm_api_key
+        )
+        try:
+            await litellm_service.delete_key(private_ai_key.litellm_token)
+        except HTTPException as e:
+            # Propagate the HTTP exception with its status code
+            raise e
 
     # Only delete the database if it exists
     if private_ai_key.database_name:
         postgres_manager = PostgresManager(region=region)
-        await postgres_manager.delete_database(private_ai_key.database_name)
+        await postgres_manager.delete_database(
+            private_ai_key.database_name, private_ai_key.database_username
+        )
 
     # Remove the private AI key record from the application database
     db.delete(private_ai_key)

--- a/app/db/postgres.py
+++ b/app/db/postgres.py
@@ -1,9 +1,20 @@
 import asyncpg
+import re
 import uuid
 import logging
 from app.db.models import DBRegion
 
 logger = logging.getLogger(__name__)
+
+_IDENTIFIER_RE = re.compile(r"^[a-zA-Z0-9_]+$")
+
+
+def _validate_identifier(name: str, label: str = "identifier") -> None:
+    """Raise ValueError if *name* is not a safe SQL identifier."""
+    if not _IDENTIFIER_RE.match(name):
+        raise ValueError(
+            f"Invalid {label} '{name}': only alphanumeric characters and underscores are allowed"
+        )
 
 
 class PostgresManager:
@@ -103,19 +114,27 @@ class PostgresManager:
         )
 
         try:
-            # Terminate all connections to the database
-            await conn.execute(f"""
+            _validate_identifier(database_name, "database name")
+            # Terminate all connections to the database (parameterized to prevent injection)
+            await conn.execute(
+                """
                 SELECT pg_terminate_backend(pg_stat_activity.pid)
                 FROM pg_stat_activity
-                WHERE pg_stat_activity.datname = '{database_name}'
-            """)
-            await conn.execute(f'DROP DATABASE IF EXISTS "{database_name}"')
+                WHERE pg_stat_activity.datname = $1
+                """,
+                database_name,
+            )
+            await conn.execute(f"DROP DATABASE IF EXISTS {database_name}")
             if database_username:
-                await conn.execute(f"""
+                _validate_identifier(database_username, "database username")
+                await conn.execute(
+                    """
                     SELECT pg_terminate_backend(pg_stat_activity.pid)
                     FROM pg_stat_activity
-                    WHERE pg_stat_activity.usename = '{database_username}'
-                """)
-                await conn.execute(f'DROP USER IF EXISTS "{database_username}"')
+                    WHERE pg_stat_activity.usename = $1
+                    """,
+                    database_username,
+                )
+                await conn.execute(f"DROP USER IF EXISTS {database_username}")
         finally:
             await conn.close()

--- a/app/db/postgres.py
+++ b/app/db/postgres.py
@@ -92,7 +92,9 @@ class PostgresManager:
         finally:
             await conn.close()
 
-    async def delete_database(self, database_name: str):
+    async def delete_database(
+        self, database_name: str, database_username: str | None = None
+    ):
         conn = await asyncpg.connect(
             host=self.host,
             port=self.port,
@@ -108,5 +110,12 @@ class PostgresManager:
                 WHERE pg_stat_activity.datname = '{database_name}'
             """)
             await conn.execute(f'DROP DATABASE IF EXISTS "{database_name}"')
+            if database_username:
+                await conn.execute(f"""
+                    SELECT pg_terminate_backend(pg_stat_activity.pid)
+                    FROM pg_stat_activity
+                    WHERE pg_stat_activity.usename = '{database_username}'
+                """)
+                await conn.execute(f'DROP USER IF EXISTS "{database_username}"')
         finally:
             await conn.close()

--- a/app/db/postgres.py
+++ b/app/db/postgres.py
@@ -106,6 +106,10 @@ class PostgresManager:
     async def delete_database(
         self, database_name: str, database_username: str | None = None
     ):
+        _validate_identifier(database_name, "database name")
+        if database_username:
+            _validate_identifier(database_username, "database username")
+
         conn = await asyncpg.connect(
             host=self.host,
             port=self.port,
@@ -114,7 +118,6 @@ class PostgresManager:
         )
 
         try:
-            _validate_identifier(database_name, "database name")
             # Terminate all connections to the database (parameterized to prevent injection)
             await conn.execute(
                 """
@@ -126,7 +129,6 @@ class PostgresManager:
             )
             await conn.execute(f"DROP DATABASE IF EXISTS {database_name}")
             if database_username:
-                _validate_identifier(database_username, "database username")
                 await conn.execute(
                     """
                     SELECT pg_terminate_backend(pg_stat_activity.pid)

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -1,0 +1,43 @@
+import pytest
+from app.db.postgres import _validate_identifier
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "db_abc123",
+        "user_1a2b3c4d",
+        "mydb",
+        "MYDB",
+        "db_00000000",
+        "a",
+        "_leading_underscore",
+    ],
+)
+def test_validate_identifier_accepts_valid_names(name):
+    # Should not raise
+    _validate_identifier(name)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "db-name",           # hyphen
+        "db name",           # space
+        "db'name",           # single quote (SQL injection vector)
+        'db"name',           # double quote
+        "db;DROP TABLE x",   # semicolon injection
+        "db\x00name",        # null byte
+        "",                  # empty string
+        "db/name",           # slash
+        "db.name",           # dot
+    ],
+)
+def test_validate_identifier_rejects_unsafe_names(name):
+    with pytest.raises(ValueError, match="only alphanumeric characters and underscores"):
+        _validate_identifier(name)
+
+
+def test_validate_identifier_uses_provided_label():
+    with pytest.raises(ValueError, match="database name"):
+        _validate_identifier("bad-name", "database name")

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -1938,8 +1938,6 @@ def test_delete_private_ai_key_with_only_vector_db(
     mock_client_class, client, admin_token, test_region, db, mock_httpx_post_client
 ):
     """Test deleting a private AI key that only has a vector database (no LLM token)"""
-    litellm_api_url = test_region.litellm_api_url
-    litellm_api_key = test_region.litellm_api_key
     # Create a test key with only vector DB
     test_key = DBPrivateAIKey(
         database_name="test-db-vector-only",
@@ -1978,12 +1976,8 @@ def test_delete_private_ai_key_with_only_vector_db(
     )
     assert deleted_key is None
 
-    # Verify that LiteLLM API was called with None token
-    mock_httpx_post_client.post.assert_called_with(
-        f"{litellm_api_url}/key/delete",
-        headers={"Authorization": f"Bearer {litellm_api_key}"},
-        json={"keys": [None]},
-    )
+    # Verify that LiteLLM API was not called because no token exists
+    mock_httpx_post_client.post.assert_not_called()
 
 
 @patch("httpx.AsyncClient")
@@ -2036,6 +2030,49 @@ def test_delete_private_ai_key_with_only_llm_token(
         f"{litellm_api_url}/key/delete",
         headers={"Authorization": f"Bearer {api_key}"},
         json={"keys": [test_key.litellm_token]},
+    )
+
+
+@patch("app.db.postgres.PostgresManager.delete_database")
+@patch("httpx.AsyncClient")
+def test_delete_private_ai_key_cleans_up_database_user(
+    mock_client_class,
+    mock_delete_database,
+    client,
+    admin_token,
+    test_region,
+    db,
+    mock_httpx_post_client,
+):
+    """Test deleting a private AI key removes both DB and DB user when available."""
+    mock_client_class.return_value = mock_httpx_post_client
+    mock_httpx_post_client.post.return_value.status_code = 200
+    mock_httpx_post_client.post.return_value.raise_for_status.return_value = None
+
+    test_key = DBPrivateAIKey(
+        database_name="test-db-cleanup-user",
+        name="Test DB User Cleanup",
+        database_host="test-host",
+        database_username="test-user-cleanup",
+        database_password="test-pass",
+        litellm_token="test-token-cleanup-user",
+        litellm_api_url="https://test-litellm.com",
+        owner_id=None,
+        region_id=test_region.id,
+    )
+    db.add(test_key)
+    db.commit()
+    db.refresh(test_key)
+
+    delete_response = client.delete(
+        f"/private-ai-keys/{test_key.id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+
+    assert delete_response.status_code == 200
+    assert delete_response.json()["message"] == "Private AI Key deleted successfully"
+    mock_delete_database.assert_called_once_with(
+        test_key.database_name, test_key.database_username
     )
 
 

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -99,10 +99,10 @@ def test_delete_private_ai_key(
 
     # Create a test private AI key
     test_key = DBPrivateAIKey(
-        database_name="test-db-delete",
+        database_name="test_db_delete",
         name="Test Key to Delete",
         database_host="test-host",
-        database_username="test-user",
+        database_username="test_user",
         database_password="test-pass",
         litellm_token="test-token-delete",
         litellm_api_url="https://test-litellm.com",
@@ -1940,10 +1940,10 @@ def test_delete_private_ai_key_with_only_vector_db(
     """Test deleting a private AI key that only has a vector database (no LLM token)"""
     # Create a test key with only vector DB
     test_key = DBPrivateAIKey(
-        database_name="test-db-vector-only",
+        database_name="test_db_vector_only",
         name="Test Vector DB Only",
         database_host="test-host",
-        database_username="test-user",
+        database_username="test_user",
         database_password="test-pass",
         litellm_token=None,  # No LLM token
         litellm_api_url=None,  # No LLM API URL


### PR DESCRIPTION
`delete_database` interpolated `database_name`/`database_username` directly into DDL via f-strings, enabling SQL injection. Additionally, vector-DB-only keys (no `litellm_token`) incorrectly triggered a LiteLLM deletion call, and the DB user was never dropped on cleanup.

## Changes

### `app/db/postgres.py`
- Add `_validate_identifier()` — enforces `^[a-zA-Z0-9_]+$` allowlist, raises `ValueError` on violation; called **before** `asyncpg.connect` so invalid input is rejected without opening a connection
- Replace f-string interpolation in both `pg_stat_activity` WHERE clauses with asyncpg parameterized queries (`$1`)
- DDL identifiers (`DROP DATABASE`, `DROP USER`) are safe — validated by allowlist; PostgreSQL does not support parameterized identifiers in DDL
- Extend `delete_database` to optionally terminate sessions for and drop the DB user

```python
async def delete_database(self, database_name: str, database_username: str | None = None):
    _validate_identifier(database_name, "database name")
    if database_username:
        _validate_identifier(database_username, "database username")
    conn = await asyncpg.connect(...)
    ...
    await conn.execute(f"DROP DATABASE IF EXISTS {database_name}")
    await conn.execute(f"DROP USER IF EXISTS {database_username}")
```

### `app/api/private_ai_keys.py`
- Gate LiteLLM key deletion on `private_ai_key.litellm_token` being present — vector-DB-only keys skip that call entirely
- Pass `database_username` into `delete_database` so the PG role is cleaned up alongside the database

### `tests/`
- Add `tests/test_postgres.py` covering valid identifiers and unsafe inputs (hyphens, quotes, semicolons, spaces, empty string)
- Update fixture data in `test_private_ai.py` to use underscore-based identifiers (`test_db_delete`, `test_user`) that satisfy the allowlist