### PR TITLE
fix: harden DB rollback in LiteLLM bootstrap compensation path

### DIFF
--- a/app/api/regions.py
+++ b/app/api/regions.py
@@ -377,7 +377,8 @@ async def associate_team_with_region(
         db.delete(team_region)
         db.commit()
         logger.error(
-            "Failed to bootstrap LiteLLM team %s in dedicated region %s: %s",
+            "Failed to bootstrap LiteLLM team %s (db team_id=%s) in dedicated region %s: %s",
+            lite_team_id,
             team_id,
             region.name,
             str(e),

--- a/app/api/regions.py
+++ b/app/api/regions.py
@@ -374,8 +374,6 @@ async def associate_team_with_region(
             budget_duration=budget_duration,
         )
     except Exception as e:
-        db.delete(team_region)
-        db.commit()
         logger.error(
             "Failed to bootstrap LiteLLM team %s (db team_id=%s) in dedicated region %s: %s",
             lite_team_id,
@@ -383,6 +381,17 @@ async def associate_team_with_region(
             region.name,
             str(e),
         )
+        try:
+            db.delete(team_region)
+            db.commit()
+        except Exception as db_err:
+            db.rollback()
+            logger.error(
+                "Failed to remove DB association for team %s in region %s after LiteLLM bootstrap failure: %s",
+                team_id,
+                region.name,
+                str(db_err),
+            )
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="Failed to bootstrap team in LiteLLM",

--- a/app/api/regions.py
+++ b/app/api/regions.py
@@ -28,6 +28,7 @@ from app.core.security import (
     get_role_min_system_admin,
     get_role_min_specific_team_admin,
 )
+from app.core.config import settings
 from app.core.limit_service import LimitService, DEFAULT_MAX_SPEND
 from app.schemas.limits import ResourceType
 from app.services.litellm import LiteLLMService
@@ -347,6 +348,43 @@ async def associate_team_with_region(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to associate team with region: {str(e)}",
+        )
+
+    # Bootstrap the team in the dedicated region's LiteLLM instance.
+    # POOL teams start at $0 (purchases raise the budget).
+    # PERIODIC teams start at DEFAULT_MAX_SPEND.
+    # Must happen after commit so the association is durable before touching
+    # the external service. Roll back on failure to avoid a broken half-state
+    # where the DB association exists but LiteLLM has no team entry.
+    max_budget = 0.0 if team.budget_type == BudgetType.POOL else DEFAULT_MAX_SPEND
+    budget_duration = (
+        f"{settings.POOL_BUDGET_EXPIRATION_DAYS}d"
+        if team.budget_type == BudgetType.POOL
+        else None
+    )
+    litellm_service = LiteLLMService(
+        api_url=region.litellm_api_url, api_key=region.litellm_api_key
+    )
+    lite_team_id = LiteLLMService.format_team_id(region.name, team_id)
+    try:
+        await litellm_service.create_team(
+            team_id=lite_team_id,
+            team_alias=lite_team_id,
+            max_budget=max_budget,
+            budget_duration=budget_duration,
+        )
+    except Exception as e:
+        db.delete(team_region)
+        db.commit()
+        logger.error(
+            "Failed to bootstrap LiteLLM team %s in dedicated region %s: %s",
+            team_id,
+            region.name,
+            str(e),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Failed to bootstrap team in LiteLLM: {str(e)}",
         )
 
     return {"message": "Team associated with region successfully"}

--- a/app/api/regions.py
+++ b/app/api/regions.py
@@ -385,7 +385,7 @@ async def associate_team_with_region(
         )
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=f"Failed to bootstrap team in LiteLLM: {str(e)}",
+            detail="Failed to bootstrap team in LiteLLM",
         )
 
     return {"message": "Team associated with region successfully"}

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -933,7 +933,9 @@ def test_associate_team_with_dedicated_region(
     assert response.json()["message"] == "Team associated with region successfully"
     mock_create_team.assert_called_once()
     call_kwargs = mock_create_team.call_args.kwargs
-    assert call_kwargs["team_id"] == f"dedicated-region-for-association_{test_team.id}"
+    assert call_kwargs["team_id"] == LiteLLMService.format_team_id(
+        "dedicated-region-for-association", test_team.id
+    )
     # PERIODIC team: max_budget should be DEFAULT_MAX_SPEND, no budget_duration
     assert call_kwargs["max_budget"] > 0
     assert call_kwargs["budget_duration"] is None

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -899,13 +899,15 @@ def test_create_dedicated_region_non_admin_fails(client, test_token):
     assert "Not authorized to perform this action" in response.json()["detail"]
 
 
-def test_associate_team_with_dedicated_region(client, admin_token, db, test_team):
+@patch("app.api.regions.LiteLLMService.create_team", new_callable=AsyncMock)
+def test_associate_team_with_dedicated_region(
+    mock_create_team, client, admin_token, db, test_team
+):
     """
     Given an admin user and a dedicated region
     When they associate a team with the region
-    Then the association should be created successfully
+    Then the association should be created and the team bootstrapped in LiteLLM
     """
-    # Create a dedicated region
     dedicated_region = DBRegion(
         name="dedicated-region-for-association",
         label="Dedicated Region for Association",
@@ -929,6 +931,109 @@ def test_associate_team_with_dedicated_region(client, admin_token, db, test_team
 
     assert response.status_code == 200
     assert response.json()["message"] == "Team associated with region successfully"
+    mock_create_team.assert_called_once()
+    call_kwargs = mock_create_team.call_args.kwargs
+    assert call_kwargs["team_id"] == f"dedicated-region-for-association_{test_team.id}"
+    # PERIODIC team: max_budget should be DEFAULT_MAX_SPEND, no budget_duration
+    assert call_kwargs["max_budget"] > 0
+    assert call_kwargs["budget_duration"] is None
+
+
+@patch("app.api.regions.LiteLLMService.create_team", new_callable=AsyncMock)
+def test_associate_pool_team_with_dedicated_region(
+    mock_create_team, client, admin_token, db
+):
+    """
+    Given a POOL team and a dedicated region
+    When they are associated
+    Then LiteLLM team is created with max_budget=0 and a budget_duration
+    """
+    from app.db.models import DBTeam
+
+    pool_team = DBTeam(
+        name="pool-team-for-dedicated",
+        admin_email="pool-dedicated@test.com",
+        budget_type="pool",
+    )
+    db.add(pool_team)
+
+    dedicated_region = DBRegion(
+        name="dedicated-region-for-pool",
+        label="Dedicated for Pool",
+        postgres_host="h",
+        postgres_port=5432,
+        postgres_admin_user="a",
+        postgres_admin_password="p",
+        litellm_api_url="https://pool-dedicated-litellm.com",
+        litellm_api_key="key",
+        is_active=True,
+        is_dedicated=True,
+    )
+    db.add(dedicated_region)
+    db.commit()
+    db.refresh(pool_team)
+    db.refresh(dedicated_region)
+
+    response = client.post(
+        f"/regions/{dedicated_region.id}/teams/{pool_team.id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+
+    assert response.status_code == 200
+    call_kwargs = mock_create_team.call_args.kwargs
+    assert call_kwargs["max_budget"] == 0.0
+    assert call_kwargs["budget_duration"] is not None
+
+
+@patch(
+    "app.api.regions.LiteLLMService.create_team",
+    new_callable=AsyncMock,
+    side_effect=Exception("LiteLLM unreachable"),
+)
+def test_associate_team_litellm_failure_rolls_back(
+    mock_create_team, client, admin_token, db, test_team
+):
+    """
+    Given a LiteLLM failure during association
+    When the endpoint is called
+    Then it returns 502 and the DB association is rolled back
+    """
+    from app.db.models import DBTeamRegion
+
+    dedicated_region = DBRegion(
+        name="dedicated-region-litellm-fail",
+        label="Dedicated LiteLLM Fail",
+        postgres_host="h",
+        postgres_port=5432,
+        postgres_admin_user="a",
+        postgres_admin_password="p",
+        litellm_api_url="https://fail-litellm.com",
+        litellm_api_key="key",
+        is_active=True,
+        is_dedicated=True,
+    )
+    db.add(dedicated_region)
+    db.commit()
+    db.refresh(dedicated_region)
+
+    response = client.post(
+        f"/regions/{dedicated_region.id}/teams/{test_team.id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+
+    assert response.status_code == 502
+    assert "Failed to bootstrap team in LiteLLM" in response.json()["detail"]
+
+    # DB association must not exist
+    association = (
+        db.query(DBTeamRegion)
+        .filter(
+            DBTeamRegion.team_id == test_team.id,
+            DBTeamRegion.region_id == dedicated_region.id,
+        )
+        .first()
+    )
+    assert association is None
 
 
 def test_associate_team_with_non_dedicated_region_fails(


### PR DESCRIPTION
The compensating `db.delete` + `db.commit` after a failed LiteLLM team bootstrap had no error handling — a DB failure there would raise an unhandled 500 and leave the association in place, the exact broken half-state the bootstrap logic was introduced to prevent.

## Changes

- **`app/api/regions.py`**: Wrap the cleanup `db.delete(team_region)` + `db.commit()` in a nested `try/except`; on failure call `db.rollback()` and log the DB cleanup error explicitly. The 502 is raised regardless of whether cleanup succeeded.