### PR TITLE
fix: include user-owned keys in per-user spend calculation

### DIFF
--- a/app/api/users.py
+++ b/app/api/users.py
@@ -254,7 +254,7 @@ async def _compute_user_spend(
         all_owner_ids.update(uid_set)
 
     key_pair_rows = (
-        db.query(DBPrivateAIKey.team_id, DBPrivateAIKey.region_id)
+        db.query(DBPrivateAIKey.team_id, DBPrivateAIKey.owner_id, DBPrivateAIKey.region_id)
         .filter(
             or_(
                 DBPrivateAIKey.team_id.in_(team_ids),
@@ -265,12 +265,18 @@ async def _compute_user_spend(
         .all()
     )
     key_team_region_set = {(row.team_id, row.region_id) for row in key_pair_rows}
-    key_region_set = {row.region_id for row in key_pair_rows if row.team_id is None}
+    # Per-team set of regions with user-owned keys (team_id=NULL, owner in that team).
+    user_key_regions_by_team: dict[int, set[int]] = defaultdict(set)
+    for row in key_pair_rows:
+        if row.team_id is None and row.owner_id is not None:
+            for tid, uids in user_ids_by_team.items():
+                if row.owner_id in uids:
+                    user_key_regions_by_team[tid].add(row.region_id)
 
     for team_id in team_ids:
         team_name = team_names[team_id]
         for region in regions_by_team.get(team_id, {}).values():
-            if (team_id, region.id) not in key_team_region_set and region.id not in key_region_set:
+            if (team_id, region.id) not in key_team_region_set and region.id not in user_key_regions_by_team.get(team_id, set()):
                 continue
 
             tasks.append(

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
-from sqlalchemy import func
+from sqlalchemy import func, or_
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from typing import List, Optional
@@ -256,18 +256,21 @@ async def _compute_user_spend(
     key_pair_rows = (
         db.query(DBPrivateAIKey.team_id, DBPrivateAIKey.region_id)
         .filter(
-            DBPrivateAIKey.team_id.in_(team_ids),
-            DBPrivateAIKey.owner_id.in_(all_owner_ids),
+            or_(
+                DBPrivateAIKey.team_id.in_(team_ids),
+                DBPrivateAIKey.owner_id.in_(all_owner_ids),
+            )
         )
         .distinct()
         .all()
     )
-    key_exists_set = {(row.team_id, row.region_id) for row in key_pair_rows}
+    key_team_region_set = {(row.team_id, row.region_id) for row in key_pair_rows}
+    key_region_set = {row.region_id for row in key_pair_rows if row.team_id is None}
 
     for team_id in team_ids:
         team_name = team_names[team_id]
         for region in regions_by_team.get(team_id, {}).values():
-            if (team_id, region.id) not in key_exists_set:
+            if (team_id, region.id) not in key_team_region_set and region.id not in key_region_set:
                 continue
 
             tasks.append(

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -376,6 +376,78 @@ def test_get_user_spend_skips_regions_without_user_keys(
 
 
 @patch("app.api.users.LiteLLMService.get_team_info", new_callable=AsyncMock)
+def test_get_user_spend_includes_user_owned_keys(
+    mock_get_team_info, client, admin_token, db
+):
+    """Keys with owner_id set but team_id=NULL should still contribute to user spend."""
+    team = DBTeam(
+        name="User Key Team",
+        admin_email="userkey-team@example.com",
+        is_active=True,
+        created_at=datetime.now(UTC),
+        budget_type="periodic",
+    )
+    region = DBRegion(
+        name="region-userkey",
+        postgres_host="host",
+        postgres_port=5432,
+        postgres_admin_user="postgres",
+        postgres_admin_password="postgres",
+        litellm_api_url="http://litellm.userkey",
+        litellm_api_key="ku",
+        is_active=True,
+        is_dedicated=False,
+    )
+    user = DBUser(
+        email="carol+uk@example.com",
+        hashed_password=get_password_hash("pw"),
+        is_active=True,
+        is_admin=False,
+        team=team,
+    )
+    db.add_all([team, region, user])
+    db.commit()
+    db.refresh(team)
+    db.refresh(region)
+    db.refresh(user)
+
+    # Key with owner_id but NO team_id — this is the regression case.
+    db.add(
+        DBPrivateAIKey(
+            database_name="db-userkey",
+            database_username="u-uk",
+            owner_id=user.id,
+            team_id=None,
+            region_id=region.id,
+        )
+    )
+    db.commit()
+
+    mock_get_team_info.return_value = {
+        "keys": [
+            {
+                "metadata": {"amazeeai_user_id": str(user.id)},
+                "spend": 7.25,
+            }
+        ]
+    }
+
+    response = client.get(
+        "/users/spend?email=carol@example.com",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_spend"] == 7.25
+    assert len(data["teams"]) == 1
+    assert data["teams"][0]["team_id"] == team.id
+    assert len(data["teams"][0]["regions"]) == 1
+    assert data["teams"][0]["regions"][0]["region_name"] == "region-userkey"
+    assert data["teams"][0]["regions"][0]["spend"] == 7.25
+    assert mock_get_team_info.await_count == 1
+
+
+@patch("app.api.users.LiteLLMService.get_team_info", new_callable=AsyncMock)
 def test_get_user_spend_unavailable_region_not_cached(
     mock_get_team_info, client, admin_token, db
 ):


### PR DESCRIPTION
## Summary

- The `/users/spend` endpoint returned $0 for users whose keys have `owner_id` set but `team_id=null`
- Root cause: the query filtering keys required both `team_id IN team_ids` AND `owner_id IN all_owner_ids`, but these fields are mutually exclusive on keys
- Changed to OR logic so user-owned keys (with `team_id=null`) are also found
- Also fixed the lookup set to handle null `team_id` tuples correctly

## Test plan

- [ ] Call `GET /users/spend?email=<user>` for a user with a user-owned key (team_id=null) and verify spend > $0
- [ ] Verify team-owned keys still report spend correctly
- [ ] Check the "User spending" section on the region page shows individual user spend

🤖 Generated with [Claude Code](https://claude.com/claude-code)