### PR TITLE
fix: invalidate user spend cache after member budget set/clear

### DIFF
--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -23,6 +23,7 @@ from app.db.models import (
     DBTeam,
     DBTeamRegion,
     DBUser,
+    DBUserSpendCache,
 )
 from app.schemas.limits import OwnerType, ResourceType
 from app.schemas.models import (
@@ -38,6 +39,25 @@ from app.services.litellm import LiteLLMService
 
 router = APIRouter(tags=["spend"])
 logger = logging.getLogger(__name__)
+
+
+def _invalidate_user_spend_cache(db: Session, email: str) -> None:
+    """Delete the cached spend response for *email* so the next read is fresh.
+
+    Called after any mutation that changes a user's ``max_budget`` or spend
+    cap, because the ``GET /users/spend`` endpoint caches responses for
+    ``_USER_SPEND_CACHE_TTL_SECONDS`` and does not auto-invalidate on writes.
+    """
+    parts = email.lower().rsplit("@", 1)
+    if len(parts) == 2:
+        normalized = f"{parts[0].split('+')[0]}@{parts[1]}"
+    else:
+        normalized = email.lower()
+    db.query(DBUserSpendCache).filter(
+        DBUserSpendCache.normalized_email == normalized
+    ).delete(synchronize_session=False)
+
+
 MONTHLY_BUDGET_DURATION = "1mo"
 
 
@@ -869,6 +889,7 @@ async def update_team_member_budget(
         max_budget=body.max_budget,
         budget_duration=effective_duration,
     )
+    _invalidate_user_spend_cache(db, user.email)
     db.commit()
     return SpendBudgetUpdateResponse(
         scope="team_member",
@@ -1061,6 +1082,7 @@ async def clear_team_member_budget(
     _delete_spend_cap(
         db, scope="team_member", region_id=region_id, team_id=team_id, user_id=user_id
     )
+    _invalidate_user_spend_cache(db, user.email)
     db.commit()
     return SpendBudgetUpdateResponse(
         scope="team_member",

--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.core.limit_service import DEFAULT_MAX_SPEND, LimitService
+from app.api.users import _normalize_email_for_lookup
 from app.core.litellm_user_sync import team_role_for_litellm
 from app.core.roles import UserRole
 from app.core.security import (
@@ -46,13 +47,10 @@ def _invalidate_user_spend_cache(db: Session, email: str) -> None:
 
     Called after any mutation that changes a user's ``max_budget`` or spend
     cap, because the ``GET /users/spend`` endpoint caches responses for
-    ``_USER_SPEND_CACHE_TTL_SECONDS`` and does not auto-invalidate on writes.
+    15 minutes (``_USER_SPEND_CACHE_TTL_SECONDS`` in ``app/api/users.py``)
+    and does not auto-invalidate on writes.
     """
-    parts = email.lower().rsplit("@", 1)
-    if len(parts) == 2:
-        normalized = f"{parts[0].split('+')[0]}@{parts[1]}"
-    else:
-        normalized = email.lower()
+    normalized = _normalize_email_for_lookup(email)
     db.query(DBUserSpendCache).filter(
         DBUserSpendCache.normalized_email == normalized
     ).delete(synchronize_session=False)

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -14,6 +14,7 @@ from app.db.models import (
     DBTeam,
     DBTeamRegion,
     DBUser,
+    DBUserSpendCache,
 )
 
 
@@ -428,6 +429,39 @@ def test_update_team_member_budget_rejects_cap_above_pool_purchases(
     mock_update_team_member.assert_not_awaited()
 
 
+@patch("app.api.spend.LiteLLMService.update_team_member", new_callable=AsyncMock)
+def test_update_team_member_budget_invalidates_spend_cache(
+    mock_update_team_member,
+    client,
+    admin_token,
+    test_team,
+    test_team_user,
+    test_region,
+    db,
+):
+    cache_row = DBUserSpendCache(
+        normalized_email="teamuser@example.com",
+        response_data={"max_budget": 0.5},
+        expires_at=datetime.now(UTC) + timedelta(minutes=15),
+    )
+    db.add(cache_row)
+    db.commit()
+
+    response = client.put(
+        f"/spend/{test_region.id}/team/{test_team.id}/member/{test_team_user.id}/budget",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"max_budget": 1.0},
+    )
+    assert response.status_code == 200
+    db.expire_all()
+    remaining = (
+        db.query(DBUserSpendCache)
+        .filter(DBUserSpendCache.normalized_email == "teamuser@example.com")
+        .first()
+    )
+    assert remaining is None
+
+
 @patch("app.api.spend.logger.warning")
 @patch("app.api.spend.LiteLLMService.get_team_info", new_callable=AsyncMock)
 def test_get_team_spend_logs_when_litellm_key_cannot_map_to_db_key(
@@ -717,6 +751,38 @@ def test_clear_team_member_budget_endpoint_deletes_spend_cap(
             DBSpendCap.team_id == test_team.id,
             DBSpendCap.user_id == test_team_user.id,
         )
+        .first()
+    )
+    assert remaining is None
+
+
+@patch("app.api.spend.LiteLLMService.update_team_member", new_callable=AsyncMock)
+def test_clear_team_member_budget_invalidates_spend_cache(
+    mock_update_team_member,
+    client,
+    admin_token,
+    test_team,
+    test_team_user,
+    test_region,
+    db,
+):
+    cache_row = DBUserSpendCache(
+        normalized_email="teamuser@example.com",
+        response_data={"max_budget": 1.0},
+        expires_at=datetime.now(UTC) + timedelta(minutes=15),
+    )
+    db.add(cache_row)
+    db.commit()
+
+    response = client.post(
+        f"/spend/{test_region.id}/team/{test_team.id}/member/{test_team_user.id}/budget/clear",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    db.expire_all()
+    remaining = (
+        db.query(DBUserSpendCache)
+        .filter(DBUserSpendCache.normalized_email == "teamuser@example.com")
         .first()
     )
     assert remaining is None


### PR DESCRIPTION
## Summary

- `GET /users/spend` caches responses in `DBUserSpendCache` for 15 minutes
- `PUT /{region_id}/team/{team_id}/member/{user_id}/budget` and the corresponding `POST .../budget/clear` update the DB and LiteLLM but never touch the cache
- Result: callers (including the MOAD portal) see a stale `max_budget` for up to 15 minutes after a change, making the UI appear unresponsive

## Fix

Add `_invalidate_user_spend_cache(db, user.email)` and call it in both `update_team_member_budget` and `clear_team_member_budget` **before** `db.commit()`. This deletes the cache row for the affected user's normalized email so the next `GET /users/spend` recomputes from live data.

The normalization mirrors `_normalize_email_for_lookup` in `users.py` (strips `+` suffixes before `@`).

## Test plan

- [ ] Set a member budget → `GET /users/spend?email=...` immediately returns the new `max_budget`
- [ ] Clear a member budget → `GET /users/spend?email=...` immediately returns `max_budget: null`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)