### PR TITLE
fix: use consistent teamId string for LimitsView queryKey in TeamExpansionRow

### DIFF
--- a/frontend/src/app/admin/teams/_components/team-expansion-row.tsx
+++ b/frontend/src/app/admin/teams/_components/team-expansion-row.tsx
@@ -625,8 +625,8 @@ export function TeamExpansionRow({
                       limits={teamLimits}
                       isLoading={isLoadingTeamLimits}
                       ownerType="team"
-                      ownerId={expandedTeam.id}
-                      queryKey={["team-limits", expandedTeam.id]}
+                      ownerId={teamId}
+                      queryKey={["team-limits", teamId]}
                       showResetAll={true}
                       onResetAll={() => resetLimits(expandedTeam.id)}
                       isResettingAll={isResettingLimits}


### PR DESCRIPTION
## Problem

`TeamExpansionRow` registers the team limits query with:

```ts
queryKey: ["team-limits", teamId]  // teamId: string prop
```

But `LimitsView` was called with:

```tsx
queryKey={["team-limits", expandedTeam.id]}  // expandedTeam.id from JSON response
```

`expandedTeam` is the JSON-parsed result of `GET /teams/{teamId}`. Even though the `Team` TypeScript interface declares `id: string`, JSON parsing returns primitive types as-is — if the API returns `{"id": 1}` the runtime value is the **number** `1`, not the string `"1"`.

`teamId` (the prop) is always a string (callers pass `user.id.toString()`). So `["team-limits", 1]` (number) and `["team-limits", "1"]` (string) are **different TanStack Query cache keys** — prefix matching in `invalidateQueries` never finds the registered query, and the team limits table never refreshes after an edit.

## Fix

Pass `teamId` (the string prop) consistently to both `queryKey` and `ownerId` in `LimitsView` instead of `expandedTeam.id`.

## Files changed

- `frontend/src/app/admin/teams/_components/team-expansion-row.tsx`