### PR TITLE
fix: invalidate user spend cache after member budget set/clear

### DIFF
--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -25,6 +25,7 @@ from app.db.models import (
     DBUser,
 )
 from app.schemas.limits import OwnerType, ResourceType
+from app.api.users import invalidate_user_spend_cache
 from app.schemas.models import (
     BudgetType,
     PrivateAIKeySpend,
@@ -870,6 +871,7 @@ async def update_team_member_budget(
         budget_duration=effective_duration,
     )
     db.commit()
+    invalidate_user_spend_cache(db, user.email)
     return SpendBudgetUpdateResponse(
         scope="team_member",
         source_endpoint="/team/member_update",
@@ -1062,6 +1064,7 @@ async def clear_team_member_budget(
         db, scope="team_member", region_id=region_id, team_id=team_id, user_id=user_id
     )
     db.commit()
+    invalidate_user_spend_cache(db, user.email)
     return SpendBudgetUpdateResponse(
         scope="team_member",
         source_endpoint="/team/member_clear",

--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -870,8 +870,8 @@ async def update_team_member_budget(
         max_budget=body.max_budget,
         budget_duration=effective_duration,
     )
-    db.commit()
     invalidate_user_spend_cache(db, user.email)
+    db.commit()
     return SpendBudgetUpdateResponse(
         scope="team_member",
         source_endpoint="/team/member_update",

--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -1064,6 +1064,7 @@ async def clear_team_member_budget(
         db, scope="team_member", region_id=region_id, team_id=team_id, user_id=user_id
     )
     invalidate_user_spend_cache(db, user.email)
+    db.commit()
     return SpendBudgetUpdateResponse(
         scope="team_member",
         source_endpoint="/team/member_clear",

--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -1063,7 +1063,6 @@ async def clear_team_member_budget(
     _delete_spend_cap(
         db, scope="team_member", region_id=region_id, team_id=team_id, user_id=user_id
     )
-    db.commit()
     invalidate_user_spend_cache(db, user.email)
     return SpendBudgetUpdateResponse(
         scope="team_member",

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -75,6 +75,20 @@ def _normalize_email_for_lookup(email: str) -> str:
     return email.lower()
 
 
+def invalidate_user_spend_cache(db: Session, email: str) -> None:
+    """Delete the cached /users/spend response for *email*.
+
+    Call this whenever a write operation (budget set/clear) changes data that
+    the cache stores, so the next GET returns fresh values instead of the
+    15-minute stale snapshot.
+    """
+    normalized = _normalize_email_for_lookup(email)
+    db.query(DBUserSpendCache).filter(
+        DBUserSpendCache.normalized_email == normalized
+    ).delete()
+    db.commit()
+
+
 def _is_valid_email_input(email: str) -> bool:
     at_idx = email.find("@")
     if at_idx <= 0:

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -81,12 +81,15 @@ def invalidate_user_spend_cache(db: Session, email: str) -> None:
     Call this whenever a write operation (budget set/clear) changes data that
     the cache stores, so the next GET returns fresh values instead of the
     15-minute stale snapshot.
+
+    This helper intentionally does not commit; callers control the transaction
+    boundary so cache invalidation remains atomic with the related write.
     """
     normalized = _normalize_email_for_lookup(email)
     db.query(DBUserSpendCache).filter(
         DBUserSpendCache.normalized_email == normalized
-    ).delete()
-    db.commit()
+    ).delete(synchronize_session=False)
+    db.flush()
 
 
 def _is_valid_email_input(email: str) -> bool:


### PR DESCRIPTION
## Problem

`GET /users/spend` caches its response in the `user_spend_cache` table with a **15-minute TTL**.

`update_team_member_budget` and `clear_team_member_budget` in `spend.py` write the new budget to LiteLLM and the `spend_caps` table, but they never touch the cache. The next `GET /users/spend` for that user therefore still returns the pre-write snapshot — for up to 15 minutes — making the change invisible in the UI even though the network request succeeded.

Confirmed via live API tests against teams 331 and 1321:
- `PUT /spend/35/team/331/member/595/budget` → returns `max_budget: 15.0` ✓
- Immediate `GET /users/spend?email=…` → still returns `max_budget: 10.0` (old cached value) ✗
- After 60 s → still stale ✗

## Fix

Add `invalidate_user_spend_cache(db, email)` to `users.py`. It deletes the `user_spend_cache` row for the normalized email, so the next GET recomputes from LiteLLM.

Call it from both write endpoints in `spend.py` immediately after `db.commit()`:
- `update_team_member_budget` — after setting the cap
- `clear_team_member_budget` — after clearing the cap

## Files changed

- `app/api/users.py` — adds `invalidate_user_spend_cache()`
- `app/api/spend.py` — imports and calls it in both member budget write endpoints