### PR TITLE
fix: allow key/user budget limits above team limit for dedicated teams

### DIFF
--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -247,6 +247,11 @@ def _assert_pool_budget_cap_within_purchases(
 ) -> None:
     if team is None or team.budget_type != BudgetType.POOL or max_budget is None:
         return
+    # Dedicated teams (hide_public_regions=True) operate on an infinite budget
+    # represented as $0 in LiteLLM. They don't go through the purchase flow so
+    # the pool-purchase cap does not apply to them.
+    if team.hide_public_regions:
+        return
     purchased_budget = _pool_purchased_budget_for_team_region(db, team.id, region_id)
     if float(max_budget) > purchased_budget:
         raise HTTPException(

--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -247,10 +247,9 @@ def _assert_pool_budget_cap_within_purchases(
 ) -> None:
     if team is None or team.budget_type != BudgetType.POOL or max_budget is None:
         return
-    # Dedicated teams (hide_public_regions=True) operate on an infinite budget
-    # represented as $0 in LiteLLM. They don't go through the purchase flow so
-    # the pool-purchase cap does not apply to them.
-    if team.hide_public_regions:
+    # Dedicated teams operate on a direct budget and do not use the purchase flow,
+    # so the pool-purchase cap does not apply to them.
+    if team.is_dedicated:
         return
     purchased_budget = _pool_purchased_budget_for_team_region(db, team.id, region_id)
     if float(max_budget) > purchased_budget:
@@ -760,15 +759,20 @@ async def update_team_budget(
     month_start_spend = None
 
     if team.budget_type == BudgetType.POOL and body.max_budget is not None:
-        purchased_total = _pool_purchased_budget_for_team_region(db, team_id, region_id)
-        team_info = (await service.get_team_info(lite_team_id)).get("team_info", {})
-        month_start_spend = round(float(team_info.get("spend", 0.0) or 0.0), 4)
-        month_anchor = _current_month_anchor()
-        effective_max_budget = _compute_pool_monthly_effective_budget(
-            purchased_total=purchased_total,
-            month_start_spend=month_start_spend,
-            monthly_cap=body.max_budget,
-        )
+        if team.is_dedicated:
+            # Dedicated teams have no purchase-driven ceiling; the requested
+            # max_budget is used directly without clamping.
+            effective_max_budget = body.max_budget
+        else:
+            purchased_total = _pool_purchased_budget_for_team_region(db, team_id, region_id)
+            team_info = (await service.get_team_info(lite_team_id)).get("team_info", {})
+            month_start_spend = round(float(team_info.get("spend", 0.0) or 0.0), 4)
+            month_anchor = _current_month_anchor()
+            effective_max_budget = _compute_pool_monthly_effective_budget(
+                purchased_total=purchased_total,
+                month_start_spend=month_start_spend,
+                monthly_cap=body.max_budget,
+            )
 
     await service.update_team_budget(
         team_id=lite_team_id,

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -176,6 +176,17 @@ class DBTeam(Base):
     def products(self):
         return [tp.product for tp in self.active_products if tp.product]
 
+    @property
+    def is_dedicated(self) -> bool:
+        """True for dedicated teams that operate on a direct, infinite budget.
+
+        Dedicated teams hide public regions (``hide_public_regions=True``) and are
+        provisioned with private infrastructure — their budget is not driven by the
+        purchase flow. In LiteLLM, ``$0`` represents "no limit" for these teams, so
+        the normal pool-purchase cap does not apply.
+        """
+        return bool(self.hide_public_regions)
+
 
 class DBTeamMetrics(Base):
     """

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -271,6 +271,8 @@ def test_update_pool_budget_allows_any_value_for_dedicated_team(
     )
     assert response.status_code == 200, response.json()
     mock_update_team_budget.assert_awaited_once()
+    assert mock_update_team_budget.await_args.kwargs["max_budget"] == 100.0
+    assert mock_update_team_budget.await_args.kwargs["budget_duration"] == "365d"
 
 
 @patch("app.api.spend.LiteLLMService.get_team_info", new_callable=AsyncMock)
@@ -488,6 +490,7 @@ def test_update_pool_member_budget_allows_any_value_for_dedicated_team(
     )
     assert response.status_code == 200, response.json()
     mock_update_team_member.assert_awaited_once()
+    assert mock_update_team_member.await_args.kwargs["max_budget_in_team"] == 60.0
 
 
 @patch("app.api.spend.logger.warning")
@@ -711,6 +714,7 @@ def test_update_pool_key_budget_allows_any_value_for_dedicated_team(
     )
     assert response.status_code == 200, response.json()
     mock_update_key_budget.assert_awaited_once()
+    assert mock_update_key_budget.await_args.kwargs["max_budget"] == 50.0
 
 
 @patch("app.api.spend.LiteLLMService.get_key_info", new_callable=AsyncMock)

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -242,6 +242,39 @@ def test_update_team_budget_rejects_cap_above_pool_purchases(
 
 @patch("app.api.spend.LiteLLMService.get_team_info", new_callable=AsyncMock)
 @patch("app.api.spend.LiteLLMService.update_team_budget", new_callable=AsyncMock)
+def test_update_pool_budget_allows_any_value_for_dedicated_team(
+    mock_update_team_budget,
+    mock_get_team_info,
+    client,
+    admin_token,
+    test_team,
+    test_region,
+    db,
+):
+    """Dedicated POOL teams ($0 = infinite) must not be blocked by the purchase cap."""
+    test_team.budget_type = "pool"
+    test_team.hide_public_regions = True
+    db.add(test_team)
+    db.commit()
+
+    mock_get_team_info.return_value = {
+        "team_info": {"max_budget": 100.0, "budget_duration": "365d"}
+    }
+    mock_update_team_budget.return_value = None
+
+    # No purchases recorded – pool purchased_budget = 0.
+    # The request should still succeed because the team is dedicated.
+    response = client.put(
+        f"/spend/{test_region.id}/team/{test_team.id}/budget",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"max_budget": 100.0},
+    )
+    assert response.status_code == 200, response.json()
+    mock_update_team_budget.assert_awaited_once()
+
+
+@patch("app.api.spend.LiteLLMService.get_team_info", new_callable=AsyncMock)
+@patch("app.api.spend.LiteLLMService.update_team_budget", new_callable=AsyncMock)
 def test_update_pool_team_budget_uses_pool_duration(
     mock_update_team_budget,
     mock_get_team_info,
@@ -428,6 +461,35 @@ def test_update_team_member_budget_rejects_cap_above_pool_purchases(
     mock_update_team_member.assert_not_awaited()
 
 
+@patch("app.api.spend.LiteLLMService.update_team_member", new_callable=AsyncMock)
+def test_update_pool_member_budget_allows_any_value_for_dedicated_team(
+    mock_update_team_member,
+    client,
+    admin_token,
+    test_team,
+    test_team_user,
+    test_region,
+    db,
+):
+    """Dedicated POOL teams must allow setting a member budget above $0 purchases."""
+    test_team.budget_type = "pool"
+    test_team.hide_public_regions = True
+    test_team_user.team_id = test_team.id
+    db.add(test_team)
+    db.add(test_team_user)
+    db.commit()
+
+    mock_update_team_member.return_value = None
+
+    response = client.put(
+        f"/spend/{test_region.id}/team/{test_team.id}/member/{test_team_user.id}/budget",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"max_budget": 60.0},
+    )
+    assert response.status_code == 200, response.json()
+    mock_update_team_member.assert_awaited_once()
+
+
 @patch("app.api.spend.logger.warning")
 @patch("app.api.spend.LiteLLMService.get_team_info", new_callable=AsyncMock)
 def test_get_team_spend_logs_when_litellm_key_cannot_map_to_db_key(
@@ -609,6 +671,46 @@ def test_update_key_budget_rejects_cap_above_pool_purchases(
     assert response.status_code == 400
     assert "cannot exceed purchased pool budget" in response.json()["detail"]
     mock_update_key_budget.assert_not_awaited()
+
+
+@patch("app.api.spend.LiteLLMService.get_key_info", new_callable=AsyncMock)
+@patch("app.api.spend.LiteLLMService.update_key_budget", new_callable=AsyncMock)
+def test_update_pool_key_budget_allows_any_value_for_dedicated_team(
+    mock_update_key_budget,
+    mock_get_key_info,
+    client,
+    admin_token,
+    test_team,
+    test_region,
+    db,
+):
+    """Dedicated POOL teams must allow setting a key budget above $0 purchases."""
+    test_team.budget_type = "pool"
+    test_team.hide_public_regions = True
+    db.add(test_team)
+    db.commit()
+
+    key = DBPrivateAIKey(
+        name="dedicated-key",
+        litellm_token="dedicated-key-token",
+        region_id=test_region.id,
+        team_id=test_team.id,
+    )
+    db.add(key)
+    db.commit()
+
+    mock_get_key_info.return_value = {
+        "info": {"max_budget": 50.0, "budget_duration": "1mo"}
+    }
+    mock_update_key_budget.return_value = None
+
+    response = client.put(
+        f"/spend/{test_region.id}/key/{key.id}/budget",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"max_budget": 50.0},
+    )
+    assert response.status_code == 200, response.json()
+    mock_update_key_budget.assert_awaited_once()
 
 
 @patch("app.api.spend.LiteLLMService.get_key_info", new_callable=AsyncMock)


### PR DESCRIPTION
## Problem

`_assert_pool_budget_cap_within_purchases` blocks any positive budget on a POOL team whenever `purchased_budget == 0`. Dedicated teams (`hide_public_regions = True`) never go through the purchase flow — their budget is intentionally `$0` in LiteLLM, which represents **infinite/no-limit**. As a result, admins couldn't set any key, user, or team-member budget for these teams.

## Fix

Add an early-return guard in `_assert_pool_budget_cap_within_purchases`:

```python
# Dedicated teams operate on an infinite budget ($0 = no limit).
# They don't use the purchase flow, so the cap check does not apply.
if team.hide_public_regions:
    return
```

This is the only place the purchase-cap is enforced; all three spend endpoints (`/team/{id}/budget`, `/team/{id}/member/{uid}/budget`, `/key/{id}/budget`) call this helper.

## Tests

Three new regression tests in `tests/test_spend.py`:
- `test_update_pool_budget_allows_any_value_for_dedicated_team`
- `test_update_pool_member_budget_allows_any_value_for_dedicated_team`
- `test_update_pool_key_budget_allows_any_value_for_dedicated_team`

Each sets up a POOL team with `hide_public_regions=True` and zero purchases, then asserts that a positive `max_budget` is accepted (previously rejected with HTTP 400).
