### PR TITLE
fix: skip per-key limits for pool budget teams

### DIFF
--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -11,6 +11,7 @@ from app.schemas.models import (
     PrivateAIKeyCreate,
     PrivateAIKeySpend,
     BudgetPeriodUpdate,
+    BudgetType,
     LiteLLMToken,
     VectorDBCreate,
     VectorDB,
@@ -401,13 +402,32 @@ async def create_llm_token(
             owner_id = current_user.id
             owner = current_user
 
+    # Pool budget teams use purchase_pool_budget to set the team-level
+    # max_budget in LiteLLM. Per-key limits are meaningless there — the team
+    # budget is the sole ceiling. Skip limit resolution entirely for pool teams.
+    effective_team_id = (owner.team_id if owner is not None else None) or team_id
+    effective_team = (
+        db.query(DBTeam).filter(DBTeam.id == effective_team_id).first()
+        if effective_team_id
+        else None
+    )
+    is_pool_team = (
+        effective_team is not None
+        and effective_team.budget_type == BudgetType.POOL
+    )
+
     if (owner is not None and owner.team_id) or team_id:
-        if settings.ENABLE_LIMITS:
+        if settings.ENABLE_LIMITS and not is_pool_team:
             limit_service.check_key_limits(owner.team_id or team_id, owner_id)
-        # Limits are conditionally applied in LiteLLM service
-        days_left_in_period, max_max_spend, max_rpm_limit = (
-            limit_service.get_token_restrictions(owner.team_id or team_id)
-        )
+        if is_pool_team:
+            days_left_in_period = None
+            max_max_spend = None
+            max_rpm_limit = None
+        else:
+            # Limits are conditionally applied in LiteLLM service
+            days_left_in_period, max_max_spend, max_rpm_limit = (
+                limit_service.get_token_restrictions(owner.team_id or team_id)
+            )
     else:  # Super system users...
         days_left_in_period = DEFAULT_KEY_DURATION
         max_max_spend = DEFAULT_MAX_SPEND
@@ -434,9 +454,10 @@ async def create_llm_token(
             name=private_ai_key.name,
             user_id=owner_id,
             team_id=LiteLLMService.format_team_id(region.name, litellm_team),
-            duration=f"{days_left_in_period}d",
+            duration=f"{days_left_in_period}d" if days_left_in_period is not None else None,
             max_budget=max_max_spend,
             rpm_limit=max_rpm_limit,
+            apply_limits=not is_pool_team,
         )
 
         # Create response object

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -78,9 +78,10 @@ class LiteLLMService:
         name: str,
         user_id: int,
         team_id: str,
-        duration: str = f"{DEFAULT_KEY_DURATION}d",
-        max_budget: float = DEFAULT_MAX_SPEND,
-        rpm_limit: int = DEFAULT_RPM_PER_KEY,
+        duration: Optional[str] = f"{DEFAULT_KEY_DURATION}d",
+        max_budget: Optional[float] = DEFAULT_MAX_SPEND,
+        rpm_limit: Optional[int] = DEFAULT_RPM_PER_KEY,
+        apply_limits: bool = True,
     ) -> str:
         """Create a new API key for LiteLLM"""
         try:
@@ -117,13 +118,14 @@ class LiteLLMService:
             request_data["metadata"] = metadata
             request_data["team_id"] = team_id
 
-            if settings.ENABLE_LIMITS:
-                request_data["duration"] = "365d"  # Sets the expiry date for the key
+            request_data["duration"] = "365d"  # Sets the key expiry date
+            if settings.ENABLE_LIMITS and apply_limits:
+                # Per-key budget limits. Skipped for pool budget teams — the
+                # team-level max_budget set by purchase_pool_budget is the
+                # sole spending ceiling for those teams.
                 request_data["budget_duration"] = duration
                 request_data["max_budget"] = max_budget
                 request_data["rpm_limit"] = rpm_limit
-            else:
-                request_data["duration"] = "365d"
 
             if user_id is not None:
                 request_data["user_id"] = str(user_id)


### PR DESCRIPTION
## Problem

Teams created through moad use `budget_type = pool`. Their spending ceiling is managed entirely at the team level via `purchase_pool_budget`, which sets the LiteLLM team-level `max_budget`. Per-key limits (`user_key: 1`, `service_key: 5`, `max_budget`, `rpm_limit`, `duration`) are meaningless in this model and actively block key creation once the default count limit is hit.

The user-count check already had a pool bypass (`check_team_user_limit` returns early for pool teams). Key limits had no equivalent bypass.

## Changes

**`app/api/private_ai_keys.py`**
- Resolve the team's `budget_type` before the limits block in `create_llm_token`
- Skip `check_key_limits` for pool teams (no count enforcement)
- Skip `get_token_restrictions` for pool teams — pass `None` for `days_left_in_period`, `max_max_spend`, `max_rpm_limit`
- Pass `apply_limits=False` to `LiteLLMService.create_key` for pool teams

**`app/services/litellm.py`**
- Add `apply_limits: bool = True` parameter to `create_key`
- Gate `budget_duration`, `max_budget`, `rpm_limit` on `apply_limits` (not just `ENABLE_LIMITS`)
- `duration` / `max_budget` / `rpm_limit` params become `Optional` to accommodate `None` from pool-team callers
- Key expiry (`duration = "365d"`) is always set regardless of `apply_limits` — pool team keys still expire

## Consistency with existing behaviour

| Check | Periodic teams | Pool teams (before) | Pool teams (after) |
|---|---|---|---|
| User count limit | enforced | **bypassed** (existing) | bypassed |
| Key count limit | enforced | enforced | **bypassed** |
| Per-key budget/RPM | enforced | enforced | **bypassed** |
| Key expiry | enforced | enforced | enforced |