### PR TITLE
Add doc staleness check workflow

### DIFF
--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -65,7 +65,7 @@ jobs:
           FILES=$(cat /tmp/matched_files.txt)
           DIFF=$(cat /tmp/diff_truncated.txt)
           PR_BODY=$(cat /tmp/pr_body.txt)
-          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_TITLE="${PR_TITLE}"
 
           PROMPT=$(cat <<'PROMPT_END'
           You are a technical writer for amazee.ai documentation (docs.amazee.ai).
@@ -113,13 +113,15 @@ jobs:
         env:
           AMAZEEAI_API_KEY: ${{ secrets.AMAZEEAI_API_KEY }}
           AMAZEEAI_ENDPOINT: ${{ vars.AMAZEEAI_ENDPOINT || 'https://llm.us104.amazee.ai' }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
 
       - name: Open docs issue
         if: steps.check.outputs.has_matches == 'true'
         env:
           GH_TOKEN: ${{ secrets.DOCS_ISSUE_TOKEN }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_TITLE="${PR_TITLE}"
           PR_URL="${{ github.event.pull_request.html_url }}"
           PR_NUM="${{ github.event.pull_request.number }}"
           FILES=$(cat /tmp/matched_files.txt)
@@ -146,14 +148,15 @@ jobs:
             exit 0
           fi
 
+          BACKTICKS='```'
           cat > /tmp/docs_issue_body.md <<EOF
           ### Source PR
           ${PR_URL}
 
           ### Changed files with doc implications
-          ```
+          ${BACKTICKS}
           ${FILES}
-          ```
+          ${BACKTICKS}
 
           ${DRAFT_SECTION}
           ### Action needed

--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -13,11 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get changed files
-        id: changed
         run: |
           FILES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only)
           echo "$FILES" > /tmp/all_changed.txt
-          echo "count=$(echo "$FILES" | wc -l)" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -114,7 +114,7 @@ jobs:
           fi
         env:
           AMAZEEAI_API_KEY: ${{ secrets.AMAZEEAI_API_KEY }}
-          AMAZEEAI_ENDPOINT: ${{ vars.AMAZEEAI_ENDPOINT || 'https://llm.ch103.amazee.ai' }}
+          AMAZEEAI_ENDPOINT: ${{ vars.AMAZEEAI_ENDPOINT || 'https://llm.us104.amazee.ai' }}
 
       - name: Open docs issue
         if: steps.check.outputs.has_matches == 'true'

--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -12,10 +12,6 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Get changed files
         id: changed
         run: |

--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -100,7 +100,7 @@ jobs:
               }')" 2>/dev/null) || true
 
           if [ -n "$RESPONSE" ]; then
-            DRAFT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // empty')
+            DRAFT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // empty' 2>/dev/null) || DRAFT=""
             if [ -n "$DRAFT" ]; then
               echo "$DRAFT" > /tmp/doc_draft.txt
               echo "has_draft=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -65,7 +65,6 @@ jobs:
           FILES=$(cat /tmp/matched_files.txt)
           DIFF=$(cat /tmp/diff_truncated.txt)
           PR_BODY=$(cat /tmp/pr_body.txt)
-          PR_TITLE="${PR_TITLE}"
 
           PROMPT=$(cat <<'PROMPT_END'
           You are a technical writer for amazee.ai documentation (docs.amazee.ai).
@@ -121,7 +120,6 @@ jobs:
           GH_TOKEN: ${{ secrets.DOCS_ISSUE_TOKEN }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          PR_TITLE="${PR_TITLE}"
           PR_URL="${{ github.event.pull_request.html_url }}"
           PR_NUM="${{ github.event.pull_request.number }}"
           FILES=$(cat /tmp/matched_files.txt)

--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -152,7 +152,6 @@ jobs:
             exit 0
           fi
 
-          gh issue create \
           cat > /tmp/docs_issue_body.md <<EOF
           ### Source PR
           ${PR_URL}

--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -155,6 +155,7 @@ jobs:
           ${FILES}
           ```
 
+          ${DRAFT_SECTION}
           ### Action needed
           Review whether [docs.amazee.ai](https://docs.amazee.ai) needs updating based on this change.
 

--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -37,19 +37,20 @@ jobs:
             "^README.md"
           )
 
-          MATCHES=""
+          HAS_MATCHES=false
+          : > /tmp/matched_files.txt
           while IFS= read -r file; do
             for pattern in "${PATTERNS[@]}"; do
               if echo "$file" | grep -qE "$pattern"; then
-                MATCHES="${MATCHES}${file}\n"
+                printf '%s\n' "$file" >> /tmp/matched_files.txt
+                HAS_MATCHES=true
                 break
               fi
             done
           done < /tmp/all_changed.txt
 
-          if [ -n "$MATCHES" ]; then
+          if [ "$HAS_MATCHES" = true ]; then
             echo "has_matches=true" >> "$GITHUB_OUTPUT"
-            echo -e "$MATCHES" > /tmp/matched_files.txt
           else
             echo "has_matches=false" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -153,20 +153,24 @@ jobs:
           fi
 
           gh issue create \
-            --repo amazeeio/docs.amazee.ai \
-            --title "[auto] amazee.ai #${PR_NUM}: ${PR_TITLE}" \
-            --body "### Source PR
+          cat > /tmp/docs_issue_body.md <<EOF
+          ### Source PR
           ${PR_URL}
 
           ### Changed files with doc implications
-          \`\`\`
+          ```
           ${FILES}
-          \`\`\`
+          ```
 
-          ${DRAFT_SECTION}
           ### Action needed
           Review whether [docs.amazee.ai](https://docs.amazee.ai) needs updating based on this change.
 
           - If **yes** → open a PR against [docs.amazee.ai](https://github.com/amazeeio/docs.amazee.ai)
-          - If **no** → close this issue" \
+          - If **no** → close this issue
+          EOF
+
+          gh issue create \
+            --repo amazeeio/docs.amazee.ai \
+            --title "[auto] amazee.ai #${PR_NUM}: ${PR_TITLE}" \
+            --body-file /tmp/docs_issue_body.md \
             --label "auto-triage,amazee.ai"

--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -51,6 +51,71 @@ jobs:
             echo "has_matches=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Get PR diff for LLM context
+        if: steps.check.outputs.has_matches == 'true'
+        run: |
+          gh pr diff ${{ github.event.pull_request.number }} > /tmp/full_diff.txt 2>/dev/null || true
+          head -c 8000 /tmp/full_diff.txt > /tmp/diff_truncated.txt
+          gh pr view ${{ github.event.pull_request.number }} --json body --jq '.body' > /tmp/pr_body.txt 2>/dev/null || true
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Draft doc update via amazee.ai
+        if: steps.check.outputs.has_matches == 'true'
+        id: draft
+        run: |
+          FILES=$(cat /tmp/matched_files.txt)
+          DIFF=$(cat /tmp/diff_truncated.txt)
+          PR_BODY=$(cat /tmp/pr_body.txt)
+          PR_TITLE="${{ github.event.pull_request.title }}"
+
+          PROMPT=$(cat <<'PROMPT_END'
+          You are a technical writer for amazee.ai documentation (docs.amazee.ai).
+          Given a PR title, description, changed files, and diff from an internal repo,
+          draft a short, customer-facing doc update. Write in plain language — no jargon,
+          no internal details, no implementation specifics customers don't need.
+
+          If this is a bug fix with no user-facing impact, just say "No customer-facing doc update needed — internal fix only."
+
+          If it IS user-facing, write 1-3 paragraphs that could be dropped into a doc page.
+          Include what changed, why it matters to users, and any action they need to take.
+          PROMPT_END
+          )
+
+          RESPONSE=$(curl -sf --max-time 30 \
+            "${AMAZEEAI_ENDPOINT}/v1/chat/completions" \
+            -H "Authorization: Bearer ${AMAZEEAI_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+              --arg prompt "$PROMPT" \
+              --arg title "$PR_TITLE" \
+              --arg body "$PR_BODY" \
+              --arg files "$FILES" \
+              --arg diff "$DIFF" \
+              '{
+                model: "claude-haiku-4-5",
+                max_tokens: 1024,
+                messages: [
+                  {role: "system", content: $prompt},
+                  {role: "user", content: ("PR: " + $title + "\n\nDescription:\n" + $body + "\n\nChanged files:\n" + $files + "\n\nDiff (truncated):\n" + $diff)}
+                ]
+              }')" 2>/dev/null) || true
+
+          if [ -n "$RESPONSE" ]; then
+            DRAFT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // empty')
+            if [ -n "$DRAFT" ]; then
+              echo "$DRAFT" > /tmp/doc_draft.txt
+              echo "has_draft=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "has_draft=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "has_draft=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          AMAZEEAI_API_KEY: ${{ secrets.AMAZEEAI_API_KEY }}
+          AMAZEEAI_ENDPOINT: ${{ vars.AMAZEEAI_ENDPOINT || 'https://llm.ch103.amazee.ai' }}
+
       - name: Open docs issue
         if: steps.check.outputs.has_matches == 'true'
         env:
@@ -60,6 +125,17 @@ jobs:
           PR_URL="${{ github.event.pull_request.html_url }}"
           PR_NUM="${{ github.event.pull_request.number }}"
           FILES=$(cat /tmp/matched_files.txt)
+
+          DRAFT_SECTION=""
+          if [ "${{ steps.draft.outputs.has_draft }}" = "true" ]; then
+            DRAFT=$(cat /tmp/doc_draft.txt)
+            DRAFT_SECTION="### Draft doc update (AI-generated — review before using)
+
+          ${DRAFT}
+
+          ---
+          "
+          fi
 
           EXISTING=$(gh issue list \
             --repo amazeeio/docs.amazee.ai \
@@ -83,6 +159,7 @@ jobs:
           ${FILES}
           \`\`\`
 
+          ${DRAFT_SECTION}
           ### Action needed
           Review whether [docs.amazee.ai](https://docs.amazee.ai) needs updating based on this change.
 

--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   check-doc-impact:
     if: github.event.pull_request.merged == true
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -1,0 +1,91 @@
+name: Doc staleness check
+on:
+  pull_request:
+    types: [closed]
+    branches: [main, dev]
+
+jobs:
+  check-doc-impact:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed
+        run: |
+          FILES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only)
+          echo "$FILES" > /tmp/all_changed.txt
+          echo "count=$(echo "$FILES" | wc -l)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Check for doc-impacting changes
+        id: check
+        run: |
+          # Paths that signal a potential doc update is needed
+          PATTERNS=(
+            "^docs/"
+            "^app/schemas/"
+            "^app/api/"
+            "^helm/"
+            "^README.md"
+          )
+
+          MATCHES=""
+          while IFS= read -r file; do
+            for pattern in "${PATTERNS[@]}"; do
+              if echo "$file" | grep -qE "$pattern"; then
+                MATCHES="${MATCHES}${file}\n"
+                break
+              fi
+            done
+          done < /tmp/all_changed.txt
+
+          if [ -n "$MATCHES" ]; then
+            echo "has_matches=true" >> "$GITHUB_OUTPUT"
+            echo -e "$MATCHES" > /tmp/matched_files.txt
+          else
+            echo "has_matches=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open docs issue
+        if: steps.check.outputs.has_matches == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_ISSUE_TOKEN }}
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          PR_NUM="${{ github.event.pull_request.number }}"
+          FILES=$(cat /tmp/matched_files.txt)
+
+          EXISTING=$(gh issue list \
+            --repo amazeeio/docs.amazee.ai \
+            --label "auto-triage,amazee.ai" \
+            --search "amazee.ai #${PR_NUM}" \
+            --json number --jq 'length')
+
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "Issue already exists for this PR, skipping"
+            exit 0
+          fi
+
+          gh issue create \
+            --repo amazeeio/docs.amazee.ai \
+            --title "[auto] amazee.ai #${PR_NUM}: ${PR_TITLE}" \
+            --body "### Source PR
+          ${PR_URL}
+
+          ### Changed files with doc implications
+          \`\`\`
+          ${FILES}
+          \`\`\`
+
+          ### Action needed
+          Review whether [docs.amazee.ai](https://docs.amazee.ai) needs updating based on this change.
+
+          - If **yes** → open a PR against [docs.amazee.ai](https://github.com/amazeeio/docs.amazee.ai)
+          - If **no** → close this issue" \
+            --label "auto-triage,amazee.ai"


### PR DESCRIPTION
### What this does

When a PR is merged to `main` or `dev`, this workflow checks if any doc-relevant files changed:
- `docs/`
- `app/schemas/`
- `app/api/`
- `helm/`
- `README.md`

If matches are found, it auto-opens an issue in [`docs.amazee.ai`](https://github.com/amazeeio/docs.amazee.ai) with the file list and PR link, labeled `auto-triage` + `amazee.ai`.

### Setup needed
Requires org-level Actions secret `DOCS_ISSUE_TOKEN` — a PAT with `repo` scope for cross-repo issue creation.