### PR TITLE
fix(api): handle team_id assignment in create_llm_token function

### DIFF
--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -475,6 +475,21 @@ async def create_llm_token(
             status_code=status.HTTP_404_NOT_FOUND, detail="Owner or team not found"
         )
 
+    # DB team_id follows the ownership decision (not LiteLLM scoping).
+    # force_user_keys clears team_id/team above — that must be respected.
+    # When no team was ever in the request but the owner has one, resolve it.
+    # Track whether team_id was originally provided so we don't re-introduce
+    # a team after force_user_keys cleared it.
+    _original_team_id = private_ai_key.team_id
+    db_team_id = team_id
+    if (
+        db_team_id is None
+        and _original_team_id is None
+        and owner is not None
+        and owner.team_id
+    ):
+        db_team_id = owner.team_id
+
     try:
         # Generate LiteLLM token
         litellm_service = LiteLLMService(
@@ -509,7 +524,7 @@ async def create_llm_token(
             litellm_token=litellm_token,
             litellm_api_url=region.litellm_api_url,
             owner_id=owner_id,
-            team_id=litellm_team if litellm_team != FAKE_ID else None,
+            team_id=db_team_id,
             name=private_ai_key.name,
             region_id=private_ai_key.region_id,
         )

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -509,7 +509,7 @@ async def create_llm_token(
             litellm_token=litellm_token,
             litellm_api_url=region.litellm_api_url,
             owner_id=owner_id,
-            team_id=None if team_id is None else team_id,
+            team_id=litellm_team if litellm_team != FAKE_ID else None,
             name=private_ai_key.name,
             region_id=private_ai_key.region_id,
         )


### PR DESCRIPTION
## What

Fix `create_llm_token()` to resolve `team_id` from the owner's team when no explicit `team_id` is provided in the request.

## Why

When a key is created with only `owner_id` (e.g. amazeeClaw webhook, E2E tests), the function correctly resolves the owner's team for LiteLLM but writes `team_id = NULL` to the database. This causes budget sync, admin UI, and team key lookups to miss these keys.

**Scale:** 121 of 451 keys (27%) in production have `team_id = NULL`.

## Change

In `private_ai_keys.py`, after the LiteLLM team resolution block, derive `db_team_id` from the ownership decision — falling back to `owner.team_id` only when `team_id` was never in the original request. This respects the `force_user_keys` flow (which explicitly clears `team_id`).

Closes #455 (Bug #2)