### PR TITLE
fix: pass team_id and user_id to _delete_spend_cap in clear_key_budget

### DIFF
--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -1446,7 +1446,14 @@ async def clear_key_budget(
         max_budget=None,
         clear_max_budget=True,
     )
-    _delete_spend_cap(db, scope="key", region_id=region_id, key_id=key_id)
+    _delete_spend_cap(
+        db,
+        scope="key",
+        region_id=region_id,
+        team_id=key.team_id,
+        user_id=key.owner_id,
+        key_id=key_id,
+    )
     _invalidate_key_related_user_spend_cache(db, key)
     key_info = await service.get_key_info(key.litellm_token)
     db.commit()


### PR DESCRIPTION
## Problem

`clear_key_budget` (`POST /spend/{region_id}/key/{key_id}/budget/clear`) called `_delete_spend_cap` without `team_id` or `user_id`:

```python
# before
_delete_spend_cap(db, scope="key", region_id=region_id, key_id=key_id)
```

`_delete_spend_cap` filters on all five identity columns. The two omitted parameters defaulted to `None`, which SQLAlchemy translates to `IS NULL`. When the spend cap was stored with a non-null `team_id` / `owner_id` (the normal case for team keys), the `DELETE` matched zero rows — the cap silently survived.

On subsequent reads (`GET /spend/{region_id}/key/{key_id}`), `_get_spend_cap_max_budget` found the un-deleted cap and returned the old `max_budget`, making it appear as if the clear had no effect.

## Fix

Pass `team_id=key.team_id` and `user_id=key.owner_id`, consistent with how every other call site (e.g. `clear_team_member_budget`) already supplies the full set of identity fields.

```python
# after
_delete_spend_cap(
    db,
    scope="key",
    region_id=region_id,
    team_id=key.team_id,
    user_id=key.owner_id,
    key_id=key_id,
)
```
