### PR TITLE
Remove pricing dashboard links from trial emails

### DIFF
--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -896,7 +896,6 @@ def _send_expiry_notification(
                     template_data = {
                         "name": team.name,
                         "days_remaining": days_remaining,
-                        "dashboard_url": generate_pricing_url(admin_email),
                     }
                     ses_service.send_email(
                         to_addresses=[admin_email],
@@ -924,7 +923,6 @@ def _send_expiry_notification(
                 if admin_email and ses_service:
                     template_data = {
                         "name": team.name,
-                        "dashboard_url": generate_pricing_url(admin_email),
                     }
                     ses_service.send_email(
                         to_addresses=[admin_email],

--- a/app/templates/team-expiring.md
+++ b/app/templates/team-expiring.md
@@ -1,16 +1,13 @@
 Your amazee.ai trial is ending - Let's keep going!
 Hi {{name}},
+
 Your free trial of amazee.ai is ending soon, and we hope you've enjoyed
 building with private AI using your amazee.ai account.
 
 Ready to keep going?
-Select your subscription plan to continue using amazee.ai
-without interruption. All your configurations will remain exactly as
-they are.
-
-{{dashboard_url}}
-
-Questions about plans or pricing? Please email ai.support@amazee.io.
+Reach out to us at [ai.support@amazee.io](mailto:ai.support@amazee.io)
+to find the right plan. We'll make sure there's no interruption and all
+your configurations stay exactly as they are.
 
 Thanks for trying amazee.ai!
 

--- a/app/templates/trial-expired.md
+++ b/app/templates/trial-expired.md
@@ -5,15 +5,10 @@ Your free trial of amazee.ai has ended, and we hope you've enjoyed
 building with private AI using your amazee.ai account.
 
 Want to continue using amazee.ai?
-Select from the following subscription plans. All your configurations will remain exactly as
-they are.
+We'd love to set you up with the right plan. Reach out to us at
+[ai.support@amazee.io](mailto:ai.support@amazee.io) and we'll get you sorted.
 
-{{dashboard_url}}
-
-Not ready to sign-up just yet? That's okay! We'll be here when you're ready
-to continue your amazee.ai journey.
-
-Questions about plans or pricing? Please email ai.support@amazee.io.
+All your configurations are saved and ready to go once you're subscribed.
 
 Thanks for trying amazee.ai!
 


### PR DESCRIPTION
## What

Replace the pricing dashboard CTAs in trial lifecycle emails with a "reach out to us" message. The pricing dashboard is being retired — self-serve onboarding will move to my.amazee.io once that flow is built.

## Changes

- **`app/templates/trial-expired.md`** — CTA now says "reach out to ai.support@amazee.io" instead of linking to `/upgrade`
- **`app/templates/team-expiring.md`** — same treatment
- **`app/core/worker.py`** — removed `generate_pricing_url()` calls from both `template_data` dicts (no more throwaway JWT generation for dead links)

## Not changed

- **`always-free`** email — admin-triggered, low priority, leaving as-is for now
- **`returning-user-url`** auth flow — separate concern, still uses `generate_pricing_url()`
- **`generate_pricing_url()` function** — still needed by the above two, kept in place