### PR TITLE
fix(init): re-stamp alembic when schema gap detected before migration

### DIFF
--- a/app/migrations/versions/20260429_061000_f1c2d3e4a5b6_replace_funding_mode_with_purchase_gate.py
+++ b/app/migrations/versions/20260429_061000_f1c2d3e4a5b6_replace_funding_mode_with_purchase_gate.py
@@ -17,6 +17,19 @@ down_revision: Union[str, None] = "f4d2c6a9b1e7"
 
 
 def upgrade() -> None:
+    # Idempotent: skip if column already exists (can happen when alembic
+    # stamp was ahead of actual schema and migrations are being replayed).
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name = 'teams' AND column_name = 'require_purchase_for_requests'"
+        )
+    )
+    if result.fetchone():
+        print("Column 'require_purchase_for_requests' already exists - skipping")
+        return
+
     op.add_column(
         "teams",
         sa.Column(

--- a/scripts/initialise_resources.py
+++ b/scripts/initialise_resources.py
@@ -56,7 +56,7 @@ def _restamp_to_safe_revision(
     alembic_cfg: alembic.config.Config, inspector: Inspector
 ) -> None:
     """Re-stamp alembic to the ``down_revision`` of the first migration
-    (from head backwards) whose schema effects are missing from the DB.
+    (walking from head backwards) whose schema effects are missing.
 
     This handles the case where ``alembic_version`` was stamped past
     migrations that never actually ran (e.g. a ``create_all`` +
@@ -76,103 +76,57 @@ def _restamp_to_safe_revision(
             }
         return db_columns_cache[table_name]
 
+    # Walk linearly from head backwards.  Find the first revision (from
+    # head) whose schema effects are NOT present.  Stamp to its
+    # down_revision so ``upgrade head`` can replay it and everything after.
     revision = script.get_current_head()
     if revision is None:
         print("Could not determine alembic head revision - skipping re-stamp")
         return
 
-    pending = [revision]
-    visited: set[str] = set()
-    missing_revisions: set[str] = set()
-    parent_map: dict[str, tuple[str, ...]] = {}
-
-    while pending:
-        current_revision = pending.pop()
-        if current_revision in visited:
-            continue
-        visited.add(current_revision)
-
-        rev_obj = script.get_revision(current_revision)
+    while revision:
+        rev_obj = script.get_revision(revision)
         if rev_obj is None:
-            print(
-                f"Could not resolve revision {current_revision} - skipping re-stamp"
-            )
-            return
-
-        path = getattr(rev_obj, "path", None)
-        if not path:
-            print(
-                f"Could not read source path for revision {current_revision} - skipping re-stamp"
-            )
-            return
+            break
 
         try:
-            source = pathlib.Path(path).read_text()
-        except Exception as exc:
-            print(
-                f"Could not analyze migration {current_revision} ({exc}) - skipping re-stamp"
-            )
+            source = pathlib.Path(rev_obj.module.__file__).read_text()
+        except Exception:
+            break
+
+        if _migration_has_missing_ops(source, db_tables, _get_columns):
+            # This revision hasn't been applied – stamp to its parent
+            # so ``upgrade head`` will replay from there.
+            down = rev_obj.down_revision
+            if isinstance(down, tuple):
+                down = down[0]
+            stamp_target = down or "base"
+            print(f"Re-stamping alembic to revision: {stamp_target}")
+            alembic.command.stamp(alembic_cfg, stamp_target)
             return
 
-        has_relevant_ops, creates_missing = _migration_has_missing_ops(
-            source, db_tables, _get_columns
-        )
+        # This revision is applied – keep walking back
+        down = rev_obj.down_revision
+        if isinstance(down, tuple):
+            down = down[0]
+        revision = down
 
-        down_revision = rev_obj.down_revision
-        if down_revision is None:
-            parents: tuple[str, ...] = ()
-        elif isinstance(down_revision, tuple):
-            parents = down_revision
-        else:
-            parents = (down_revision,)
-        parent_map[current_revision] = parents
-
-        if creates_missing:
-            missing_revisions.add(current_revision)
-
-        if has_relevant_ops or parents:
-            pending.extend(parents)
-
-    if not missing_revisions:
-        print(
-            "Schema gap detected but no actionable migration ops found - keeping current alembic stamp"
-        )
-        return
-
-    stamp_targets: set[str] = set()
-    for missing_revision in missing_revisions:
-        parents = parent_map.get(missing_revision, ())
-        if not parents:
-            stamp_targets.add("base")
-            continue
-        for parent in parents:
-            if parent not in missing_revisions:
-                stamp_targets.add(parent)
-
-    if len(stamp_targets) != 1:
-        print(
-            f"Could not determine a single safe alembic stamp target ({sorted(stamp_targets)}) - keeping current stamp"
-        )
-        return
-
-    stamp_target = next(iter(stamp_targets))
-    print(f"Re-stamping alembic to revision: {stamp_target}")
-    alembic.command.stamp(alembic_cfg, stamp_target)
+    # If we get here, all revisions look applied but schema still fails.
+    # Fall back to base to let alembic replay everything.
+    print("All migrations appear applied but schema still has gaps - re-stamping to base")
+    alembic.command.stamp(alembic_cfg, "base")
 
 
 def _migration_has_missing_ops(
     source: str, db_tables: set, get_columns
-) -> tuple[bool, bool]:
-    """Return (has_relevant_ops, has_missing_ops) for schema operations."""
+) -> bool:
+    """Return True when migration schema operations appear unapplied."""
     import ast
 
     try:
         tree = ast.parse(source)
     except SyntaxError:
-        return True, True
-
-    has_relevant_ops = False
-    has_missing_ops = False
+        return True
 
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
@@ -182,14 +136,12 @@ def _migration_has_missing_ops(
             continue
 
         if func.attr == "create_table":
-            has_relevant_ops = True
             # First positional arg is the table name
             if node.args and isinstance(node.args[0], ast.Constant):
                 if node.args[0].value not in db_tables:
-                    has_missing_ops = True
+                    return True
 
         elif func.attr == "add_column":
-            has_relevant_ops = True
             # First arg = table name, second arg = Column with name
             if (
                 len(node.args) >= 2
@@ -207,12 +159,9 @@ def _migration_has_missing_ops(
                 ):
                     col_name = col_arg.args[0].value
                     if col_name not in get_columns(table_name):
-                        has_missing_ops = True
-                elif table_name not in db_tables:
-                    has_missing_ops = True
+                        return True
 
         elif func.attr == "rename_table":
-            has_relevant_ops = True
             if (
                 len(node.args) >= 2
                 and isinstance(node.args[0], ast.Constant)
@@ -221,10 +170,9 @@ def _migration_has_missing_ops(
                 old_name = node.args[0].value
                 new_name = node.args[1].value
                 if old_name in db_tables and new_name not in db_tables:
-                    has_missing_ops = True
+                    return True
 
         elif func.attr == "alter_column":
-            has_relevant_ops = True
             if len(node.args) >= 2 and isinstance(node.args[0], ast.Constant):
                 table_name = node.args[0].value
                 if not isinstance(node.args[1], ast.Constant):
@@ -245,9 +193,9 @@ def _migration_has_missing_ops(
                         old_col_name in existing_columns
                         and new_col_name not in existing_columns
                     ):
-                        has_missing_ops = True
+                        return True
 
-    return has_relevant_ops, has_missing_ops
+    return False
 
 
 def init_database() -> Session:

--- a/scripts/initialise_resources.py
+++ b/scripts/initialise_resources.py
@@ -51,6 +51,111 @@ def verify_schema_matches_models() -> None:
         raise RuntimeError("Schema verification failed - " + "; ".join(details))
 
 
+def _restamp_to_safe_revision(
+    alembic_cfg: alembic.config.Config, inspector: inspect
+) -> None:
+    """Re-stamp alembic to the ``down_revision`` of the first migration
+    (from head backwards) whose schema effects are missing from the DB.
+
+    This handles the case where ``alembic_version`` was stamped past
+    migrations that never actually ran (e.g. a ``create_all`` +
+    ``stamp('head')`` on a previous deploy that missed later migrations).
+    """
+    from alembic.script import ScriptDirectory
+    import pathlib
+
+    script = ScriptDirectory.from_config(alembic_cfg)
+    db_tables = set(inspector.get_table_names())
+    db_columns_cache: dict[str, set[str]] = {}
+
+    def _get_columns(table_name: str) -> set[str]:
+        if table_name not in db_columns_cache:
+            db_columns_cache[table_name] = {
+                col["name"] for col in inspector.get_columns(table_name)
+            }
+        return db_columns_cache[table_name]
+
+    # Walk from head backwards to find the earliest unapplied revision
+    last_good_revision = None
+    revision = script.get_current_head()
+
+    while revision:
+        rev_obj = script.get_revision(revision)
+        if rev_obj is None:
+            break
+
+        # Parse the migration source to find create_table / add_column targets
+        try:
+            source = pathlib.Path(rev_obj.module.__file__).read_text()
+        except Exception:
+            break
+
+        creates_missing = _migration_has_missing_ops(source, db_tables, _get_columns)
+
+        if creates_missing:
+            # This revision hasn't been applied yet – remember its parent
+            down = rev_obj.down_revision
+            last_good_revision = down if not isinstance(down, tuple) else down[0]
+        else:
+            # This revision's effects are present – stop
+            last_good_revision = revision
+            break
+
+        revision = last_good_revision
+
+    stamp_target = last_good_revision or "base"
+    print(f"Re-stamping alembic to revision: {stamp_target}")
+    alembic.command.stamp(alembic_cfg, stamp_target)
+
+
+def _migration_has_missing_ops(
+    source: str, db_tables: set, get_columns
+) -> bool:
+    """Return True if the migration source contains ``create_table`` or
+    ``add_column`` calls targeting tables/columns not yet in the DB."""
+    import ast
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return True
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute):
+            continue
+
+        if func.attr == "create_table":
+            # First positional arg is the table name
+            if node.args and isinstance(node.args[0], ast.Constant):
+                if node.args[0].value not in db_tables:
+                    return True
+
+        elif func.attr == "add_column":
+            # First arg = table name, second arg = Column with name
+            if (
+                len(node.args) >= 2
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[1], ast.Call)
+            ):
+                table_name = node.args[0].value
+                col_arg = node.args[1]
+                if (
+                    table_name in db_tables
+                    and isinstance(col_arg.func, ast.Attribute)
+                    and col_arg.func.attr == "Column"
+                    and col_arg.args
+                    and isinstance(col_arg.args[0], ast.Constant)
+                ):
+                    col_name = col_arg.args[0].value
+                    if col_name not in get_columns(table_name):
+                        return True
+
+    return False
+
+
 def init_database() -> Session:
     # Check if database is empty (no tables exist)
     inspector = inspect(engine)
@@ -76,6 +181,21 @@ def init_database() -> Session:
         print("Stamped alembic version for future migrations")
     else:
         print("Tables already exist - running migrations...")
+
+        # Guard against stale alembic stamps: if the DB reports it is at
+        # head but the actual schema is missing tables/columns, re-stamp
+        # to a safe point so ``upgrade head`` can replay missing migrations.
+        # We walk backwards from head, checking each revision's upgrade()
+        # effects until we find one that has already been applied.
+        try:
+            verify_schema_matches_models()
+        except RuntimeError as exc:
+            print(
+                f"Schema gap detected ({exc}) "
+                f"- finding safe alembic stamp point to replay migrations"
+            )
+            _restamp_to_safe_revision(alembic_cfg, inspector)
+
         alembic.command.upgrade(alembic_cfg, "head")
         print("Database migrations completed successfully!")
 

--- a/scripts/initialise_resources.py
+++ b/scripts/initialise_resources.py
@@ -11,6 +11,7 @@ import alembic.command
 import asyncio
 import glob
 from sqlalchemy import inspect
+from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.orm import sessionmaker, Session
 from app.db.database import engine
 from app.db.models import Base, DBUser
@@ -52,7 +53,7 @@ def verify_schema_matches_models() -> None:
 
 
 def _restamp_to_safe_revision(
-    alembic_cfg: alembic.config.Config, inspector: inspect
+    alembic_cfg: alembic.config.Config, inspector: Inspector
 ) -> None:
     """Re-stamp alembic to the ``down_revision`` of the first migration
     (from head backwards) whose schema effects are missing from the DB.
@@ -75,50 +76,103 @@ def _restamp_to_safe_revision(
             }
         return db_columns_cache[table_name]
 
-    # Walk from head backwards to find the earliest unapplied revision
-    last_good_revision = None
     revision = script.get_current_head()
+    if revision is None:
+        print("Could not determine alembic head revision - skipping re-stamp")
+        return
 
-    while revision:
-        rev_obj = script.get_revision(revision)
+    pending = [revision]
+    visited: set[str] = set()
+    missing_revisions: set[str] = set()
+    parent_map: dict[str, tuple[str, ...]] = {}
+
+    while pending:
+        current_revision = pending.pop()
+        if current_revision in visited:
+            continue
+        visited.add(current_revision)
+
+        rev_obj = script.get_revision(current_revision)
         if rev_obj is None:
-            break
+            print(
+                f"Could not resolve revision {current_revision} - skipping re-stamp"
+            )
+            return
 
-        # Parse the migration source to find create_table / add_column targets
+        path = getattr(rev_obj, "path", None)
+        if not path:
+            print(
+                f"Could not read source path for revision {current_revision} - skipping re-stamp"
+            )
+            return
+
         try:
-            source = pathlib.Path(rev_obj.module.__file__).read_text()
-        except Exception:
-            break
+            source = pathlib.Path(path).read_text()
+        except Exception as exc:
+            print(
+                f"Could not analyze migration {current_revision} ({exc}) - skipping re-stamp"
+            )
+            return
 
-        creates_missing = _migration_has_missing_ops(source, db_tables, _get_columns)
+        has_relevant_ops, creates_missing = _migration_has_missing_ops(
+            source, db_tables, _get_columns
+        )
+
+        down_revision = rev_obj.down_revision
+        if down_revision is None:
+            parents: tuple[str, ...] = ()
+        elif isinstance(down_revision, tuple):
+            parents = down_revision
+        else:
+            parents = (down_revision,)
+        parent_map[current_revision] = parents
 
         if creates_missing:
-            # This revision hasn't been applied yet – remember its parent
-            down = rev_obj.down_revision
-            last_good_revision = down if not isinstance(down, tuple) else down[0]
-        else:
-            # This revision's effects are present – stop
-            last_good_revision = revision
-            break
+            missing_revisions.add(current_revision)
 
-        revision = last_good_revision
+        if has_relevant_ops or parents:
+            pending.extend(parents)
 
-    stamp_target = last_good_revision or "base"
+    if not missing_revisions:
+        print(
+            "Schema gap detected but no actionable migration ops found - keeping current alembic stamp"
+        )
+        return
+
+    stamp_targets: set[str] = set()
+    for missing_revision in missing_revisions:
+        parents = parent_map.get(missing_revision, ())
+        if not parents:
+            stamp_targets.add("base")
+            continue
+        for parent in parents:
+            if parent not in missing_revisions:
+                stamp_targets.add(parent)
+
+    if len(stamp_targets) != 1:
+        print(
+            f"Could not determine a single safe alembic stamp target ({sorted(stamp_targets)}) - keeping current stamp"
+        )
+        return
+
+    stamp_target = next(iter(stamp_targets))
     print(f"Re-stamping alembic to revision: {stamp_target}")
     alembic.command.stamp(alembic_cfg, stamp_target)
 
 
 def _migration_has_missing_ops(
     source: str, db_tables: set, get_columns
-) -> bool:
-    """Return True if the migration source contains ``create_table`` or
-    ``add_column`` calls targeting tables/columns not yet in the DB."""
+) -> tuple[bool, bool]:
+    """Return (has_relevant_ops, has_missing_ops) for schema operations."""
     import ast
 
     try:
         tree = ast.parse(source)
     except SyntaxError:
-        return True
+        return True, True
+
+    has_relevant_ops = False
+    has_missing_ops = False
 
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
@@ -128,12 +182,14 @@ def _migration_has_missing_ops(
             continue
 
         if func.attr == "create_table":
+            has_relevant_ops = True
             # First positional arg is the table name
             if node.args and isinstance(node.args[0], ast.Constant):
                 if node.args[0].value not in db_tables:
-                    return True
+                    has_missing_ops = True
 
         elif func.attr == "add_column":
+            has_relevant_ops = True
             # First arg = table name, second arg = Column with name
             if (
                 len(node.args) >= 2
@@ -151,9 +207,47 @@ def _migration_has_missing_ops(
                 ):
                     col_name = col_arg.args[0].value
                     if col_name not in get_columns(table_name):
-                        return True
+                        has_missing_ops = True
+                elif table_name not in db_tables:
+                    has_missing_ops = True
 
-    return False
+        elif func.attr == "rename_table":
+            has_relevant_ops = True
+            if (
+                len(node.args) >= 2
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[1], ast.Constant)
+            ):
+                old_name = node.args[0].value
+                new_name = node.args[1].value
+                if old_name in db_tables and new_name not in db_tables:
+                    has_missing_ops = True
+
+        elif func.attr == "alter_column":
+            has_relevant_ops = True
+            if len(node.args) >= 2 and isinstance(node.args[0], ast.Constant):
+                table_name = node.args[0].value
+                if not isinstance(node.args[1], ast.Constant):
+                    continue
+                old_col_name = node.args[1].value
+                new_col_name = None
+                for kwarg in node.keywords:
+                    if (
+                        kwarg.arg == "new_column_name"
+                        and isinstance(kwarg.value, ast.Constant)
+                    ):
+                        new_col_name = kwarg.value.value
+                        break
+
+                if new_col_name and table_name in db_tables:
+                    existing_columns = get_columns(table_name)
+                    if (
+                        old_col_name in existing_columns
+                        and new_col_name not in existing_columns
+                    ):
+                        has_missing_ops = True
+
+    return has_relevant_ops, has_missing_ops
 
 
 def init_database() -> Session:


### PR DESCRIPTION
When alembic_version is stamped at head but migrations never actually ran (e.g. after a create_all + stamp('head')), the upgrade(head) call is a no-op and schema verification fails.

This adds a pre-migration schema check that detects missing tables or columns and walks the alembic chain backwards from head to find the last correctly-applied revision. It re-stamps to that point so upgrade(head) can replay the missing migrations.