### PR TITLE
AI-487: Store store spend snapshots

### DIFF
--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -31,6 +31,10 @@ from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from app.services.litellm import LiteLLMService
+from app.core.spend_period_service import (
+    fetch_team_spend_snapshot_for_region,
+    upsert_team_spend_period,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -220,6 +224,48 @@ async def purchase_pool_budget(
             status_code=status.HTTP_409_CONFLICT,
             detail="A purchase with this stripe_payment_id already exists",
         )
+
+    # Capture spend for the closing POOL period BEFORE mutating budget state.
+    latest_purchase_at = (
+        db.query(func.max(DBPoolPurchase.purchased_at))
+        .filter(DBPoolPurchase.team_id == team_id, DBPoolPurchase.region_id == region_id)
+        .scalar()
+    )
+    period_start = latest_purchase_at or team.created_at or purchase.purchased_at
+    period_end = purchase.purchased_at
+    if period_start and period_end and period_end > period_start:
+        try:
+            snapshot = await fetch_team_spend_snapshot_for_region(
+                db=db,
+                team=team,
+                region=region,
+            )
+            upsert_team_spend_period(
+                db=db,
+                team=team,
+                region_id=region_id,
+                period_start=period_start,
+                period_end=period_end,
+                source="pool_purchase_litellm_sync",
+                snapshot=snapshot,
+                stripe_invoice_id=purchase.stripe_payment_id,
+                raw_payload={
+                    "trigger": "pool_purchase",
+                    "amount_cents": purchase.amount_cents,
+                    "currency": purchase.currency,
+                },
+            )
+        except Exception as exc:
+            logger.error(
+                "Failed to capture POOL spend period for team_id=%s region_id=%s before purchase: %s",
+                team_id,
+                region_id,
+                str(exc),
+            )
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Failed to capture pre-purchase spend snapshot",
+            )
 
     purchase_record = DBPoolPurchase(
         team_id=team_id,

--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -267,7 +267,6 @@ async def purchase_pool_budget(
             # Do not block purchases if snapshot capture fails (e.g. transient
             # LiteLLM DNS/network issues in tests or degraded environments).
             # Budget update/purchase recording remains the primary operation.
-            pass
 
     purchase_record = DBPoolPurchase(
         team_id=team_id,

--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -228,7 +228,9 @@ async def purchase_pool_budget(
     # Capture spend for the closing POOL period BEFORE mutating budget state.
     latest_purchase_at = (
         db.query(func.max(DBPoolPurchase.purchased_at))
-        .filter(DBPoolPurchase.team_id == team_id, DBPoolPurchase.region_id == region_id)
+        .filter(
+            DBPoolPurchase.team_id == team_id, DBPoolPurchase.region_id == region_id
+        )
         .scalar()
     )
     period_start = latest_purchase_at or team.created_at or purchase.purchased_at
@@ -262,10 +264,10 @@ async def purchase_pool_budget(
                 region_id,
                 str(exc),
             )
-            raise HTTPException(
-                status_code=status.HTTP_502_BAD_GATEWAY,
-                detail="Failed to capture pre-purchase spend snapshot",
-            )
+            # Do not block purchases if snapshot capture fails (e.g. transient
+            # LiteLLM DNS/network issues in tests or degraded environments).
+            # Budget update/purchase recording remains the primary operation.
+            pass
 
     purchase_record = DBPoolPurchase(
         team_id=team_id,

--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -225,7 +225,8 @@ async def purchase_pool_budget(
             detail="A purchase with this stripe_payment_id already exists",
         )
 
-    # Capture spend for the closing POOL period BEFORE mutating budget state.
+    # Compute the closing POOL period window using the state BEFORE the new
+    # purchase is recorded (latest_purchase_at must be queried before the insert).
     latest_purchase_at = (
         db.query(func.max(DBPoolPurchase.purchased_at))
         .filter(
@@ -235,6 +236,35 @@ async def purchase_pool_budget(
     )
     period_start = latest_purchase_at or team.created_at or purchase.purchased_at
     period_end = purchase.purchased_at
+
+    # Insert the purchase record and flush BEFORE any external calls so that
+    # stripe_payment_id uniqueness is enforced in the DB before side effects.
+    # Concurrent duplicate requests will fail here rather than wasting an
+    # external LiteLLM round-trip.
+    purchase_record = DBPoolPurchase(
+        team_id=team_id,
+        region_id=region_id,
+        amount_cents=purchase.amount_cents,
+        currency=purchase.currency,
+        purchased_at=purchase.purchased_at,
+        stripe_payment_id=purchase.stripe_payment_id,
+        created_at=datetime.now(UTC),
+    )
+    db.add(purchase_record)
+
+    team.last_pool_purchase = purchase.purchased_at
+
+    try:
+        db.flush()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A purchase with this stripe_payment_id already exists",
+        )
+
+    # Capture spend for the closing POOL period BEFORE mutating budget state.
+    # Uses the pre-computed period window (before the insert above).
     if period_start and period_end and period_end > period_start:
         try:
             snapshot = await fetch_team_spend_snapshot_for_region(
@@ -268,19 +298,6 @@ async def purchase_pool_budget(
             # LiteLLM DNS/network issues in tests or degraded environments).
             # Budget update/purchase recording remains the primary operation.
 
-    purchase_record = DBPoolPurchase(
-        team_id=team_id,
-        region_id=region_id,
-        amount_cents=purchase.amount_cents,
-        currency=purchase.currency,
-        purchased_at=purchase.purchased_at,
-        stripe_payment_id=purchase.stripe_payment_id,
-        created_at=datetime.now(UTC),
-    )
-    db.add(purchase_record)
-
-    team.last_pool_purchase = purchase.purchased_at
-
     amount_dollars = purchase.amount_cents / 100.0
     service = LiteLLMService(
         api_url=region.litellm_api_url, api_key=region.litellm_api_key
@@ -302,17 +319,6 @@ async def purchase_pool_budget(
             team_id,
             region_id,
             str(exc),
-        )
-
-    # Flush before external side effects so stripe_payment_id uniqueness is
-    # enforced in this transaction (handles concurrent duplicate requests).
-    try:
-        db.flush()
-    except IntegrityError:
-        db.rollback()
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="A purchase with this stripe_payment_id already exists",
         )
 
     total_purchased_cents = (

--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -4,7 +4,7 @@ from datetime import UTC, date, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import func
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 
 from app.core.config import settings
 from app.core.limit_service import DEFAULT_MAX_SPEND, LimitService
@@ -24,7 +24,6 @@ from app.db.models import (
     DBSpendCap,
     DBTeam,
     DBTeamSpendPeriod,
-    DBTeamSpendPeriodKey,
     DBTeamRegion,
     DBUser,
 )
@@ -77,6 +76,7 @@ async def get_team_spend_history(
 
     periods = (
         db.query(DBTeamSpendPeriod)
+        .options(selectinload(DBTeamSpendPeriod.keys))
         .filter(
             DBTeamSpendPeriod.team_id == team_id,
             DBTeamSpendPeriod.region_id == region_id,
@@ -87,12 +87,6 @@ async def get_team_spend_history(
 
     period_items: list[TeamSpendHistoryPeriodItem] = []
     for period in periods:
-        key_rows = (
-            db.query(DBTeamSpendPeriodKey)
-            .filter(DBTeamSpendPeriodKey.team_spend_period_id == period.id)
-            .order_by(DBTeamSpendPeriodKey.id.asc())
-            .all()
-        )
         key_items = [
             TeamSpendHistoryKeyItem(
                 key_id=row.key_id,
@@ -107,7 +101,7 @@ async def get_team_spend_history(
                 completion_tokens=row.completion_tokens,
                 total_tokens=row.total_tokens,
             )
-            for row in key_rows
+            for row in sorted(period.keys, key=lambda k: k.id)
         ]
 
         period_items.append(

--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -91,6 +91,7 @@ async def get_team_spend_history(
             TeamSpendHistoryKeyItem(
                 key_id=row.key_id,
                 owner_id=row.owner_id,
+                key_name_snapshot=row.key_name_snapshot,
                 spend=round(float(row.spend or 0.0), 4),
                 max_budget=(
                     round(float(row.max_budget), 4)

--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -97,7 +97,6 @@ async def get_team_spend_history(
             TeamSpendHistoryKeyItem(
                 key_id=row.key_id,
                 owner_id=row.owner_id,
-                key_name=row.key_name_snapshot,
                 spend=round(float(row.spend or 0.0), 4),
                 max_budget=(
                     round(float(row.max_budget), 4)

--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -23,6 +23,8 @@ from app.db.models import (
     DBRegion,
     DBSpendCap,
     DBTeam,
+    DBTeamSpendPeriod,
+    DBTeamSpendPeriodKey,
     DBTeamRegion,
     DBUser,
 )
@@ -33,6 +35,9 @@ from app.schemas.models import (
     SpendBudgetUpdateRequest,
     SpendBudgetUpdateResponse,
     SpendKeyItem,
+    TeamSpendHistoryKeyItem,
+    TeamSpendHistoryPeriodItem,
+    TeamSpendHistoryResponse,
     TeamSpendResponse,
     UserSpendResponse,
 )
@@ -41,6 +46,100 @@ from app.services.litellm import LiteLLMService
 router = APIRouter(tags=["spend"])
 logger = logging.getLogger(__name__)
 MONTHLY_BUDGET_DURATION = "1mo"
+
+
+@router.get(
+    "/{region_id}/team/{team_id}/history",
+    response_model=TeamSpendHistoryResponse,
+    summary="Get historical team spend by region",
+    description=(
+        "Returns historical spend periods from the API database for a team in a "
+        "region, including per-key spend for each period."
+    ),
+    response_description="Team historical spend periods with per-key breakdown.",
+)
+async def get_team_spend_history(
+    region_id: int,
+    team_id: int,
+    current_user: DBUser = Depends(get_current_user_from_auth),
+    user_role: str = Depends(get_private_ai_access),
+    db: Session = Depends(get_db),
+):
+    team = (
+        db.query(DBTeam)
+        .filter(DBTeam.id == team_id, DBTeam.deleted_at.is_(None))
+        .first()
+    )
+    if not team:
+        raise HTTPException(status_code=404, detail="Team not found")
+    _assert_team_access(current_user, user_role, team_id)
+    region = _get_region_or_404(db, region_id)
+
+    periods = (
+        db.query(DBTeamSpendPeriod)
+        .filter(
+            DBTeamSpendPeriod.team_id == team_id,
+            DBTeamSpendPeriod.region_id == region_id,
+        )
+        .order_by(DBTeamSpendPeriod.period_end.desc(), DBTeamSpendPeriod.id.desc())
+        .all()
+    )
+
+    period_items: list[TeamSpendHistoryPeriodItem] = []
+    for period in periods:
+        key_rows = (
+            db.query(DBTeamSpendPeriodKey)
+            .filter(DBTeamSpendPeriodKey.team_spend_period_id == period.id)
+            .order_by(DBTeamSpendPeriodKey.id.asc())
+            .all()
+        )
+        key_items = [
+            TeamSpendHistoryKeyItem(
+                key_id=row.key_id,
+                owner_id=row.owner_id,
+                key_name=row.key_name_snapshot,
+                spend=round(float(row.spend or 0.0), 4),
+                max_budget=(
+                    round(float(row.max_budget), 4)
+                    if row.max_budget is not None
+                    else None
+                ),
+                prompt_tokens=row.prompt_tokens,
+                completion_tokens=row.completion_tokens,
+                total_tokens=row.total_tokens,
+            )
+            for row in key_rows
+        ]
+
+        period_items.append(
+            TeamSpendHistoryPeriodItem(
+                period_start=period.period_start,
+                period_end=period.period_end,
+                budget_type=period.budget_type,
+                total_spend=round(float(period.total_spend or 0.0), 4),
+                total_budget=(
+                    round(float(period.total_budget), 4)
+                    if period.total_budget is not None
+                    else None
+                ),
+                total_prompt_tokens=period.total_prompt_tokens,
+                total_completion_tokens=period.total_completion_tokens,
+                total_tokens=period.total_tokens,
+                source=period.source,
+                stripe_event_id=period.stripe_event_id,
+                stripe_invoice_id=period.stripe_invoice_id,
+                stripe_subscription_id=period.stripe_subscription_id,
+                keys=key_items,
+            )
+        )
+
+    return TeamSpendHistoryResponse(
+        region_id=region_id,
+        region_name=region.name,
+        team_id=team_id,
+        team_name=team.name,
+        periods=period_items,
+    )
 
 
 def _to_int_or_none(value) -> int | None:

--- a/app/core/spend_period_service.py
+++ b/app/core/spend_period_service.py
@@ -154,16 +154,25 @@ def upsert_team_spend_period(
             source=source,
             created_at=datetime.now(UTC),
         )
-        db.add(new_row)
         try:
-            db.flush()
+            # Use a savepoint so that a concurrent insert only rolls back the
+            # nested transaction, leaving the outer transaction intact.
+            with db.begin_nested():
+                db.add(new_row)
+                db.flush()
             row = new_row
         except IntegrityError:
-            # Another concurrent task inserted the same row; roll back and re-fetch.
-            db.rollback()
+            # Another concurrent task inserted the same row; the savepoint was
+            # rolled back, so the outer transaction is still valid – re-fetch.
             row = _query_spend_period(
                 db, team.id, region_id, budget_type, period_start, period_end
             )
+            if row is None:
+                raise RuntimeError(
+                    f"Concurrent insert race: spend period not found after IntegrityError "
+                    f"(team_id={team.id} region_id={region_id} "
+                    f"window={period_start} to {period_end})"
+                )
 
     row.currency = None
     row.total_spend = float(snapshot.get("total_spend", 0.0) or 0.0)

--- a/app/core/spend_period_service.py
+++ b/app/core/spend_period_service.py
@@ -73,15 +73,11 @@ async def fetch_team_spend_snapshot_for_region(
                     if litellm_key.get("max_budget") is not None
                     else None
                 ),
-                "prompt_tokens": int(litellm_key.get("prompt_tokens"))
-                if str(litellm_key.get("prompt_tokens", "")).isdigit()
-                else None,
-                "completion_tokens": int(litellm_key.get("completion_tokens"))
-                if str(litellm_key.get("completion_tokens", "")).isdigit()
-                else None,
-                "total_tokens": int(litellm_key.get("total_tokens"))
-                if str(litellm_key.get("total_tokens", "")).isdigit()
-                else None,
+                "prompt_tokens": _to_int_or_none(litellm_key.get("prompt_tokens")),
+                "completion_tokens": _to_int_or_none(
+                    litellm_key.get("completion_tokens")
+                ),
+                "total_tokens": _to_int_or_none(litellm_key.get("total_tokens")),
             }
         )
 

--- a/app/core/spend_period_service.py
+++ b/app/core/spend_period_service.py
@@ -16,6 +16,15 @@ from app.schemas.models import BudgetType
 from app.services.litellm import LiteLLMService
 
 
+def _to_int_or_none(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
 def _resolve_budget_type(team: DBTeam) -> str:
     budget_type = team.budget_type
     if isinstance(budget_type, BudgetType):

--- a/app/core/spend_period_service.py
+++ b/app/core/spend_period_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.db.models import (
@@ -35,6 +36,17 @@ async def fetch_team_spend_snapshot_for_region(
     team_data = await service.get_team_info(lite_team_id)
     team_info = team_data.get("team_info", team_data)
 
+    # Preload all keys for this region/team once to avoid per-key DB round trips.
+    all_region_team_keys: list[DBPrivateAIKey] = (
+        db.query(DBPrivateAIKey)
+        .filter(
+            DBPrivateAIKey.region_id == region.id,
+            DBPrivateAIKey.team_id == team.id,
+        )
+        .order_by(DBPrivateAIKey.id.desc())
+        .all()
+    )
+
     keys_payload: list[dict[str, Any]] = []
     for litellm_key in team_data.get("keys", []):
         metadata = litellm_key.get("metadata") or {}
@@ -42,17 +54,13 @@ async def fetch_team_spend_snapshot_for_region(
         owner_raw = litellm_key.get("user_id")
         owner_id = int(owner_raw) if str(owner_raw).isdigit() else None
 
-        key_id = None
-        query = db.query(DBPrivateAIKey).filter(DBPrivateAIKey.region_id == region.id)
+        candidates = list(all_region_team_keys)
         if key_name:
-            query = query.filter(DBPrivateAIKey.name == key_name)
+            candidates = [k for k in candidates if k.name == key_name]
         if owner_id is not None:
-            query = query.filter(DBPrivateAIKey.owner_id == owner_id)
-        else:
-            query = query.filter(DBPrivateAIKey.team_id == team.id)
-        db_key = query.order_by(DBPrivateAIKey.id.desc()).first()
-        if db_key:
-            key_id = db_key.id
+            candidates = [k for k in candidates if k.owner_id == owner_id]
+        db_key = candidates[0] if candidates else None
+        key_id = db_key.id if db_key else None
 
         keys_payload.append(
             {
@@ -97,6 +105,27 @@ async def fetch_team_spend_snapshot_for_region(
     }
 
 
+def _query_spend_period(
+    db: Session,
+    team_id: int,
+    region_id: int,
+    budget_type: str,
+    period_start: datetime,
+    period_end: datetime,
+):
+    return (
+        db.query(DBTeamSpendPeriod)
+        .filter(
+            DBTeamSpendPeriod.team_id == team_id,
+            DBTeamSpendPeriod.region_id == region_id,
+            DBTeamSpendPeriod.budget_type == budget_type,
+            DBTeamSpendPeriod.period_start == period_start,
+            DBTeamSpendPeriod.period_end == period_end,
+        )
+        .first()
+    )
+
+
 def upsert_team_spend_period(
     *,
     db: Session,
@@ -111,27 +140,30 @@ def upsert_team_spend_period(
     stripe_subscription_id: str | None = None,
     raw_payload: dict[str, Any] | None = None,
 ) -> DBTeamSpendPeriod:
-    row = (
-        db.query(DBTeamSpendPeriod)
-        .filter(
-            DBTeamSpendPeriod.team_id == team.id,
-            DBTeamSpendPeriod.region_id == region_id,
-            DBTeamSpendPeriod.budget_type == _resolve_budget_type(team),
-            DBTeamSpendPeriod.period_start == period_start,
-            DBTeamSpendPeriod.period_end == period_end,
-        )
-        .first()
+    budget_type = _resolve_budget_type(team)
+    row = _query_spend_period(
+        db, team.id, region_id, budget_type, period_start, period_end
     )
     if row is None:
-        row = DBTeamSpendPeriod(
+        new_row = DBTeamSpendPeriod(
             team_id=team.id,
             region_id=region_id,
-            budget_type=_resolve_budget_type(team),
+            budget_type=budget_type,
             period_start=period_start,
             period_end=period_end,
             source=source,
             created_at=datetime.now(UTC),
         )
+        db.add(new_row)
+        try:
+            db.flush()
+            row = new_row
+        except IntegrityError:
+            # Another concurrent task inserted the same row; roll back and re-fetch.
+            db.rollback()
+            row = _query_spend_period(
+                db, team.id, region_id, budget_type, period_start, period_end
+            )
 
     row.currency = None
     row.total_spend = float(snapshot.get("total_spend", 0.0) or 0.0)

--- a/app/core/spend_period_service.py
+++ b/app/core/spend_period_service.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.db.models import (
+    DBPrivateAIKey,
+    DBTeam,
+    DBTeamSpendPeriod,
+    DBTeamSpendPeriodKey,
+)
+from app.schemas.models import BudgetType
+from app.services.litellm import LiteLLMService
+
+
+def _resolve_budget_type(team: DBTeam) -> str:
+    budget_type = team.budget_type
+    if isinstance(budget_type, BudgetType):
+        return budget_type.value
+    return str(budget_type).lower()
+
+
+async def fetch_team_spend_snapshot_for_region(
+    *,
+    db: Session,
+    team: DBTeam,
+    region,
+) -> dict[str, Any]:
+    service = LiteLLMService(api_url=region.litellm_api_url, api_key=region.litellm_api_key)
+    lite_team_id = LiteLLMService.format_team_id(region.name, team.id)
+    team_data = await service.get_team_info(lite_team_id)
+    team_info = team_data.get("team_info", team_data)
+
+    keys_payload: list[dict[str, Any]] = []
+    for litellm_key in team_data.get("keys", []):
+        metadata = litellm_key.get("metadata") or {}
+        key_name = metadata.get("amazeeai_private_ai_key_name")
+        owner_raw = litellm_key.get("user_id")
+        owner_id = int(owner_raw) if str(owner_raw).isdigit() else None
+
+        key_id = None
+        query = db.query(DBPrivateAIKey).filter(DBPrivateAIKey.region_id == region.id)
+        if key_name:
+            query = query.filter(DBPrivateAIKey.name == key_name)
+        if owner_id is not None:
+            query = query.filter(DBPrivateAIKey.owner_id == owner_id)
+        else:
+            query = query.filter(DBPrivateAIKey.team_id == team.id)
+        db_key = query.order_by(DBPrivateAIKey.id.desc()).first()
+        if db_key:
+            key_id = db_key.id
+
+        keys_payload.append(
+            {
+                "key_id": key_id,
+                "owner_id": owner_id,
+                "key_name_snapshot": key_name,
+                "spend": float(litellm_key.get("spend", 0.0) or 0.0),
+                "max_budget": (
+                    float(litellm_key.get("max_budget"))
+                    if litellm_key.get("max_budget") is not None
+                    else None
+                ),
+                "prompt_tokens": int(litellm_key.get("prompt_tokens"))
+                if str(litellm_key.get("prompt_tokens", "")).isdigit()
+                else None,
+                "completion_tokens": int(litellm_key.get("completion_tokens"))
+                if str(litellm_key.get("completion_tokens", "")).isdigit()
+                else None,
+                "total_tokens": int(litellm_key.get("total_tokens"))
+                if str(litellm_key.get("total_tokens", "")).isdigit()
+                else None,
+            }
+        )
+
+    return {
+        "total_spend": float(team_info.get("spend", 0.0) or 0.0),
+        "total_budget": (
+            float(team_info.get("max_budget"))
+            if team_info.get("max_budget") is not None
+            else None
+        ),
+        "total_prompt_tokens": int(team_info.get("prompt_tokens"))
+        if str(team_info.get("prompt_tokens", "")).isdigit()
+        else None,
+        "total_completion_tokens": int(team_info.get("completion_tokens"))
+        if str(team_info.get("completion_tokens", "")).isdigit()
+        else None,
+        "total_tokens": int(team_info.get("total_tokens"))
+        if str(team_info.get("total_tokens", "")).isdigit()
+        else None,
+        "keys": keys_payload,
+    }
+
+
+def upsert_team_spend_period(
+    *,
+    db: Session,
+    team: DBTeam,
+    region_id: int,
+    period_start: datetime,
+    period_end: datetime,
+    source: str,
+    snapshot: dict[str, Any],
+    stripe_event_id: str | None = None,
+    stripe_invoice_id: str | None = None,
+    stripe_subscription_id: str | None = None,
+    raw_payload: dict[str, Any] | None = None,
+) -> DBTeamSpendPeriod:
+    row = (
+        db.query(DBTeamSpendPeriod)
+        .filter(
+            DBTeamSpendPeriod.team_id == team.id,
+            DBTeamSpendPeriod.region_id == region_id,
+            DBTeamSpendPeriod.budget_type == _resolve_budget_type(team),
+            DBTeamSpendPeriod.period_start == period_start,
+            DBTeamSpendPeriod.period_end == period_end,
+        )
+        .first()
+    )
+    if row is None:
+        row = DBTeamSpendPeriod(
+            team_id=team.id,
+            region_id=region_id,
+            budget_type=_resolve_budget_type(team),
+            period_start=period_start,
+            period_end=period_end,
+            source=source,
+            created_at=datetime.now(UTC),
+        )
+
+    row.currency = None
+    row.total_spend = float(snapshot.get("total_spend", 0.0) or 0.0)
+    row.total_budget = (
+        float(snapshot["total_budget"])
+        if snapshot.get("total_budget") is not None
+        else None
+    )
+    row.total_prompt_tokens = snapshot.get("total_prompt_tokens")
+    row.total_completion_tokens = snapshot.get("total_completion_tokens")
+    row.total_tokens = snapshot.get("total_tokens")
+    row.source = source
+    row.stripe_event_id = stripe_event_id
+    row.stripe_invoice_id = stripe_invoice_id
+    row.stripe_subscription_id = stripe_subscription_id
+    row.raw_payload = raw_payload
+    db.add(row)
+    db.flush()
+
+    db.query(DBTeamSpendPeriodKey).filter(
+        DBTeamSpendPeriodKey.team_spend_period_id == row.id
+    ).delete()
+
+    for item in snapshot.get("keys", []):
+        db.add(
+            DBTeamSpendPeriodKey(
+                team_spend_period_id=row.id,
+                key_id=item.get("key_id"),
+                owner_id=item.get("owner_id"),
+                key_name_snapshot=item.get("key_name_snapshot"),
+                spend=float(item.get("spend", 0.0) or 0.0),
+                max_budget=(
+                    float(item["max_budget"])
+                    if item.get("max_budget") is not None
+                    else None
+                ),
+                prompt_tokens=item.get("prompt_tokens"),
+                completion_tokens=item.get("completion_tokens"),
+                total_tokens=item.get("total_tokens"),
+            )
+        )
+
+    db.flush()
+    return row

--- a/app/core/spend_period_service.py
+++ b/app/core/spend_period_service.py
@@ -28,7 +28,9 @@ async def fetch_team_spend_snapshot_for_region(
     team: DBTeam,
     region,
 ) -> dict[str, Any]:
-    service = LiteLLMService(api_url=region.litellm_api_url, api_key=region.litellm_api_key)
+    service = LiteLLMService(
+        api_url=region.litellm_api_url, api_key=region.litellm_api_key
+    )
     lite_team_id = LiteLLMService.format_team_id(region.name, team.id)
     team_data = await service.get_team_info(lite_team_id)
     team_info = team_data.get("team_info", team_data)

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -40,6 +40,10 @@ from typing import Dict, List, Optional
 from app.core.security import create_access_token
 from app.core.config import settings
 from urllib.parse import urljoin
+from app.core.spend_period_service import (
+    fetch_team_spend_snapshot_for_region,
+    upsert_team_spend_period,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -212,6 +216,7 @@ async def handle_stripe_event_background(event):
             logger.info(f"Unknown event type: {event_type}")
             return
         event_object = event.data.object
+        event_id = getattr(event, "id", None)
         customer_id = event_object.customer
         if not customer_id:
             logger.warning("No customer ID found in event, cannot complete processing")
@@ -228,6 +233,12 @@ async def handle_stripe_event_background(event):
             product_id = await get_product_id_from_subscription(subscription)
             start_date = datetime.fromtimestamp(event_object.period_start, tz=UTC)
             await apply_product_for_team(db, customer_id, product_id, start_date)
+            await capture_periodic_team_spend_for_invoice(
+                db=db,
+                customer_id=customer_id,
+                invoice_obj=event_object,
+                stripe_event_id=event_id,
+            )
         # Failure Events
         elif event_type in SESSION_FAILURE_EVENTS:
             product_id = await get_product_id_from_session(event_object.id)
@@ -244,6 +255,72 @@ async def handle_stripe_event_background(event):
         logger.error(f"Error in background event handler: {str(e)}")
     finally:
         db.close()
+
+
+async def capture_periodic_team_spend_for_invoice(
+    *,
+    db: Session,
+    customer_id: str,
+    invoice_obj,
+    stripe_event_id: str | None,
+) -> None:
+    team = db.query(DBTeam).filter(DBTeam.stripe_customer_id == customer_id).first()
+    if team is None:
+        logger.warning(
+            "Skipping spend period capture: no team for customer_id=%s", customer_id
+        )
+        return
+    if team.budget_type != BudgetType.PERIODIC:
+        return
+
+    period_start_ts = getattr(invoice_obj, "period_start", None)
+    period_end_ts = getattr(invoice_obj, "period_end", None)
+    if period_start_ts is None or period_end_ts is None:
+        logger.warning(
+            "Skipping spend period capture: missing period_start/period_end for team_id=%s",
+            team.id,
+        )
+        return
+
+    period_start = datetime.fromtimestamp(period_start_ts, tz=UTC)
+    period_end = datetime.fromtimestamp(period_end_ts, tz=UTC)
+
+    keys_by_region = get_team_keys_by_region(db, team.id)
+    if not keys_by_region:
+        return
+
+    for region in keys_by_region.keys():
+        try:
+            snapshot = await fetch_team_spend_snapshot_for_region(
+                db=db,
+                team=team,
+                region=region,
+            )
+            upsert_team_spend_period(
+                db=db,
+                team=team,
+                region_id=region.id,
+                period_start=period_start,
+                period_end=period_end,
+                source="stripe_webhook_litellm_sync",
+                snapshot=snapshot,
+                stripe_event_id=stripe_event_id,
+                stripe_invoice_id=getattr(invoice_obj, "id", None),
+                stripe_subscription_id=getattr(
+                    getattr(getattr(invoice_obj, "parent", None), "subscription_details", None),
+                    "subscription",
+                    None,
+                ),
+            )
+            db.commit()
+        except Exception as exc:
+            db.rollback()
+            logger.error(
+                "Failed to capture spend period for team_id=%s region_id=%s: %s",
+                team.id,
+                region.id,
+                str(exc),
+            )
 
 
 async def apply_product_for_team(

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -313,7 +313,11 @@ async def capture_periodic_team_spend_for_invoice(
                 stripe_event_id=stripe_event_id,
                 stripe_invoice_id=getattr(invoice_obj, "id", None),
                 stripe_subscription_id=getattr(
-                    getattr(getattr(invoice_obj, "parent", None), "subscription_details", None),
+                    getattr(
+                        getattr(invoice_obj, "parent", None),
+                        "subscription_details",
+                        None,
+                    ),
                     "subscription",
                     None,
                 ),

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -235,15 +235,15 @@ async def handle_stripe_event_background(event):
             await apply_product_for_team(db, customer_id, product_id, start_date)
         elif event_type in INVOICE_SUCCESS_EVENTS:
             # subscription renewed
-            subscription = event_object.parent.subscription_details.subscription
-            product_id = await get_product_id_from_subscription(subscription)
-            start_date = datetime.fromtimestamp(event_object.period_start, tz=UTC)
             await capture_periodic_team_spend_for_invoice(
                 db=db,
                 customer_id=customer_id,
                 invoice_obj=event_object,
                 stripe_event_id=event_id,
             )
+            subscription = event_object.parent.subscription_details.subscription
+            product_id = await get_product_id_from_subscription(subscription)
+            start_date = datetime.fromtimestamp(event_object.period_start, tz=UTC)
             await apply_product_for_team(db, customer_id, product_id, start_date)
         # Failure Events
         elif event_type in SESSION_FAILURE_EVENTS:

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -226,19 +226,25 @@ async def handle_stripe_event_background(event):
             # new subscription
             product_id = await get_product_id_from_subscription(event_object.id)
             start_date = datetime.fromtimestamp(event_object.start_date, tz=UTC)
-            await apply_product_for_team(db, customer_id, product_id, start_date)
-        elif event_type in INVOICE_SUCCESS_EVENTS:
-            # subscription renewed
-            subscription = event_object.parent.subscription_details.subscription
-            product_id = await get_product_id_from_subscription(subscription)
-            start_date = datetime.fromtimestamp(event_object.period_start, tz=UTC)
-            await apply_product_for_team(db, customer_id, product_id, start_date)
             await capture_periodic_team_spend_for_invoice(
                 db=db,
                 customer_id=customer_id,
                 invoice_obj=event_object,
                 stripe_event_id=event_id,
             )
+            await apply_product_for_team(db, customer_id, product_id, start_date)
+        elif event_type in INVOICE_SUCCESS_EVENTS:
+            # subscription renewed
+            subscription = event_object.parent.subscription_details.subscription
+            product_id = await get_product_id_from_subscription(subscription)
+            start_date = datetime.fromtimestamp(event_object.period_start, tz=UTC)
+            await capture_periodic_team_spend_for_invoice(
+                db=db,
+                customer_id=customer_id,
+                invoice_obj=event_object,
+                stripe_event_id=event_id,
+            )
+            await apply_product_for_team(db, customer_id, product_id, start_date)
         # Failure Events
         elif event_type in SESSION_FAILURE_EVENTS:
             product_id = await get_product_id_from_session(event_object.id)

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -223,15 +223,10 @@ async def handle_stripe_event_background(event):
             return
         # Success Events
         if event_type in SUBSCRIPTION_SUCCESS_EVENTS:
-            # new subscription
+            # new subscription – subscription objects expose current_period_start/end,
+            # not period_start/period_end, so spend capture is handled on invoice events only.
             product_id = await get_product_id_from_subscription(event_object.id)
             start_date = datetime.fromtimestamp(event_object.start_date, tz=UTC)
-            await capture_periodic_team_spend_for_invoice(
-                db=db,
-                customer_id=customer_id,
-                invoice_obj=event_object,
-                stripe_event_id=event_id,
-            )
             await apply_product_for_team(db, customer_id, product_id, start_date)
         elif event_type in INVOICE_SUCCESS_EVENTS:
             # subscription renewed

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -577,8 +577,12 @@ class DBTeamSpendPeriodKey(Base):
         nullable=False,
         index=True,
     )
-    key_id = Column(Integer, ForeignKey("ai_tokens.id", ondelete="SET NULL"), nullable=True)
-    owner_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    key_id = Column(
+        Integer, ForeignKey("ai_tokens.id", ondelete="SET NULL"), nullable=True
+    )
+    owner_id = Column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
     key_name_snapshot = Column(String, nullable=True)
     spend = Column(Float, nullable=False, default=0.0)
     max_budget = Column(Float, nullable=True)

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -598,4 +598,13 @@ class DBTeamSpendPeriodKey(Base):
             "key_id",
             name="uq_team_spend_period_key",
         ),
+        Index(
+            "uq_team_spend_period_key_null_key_id",
+            "team_spend_period_id",
+            "owner_id",
+            "key_name_snapshot",
+            unique=True,
+            postgresql_where=text("key_id IS NULL"),
+            sqlite_where=text("key_id IS NULL"),
+        ),
     )

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -515,3 +515,83 @@ class DBSpendCap(Base):
             sqlite_where=text("scope = 'key' AND key_id IS NOT NULL"),
         ),
     )
+
+
+class DBTeamSpendPeriod(Base):
+    __tablename__ = "team_spend_periods"
+
+    id = Column(Integer, primary_key=True, index=True)
+    team_id = Column(
+        Integer, ForeignKey("teams.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    region_id = Column(
+        Integer,
+        ForeignKey("regions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    budget_type = Column(String, nullable=False, index=True)
+    period_start = Column(DateTime(timezone=True), nullable=False, index=True)
+    period_end = Column(DateTime(timezone=True), nullable=False, index=True)
+    currency = Column(String, nullable=True)
+    total_spend = Column(Float, nullable=False, default=0.0)
+    total_budget = Column(Float, nullable=True)
+    total_prompt_tokens = Column(Integer, nullable=True)
+    total_completion_tokens = Column(Integer, nullable=True)
+    total_tokens = Column(Integer, nullable=True)
+    source = Column(String, nullable=False)
+    stripe_event_id = Column(String, nullable=True, index=True)
+    stripe_invoice_id = Column(String, nullable=True)
+    stripe_subscription_id = Column(String, nullable=True)
+    raw_payload = Column(JSON, nullable=True)
+    created_at = Column(DateTime(timezone=True), default=func.now(), nullable=False)
+
+    team = relationship("DBTeam")
+    region = relationship("DBRegion")
+    keys = relationship(
+        "DBTeamSpendPeriodKey",
+        back_populates="team_spend_period",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "team_id",
+            "region_id",
+            "budget_type",
+            "period_start",
+            "period_end",
+            name="uq_team_spend_period_unique_window",
+        ),
+    )
+
+
+class DBTeamSpendPeriodKey(Base):
+    __tablename__ = "team_spend_period_keys"
+
+    id = Column(Integer, primary_key=True, index=True)
+    team_spend_period_id = Column(
+        Integer,
+        ForeignKey("team_spend_periods.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    key_id = Column(Integer, ForeignKey("ai_tokens.id", ondelete="SET NULL"), nullable=True)
+    owner_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    key_name_snapshot = Column(String, nullable=True)
+    spend = Column(Float, nullable=False, default=0.0)
+    max_budget = Column(Float, nullable=True)
+    prompt_tokens = Column(Integer, nullable=True)
+    completion_tokens = Column(Integer, nullable=True)
+    total_tokens = Column(Integer, nullable=True)
+
+    team_spend_period = relationship("DBTeamSpendPeriod", back_populates="keys")
+
+    __table_args__ = (
+        UniqueConstraint(
+            "team_spend_period_id",
+            "key_id",
+            name="uq_team_spend_period_key",
+        ),
+    )

--- a/app/migrations/versions/20260512_170000_9d1a2b3c4d5e_add_team_spend_period_tables.py
+++ b/app/migrations/versions/20260512_170000_9d1a2b3c4d5e_add_team_spend_period_tables.py
@@ -1,0 +1,94 @@
+"""add team spend period tables
+
+Revision ID: 9d1a2b3c4d5e
+Revises: f1c2d3e4a5b6
+Create Date: 2026-05-12 17:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "9d1a2b3c4d5e"
+down_revision = "f1c2d3e4a5b6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "team_spend_periods",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("team_id", sa.Integer(), nullable=False),
+        sa.Column("region_id", sa.Integer(), nullable=False),
+        sa.Column("budget_type", sa.String(), nullable=False),
+        sa.Column("period_start", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("period_end", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("currency", sa.String(), nullable=True),
+        sa.Column("total_spend", sa.Float(), nullable=False),
+        sa.Column("total_budget", sa.Float(), nullable=True),
+        sa.Column("total_prompt_tokens", sa.Integer(), nullable=True),
+        sa.Column("total_completion_tokens", sa.Integer(), nullable=True),
+        sa.Column("total_tokens", sa.Integer(), nullable=True),
+        sa.Column("source", sa.String(), nullable=False),
+        sa.Column("stripe_event_id", sa.String(), nullable=True),
+        sa.Column("stripe_invoice_id", sa.String(), nullable=True),
+        sa.Column("stripe_subscription_id", sa.String(), nullable=True),
+        sa.Column("raw_payload", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["region_id"], ["regions.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["team_id"], ["teams.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "team_id",
+            "region_id",
+            "budget_type",
+            "period_start",
+            "period_end",
+            name="uq_team_spend_period_unique_window",
+        ),
+    )
+    op.create_index(op.f("ix_team_spend_periods_id"), "team_spend_periods", ["id"], unique=False)
+    op.create_index(op.f("ix_team_spend_periods_team_id"), "team_spend_periods", ["team_id"], unique=False)
+    op.create_index(op.f("ix_team_spend_periods_region_id"), "team_spend_periods", ["region_id"], unique=False)
+    op.create_index(op.f("ix_team_spend_periods_budget_type"), "team_spend_periods", ["budget_type"], unique=False)
+    op.create_index(op.f("ix_team_spend_periods_period_start"), "team_spend_periods", ["period_start"], unique=False)
+    op.create_index(op.f("ix_team_spend_periods_period_end"), "team_spend_periods", ["period_end"], unique=False)
+    op.create_index(op.f("ix_team_spend_periods_stripe_event_id"), "team_spend_periods", ["stripe_event_id"], unique=False)
+
+    op.create_table(
+        "team_spend_period_keys",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("team_spend_period_id", sa.Integer(), nullable=False),
+        sa.Column("key_id", sa.Integer(), nullable=True),
+        sa.Column("owner_id", sa.Integer(), nullable=True),
+        sa.Column("key_name_snapshot", sa.String(), nullable=True),
+        sa.Column("spend", sa.Float(), nullable=False),
+        sa.Column("max_budget", sa.Float(), nullable=True),
+        sa.Column("prompt_tokens", sa.Integer(), nullable=True),
+        sa.Column("completion_tokens", sa.Integer(), nullable=True),
+        sa.Column("total_tokens", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(["key_id"], ["ai_tokens.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["owner_id"], ["users.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["team_spend_period_id"], ["team_spend_periods.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("team_spend_period_id", "key_id", name="uq_team_spend_period_key"),
+    )
+    op.create_index(op.f("ix_team_spend_period_keys_id"), "team_spend_period_keys", ["id"], unique=False)
+    op.create_index(op.f("ix_team_spend_period_keys_team_spend_period_id"), "team_spend_period_keys", ["team_spend_period_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_team_spend_period_keys_team_spend_period_id"), table_name="team_spend_period_keys")
+    op.drop_index(op.f("ix_team_spend_period_keys_id"), table_name="team_spend_period_keys")
+    op.drop_table("team_spend_period_keys")
+
+    op.drop_index(op.f("ix_team_spend_periods_stripe_event_id"), table_name="team_spend_periods")
+    op.drop_index(op.f("ix_team_spend_periods_period_end"), table_name="team_spend_periods")
+    op.drop_index(op.f("ix_team_spend_periods_period_start"), table_name="team_spend_periods")
+    op.drop_index(op.f("ix_team_spend_periods_budget_type"), table_name="team_spend_periods")
+    op.drop_index(op.f("ix_team_spend_periods_region_id"), table_name="team_spend_periods")
+    op.drop_index(op.f("ix_team_spend_periods_team_id"), table_name="team_spend_periods")
+    op.drop_index(op.f("ix_team_spend_periods_id"), table_name="team_spend_periods")
+    op.drop_table("team_spend_periods")

--- a/app/migrations/versions/20260512_170000_9d1a2b3c4d5e_add_team_spend_period_tables.py
+++ b/app/migrations/versions/20260512_170000_9d1a2b3c4d5e_add_team_spend_period_tables.py
@@ -49,13 +49,45 @@ def upgrade() -> None:
             name="uq_team_spend_period_unique_window",
         ),
     )
-    op.create_index(op.f("ix_team_spend_periods_id"), "team_spend_periods", ["id"], unique=False)
-    op.create_index(op.f("ix_team_spend_periods_team_id"), "team_spend_periods", ["team_id"], unique=False)
-    op.create_index(op.f("ix_team_spend_periods_region_id"), "team_spend_periods", ["region_id"], unique=False)
-    op.create_index(op.f("ix_team_spend_periods_budget_type"), "team_spend_periods", ["budget_type"], unique=False)
-    op.create_index(op.f("ix_team_spend_periods_period_start"), "team_spend_periods", ["period_start"], unique=False)
-    op.create_index(op.f("ix_team_spend_periods_period_end"), "team_spend_periods", ["period_end"], unique=False)
-    op.create_index(op.f("ix_team_spend_periods_stripe_event_id"), "team_spend_periods", ["stripe_event_id"], unique=False)
+    op.create_index(
+        op.f("ix_team_spend_periods_id"), "team_spend_periods", ["id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_team_spend_periods_team_id"),
+        "team_spend_periods",
+        ["team_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_team_spend_periods_region_id"),
+        "team_spend_periods",
+        ["region_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_team_spend_periods_budget_type"),
+        "team_spend_periods",
+        ["budget_type"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_team_spend_periods_period_start"),
+        "team_spend_periods",
+        ["period_start"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_team_spend_periods_period_end"),
+        "team_spend_periods",
+        ["period_end"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_team_spend_periods_stripe_event_id"),
+        "team_spend_periods",
+        ["stripe_event_id"],
+        unique=False,
+    )
 
     op.create_table(
         "team_spend_period_keys",
@@ -71,24 +103,55 @@ def upgrade() -> None:
         sa.Column("total_tokens", sa.Integer(), nullable=True),
         sa.ForeignKeyConstraint(["key_id"], ["ai_tokens.id"], ondelete="SET NULL"),
         sa.ForeignKeyConstraint(["owner_id"], ["users.id"], ondelete="SET NULL"),
-        sa.ForeignKeyConstraint(["team_spend_period_id"], ["team_spend_periods.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["team_spend_period_id"], ["team_spend_periods.id"], ondelete="CASCADE"
+        ),
         sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("team_spend_period_id", "key_id", name="uq_team_spend_period_key"),
+        sa.UniqueConstraint(
+            "team_spend_period_id", "key_id", name="uq_team_spend_period_key"
+        ),
     )
-    op.create_index(op.f("ix_team_spend_period_keys_id"), "team_spend_period_keys", ["id"], unique=False)
-    op.create_index(op.f("ix_team_spend_period_keys_team_spend_period_id"), "team_spend_period_keys", ["team_spend_period_id"], unique=False)
+    op.create_index(
+        op.f("ix_team_spend_period_keys_id"),
+        "team_spend_period_keys",
+        ["id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_team_spend_period_keys_team_spend_period_id"),
+        "team_spend_period_keys",
+        ["team_spend_period_id"],
+        unique=False,
+    )
 
 
 def downgrade() -> None:
-    op.drop_index(op.f("ix_team_spend_period_keys_team_spend_period_id"), table_name="team_spend_period_keys")
-    op.drop_index(op.f("ix_team_spend_period_keys_id"), table_name="team_spend_period_keys")
+    op.drop_index(
+        op.f("ix_team_spend_period_keys_team_spend_period_id"),
+        table_name="team_spend_period_keys",
+    )
+    op.drop_index(
+        op.f("ix_team_spend_period_keys_id"), table_name="team_spend_period_keys"
+    )
     op.drop_table("team_spend_period_keys")
 
-    op.drop_index(op.f("ix_team_spend_periods_stripe_event_id"), table_name="team_spend_periods")
-    op.drop_index(op.f("ix_team_spend_periods_period_end"), table_name="team_spend_periods")
-    op.drop_index(op.f("ix_team_spend_periods_period_start"), table_name="team_spend_periods")
-    op.drop_index(op.f("ix_team_spend_periods_budget_type"), table_name="team_spend_periods")
-    op.drop_index(op.f("ix_team_spend_periods_region_id"), table_name="team_spend_periods")
-    op.drop_index(op.f("ix_team_spend_periods_team_id"), table_name="team_spend_periods")
+    op.drop_index(
+        op.f("ix_team_spend_periods_stripe_event_id"), table_name="team_spend_periods"
+    )
+    op.drop_index(
+        op.f("ix_team_spend_periods_period_end"), table_name="team_spend_periods"
+    )
+    op.drop_index(
+        op.f("ix_team_spend_periods_period_start"), table_name="team_spend_periods"
+    )
+    op.drop_index(
+        op.f("ix_team_spend_periods_budget_type"), table_name="team_spend_periods"
+    )
+    op.drop_index(
+        op.f("ix_team_spend_periods_region_id"), table_name="team_spend_periods"
+    )
+    op.drop_index(
+        op.f("ix_team_spend_periods_team_id"), table_name="team_spend_periods"
+    )
     op.drop_index(op.f("ix_team_spend_periods_id"), table_name="team_spend_periods")
     op.drop_table("team_spend_periods")

--- a/app/migrations/versions/20260513_113000_2f7c9d1e4aab_enforce_unique_unmatched_spend_period_key.py
+++ b/app/migrations/versions/20260513_113000_2f7c9d1e4aab_enforce_unique_unmatched_spend_period_key.py
@@ -1,0 +1,34 @@
+"""enforce unique unmatched spend period key rows
+
+Revision ID: 2f7c9d1e4aab
+Revises: 9d1a2b3c4d5e
+Create Date: 2026-05-13 11:30:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "2f7c9d1e4aab"
+down_revision = "9d1a2b3c4d5e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "uq_team_spend_period_key_null_key_id",
+        "team_spend_period_keys",
+        ["team_spend_period_id", "owner_id", "key_name_snapshot"],
+        unique=True,
+        postgresql_where=sa.text("key_id IS NULL"),
+        sqlite_where=sa.text("key_id IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_team_spend_period_key_null_key_id",
+        table_name="team_spend_period_keys",
+    )

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -443,7 +443,6 @@ class SpendBudgetUpdateResponse(BaseModel):
 class TeamSpendHistoryKeyItem(BaseModel):
     key_id: Optional[int] = None
     owner_id: Optional[int] = None
-    key_name: Optional[str] = None
     spend: float
     max_budget: Optional[float] = None
     prompt_tokens: Optional[int] = None

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -443,6 +443,7 @@ class SpendBudgetUpdateResponse(BaseModel):
 class TeamSpendHistoryKeyItem(BaseModel):
     key_id: Optional[int] = None
     owner_id: Optional[int] = None
+    key_name_snapshot: Optional[str] = None
     spend: float
     max_budget: Optional[float] = None
     prompt_tokens: Optional[int] = None

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -440,6 +440,41 @@ class SpendBudgetUpdateResponse(BaseModel):
     note: Optional[str] = None
 
 
+class TeamSpendHistoryKeyItem(BaseModel):
+    key_id: Optional[int] = None
+    owner_id: Optional[int] = None
+    key_name: Optional[str] = None
+    spend: float
+    max_budget: Optional[float] = None
+    prompt_tokens: Optional[int] = None
+    completion_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
+
+
+class TeamSpendHistoryPeriodItem(BaseModel):
+    period_start: datetime
+    period_end: datetime
+    budget_type: str
+    total_spend: float
+    total_budget: Optional[float] = None
+    total_prompt_tokens: Optional[int] = None
+    total_completion_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
+    source: str
+    stripe_event_id: Optional[str] = None
+    stripe_invoice_id: Optional[str] = None
+    stripe_subscription_id: Optional[str] = None
+    keys: List[TeamSpendHistoryKeyItem]
+
+
+class TeamSpendHistoryResponse(BaseModel):
+    region_id: int
+    region_name: str
+    team_id: int
+    team_name: str
+    periods: List[TeamSpendHistoryPeriodItem]
+
+
 class LiteLLMToken(BaseModel):
     id: int
     litellm_token: str

--- a/app/services/stripe.py
+++ b/app/services/stripe.py
@@ -14,7 +14,9 @@ logger = logging.getLogger(__name__)
 stripe.api_key = os.getenv("STRIPE_SECRET_KEY")
 
 # Full list of possible events: https://docs.stripe.com/api/events/types
-INVOICE_SUCCESS_EVENTS = ["invoice.paid"]  # Renewal
+# Keep both names: Stripe commonly emits `invoice.paid`, while some tests/
+# fixtures still use `invoice.payment_succeeded`.
+INVOICE_SUCCESS_EVENTS = ["invoice.paid", "invoice.payment_succeeded"]  # Renewal
 SUBSCRIPTION_SUCCESS_EVENTS = [
     "customer.subscription.resumed",
     "customer.subscription.created",

--- a/app/services/stripe.py
+++ b/app/services/stripe.py
@@ -14,9 +14,7 @@ logger = logging.getLogger(__name__)
 stripe.api_key = os.getenv("STRIPE_SECRET_KEY")
 
 # Full list of possible events: https://docs.stripe.com/api/events/types
-# Keep both names: Stripe commonly emits `invoice.paid`, while some tests/
-# fixtures still use `invoice.payment_succeeded`.
-INVOICE_SUCCESS_EVENTS = ["invoice.paid", "invoice.payment_succeeded"]  # Renewal
+INVOICE_SUCCESS_EVENTS = ["invoice.paid"]  # Renewal
 SUBSCRIPTION_SUCCESS_EVENTS = [
     "customer.subscription.resumed",
     "customer.subscription.created",

--- a/scripts/initialise_resources.py
+++ b/scripts/initialise_resources.py
@@ -113,13 +113,13 @@ def _restamp_to_safe_revision(
 
     # If we get here, all revisions look applied but schema still fails.
     # Fall back to base to let alembic replay everything.
-    print("All migrations appear applied but schema still has gaps - re-stamping to base")
+    print(
+        "All migrations appear applied but schema still has gaps - re-stamping to base"
+    )
     alembic.command.stamp(alembic_cfg, "base")
 
 
-def _migration_has_missing_ops(
-    source: str, db_tables: set, get_columns
-) -> bool:
+def _migration_has_missing_ops(source: str, db_tables: set, get_columns) -> bool:
     """Return True when migration schema operations appear unapplied."""
     import ast
 
@@ -180,9 +180,8 @@ def _migration_has_missing_ops(
                 old_col_name = node.args[1].value
                 new_col_name = None
                 for kwarg in node.keywords:
-                    if (
-                        kwarg.arg == "new_column_name"
-                        and isinstance(kwarg.value, ast.Constant)
+                    if kwarg.arg == "new_column_name" and isinstance(
+                        kwarg.value, ast.Constant
                     ):
                         new_col_name = kwarg.value.value
                         break

--- a/scripts/local/e2e_spend_history_periodic_webhook_local.sh
+++ b/scripts/local/e2e_spend_history_periodic_webhook_local.sh
@@ -292,7 +292,9 @@ sleep 4
 say "Querying new historical endpoint"
 api GET "/spend/${REGION_ID}/team/${TEAM_ID}/history"
 HISTORY="$HTTP_BODY"
-say "Full history endpoint JSON response"
+say "Raw history endpoint response"
+echo "$HISTORY"
+say "Pretty history endpoint response"
 echo "$HISTORY" | jq '.'
 echo "$HISTORY" | jq '{team_id,region_id,period_count:(.periods|length),latest:(.periods[0] // null)}'
 

--- a/scripts/local/e2e_spend_history_periodic_webhook_local.sh
+++ b/scripts/local/e2e_spend_history_periodic_webhook_local.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:8800}"
+AUTH_TOKEN="${AUTH_TOKEN:-LOCALBT}"
+REGION_ID="${REGION_ID:-1}"
+BACKEND_CONTAINER="${BACKEND_CONTAINER:-amazeeai-backend-1}"
+POSTGRES_CONTAINER="${POSTGRES_CONTAINER:-amazeeai-postgres-1}"
+DB_NAME="${DB_NAME:-postgres_service}"
+
+need_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "Missing command: $1" >&2; exit 1; }; }
+for c in curl jq openssl python3 docker; do need_cmd "$c"; done
+
+TMP_DIR="$(mktemp -d /tmp/e2e_spend_history.XXXXXX)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+api() {
+  local method="$1"; local path="$2"; local data="${3:-}"
+  local out="$TMP_DIR/body.json"
+  if [[ -n "$data" ]]; then
+    HTTP_STATUS=$(curl -sS -o "$out" -w "%{http_code}" -X "$method" "${BASE_URL}${path}" \
+      -H "Authorization: Bearer ${AUTH_TOKEN}" -H "Content-Type: application/json" -d "$data")
+  else
+    HTTP_STATUS=$(curl -sS -o "$out" -w "%{http_code}" -X "$method" "${BASE_URL}${path}" \
+      -H "Authorization: Bearer ${AUTH_TOKEN}")
+  fi
+  HTTP_BODY="$(cat "$out")"
+}
+
+say() { echo "[$(date +%H:%M:%S)] $*"; }
+fail() { echo "ERROR: $*" >&2; exit 1; }
+
+say "Checking local services"
+docker ps --format 'table {{.Names}}\t{{.Status}}' | sed -n '1,20p'
+
+RUN_ID="$(date +%s)"
+TEAM_NAME="spend-hist-webhook-e2e-${RUN_ID}"
+TEAM_EMAIL="spend-hist-webhook-e2e-${RUN_ID}@example.com"
+KEY1_NAME="spend-hist-key-1-${RUN_ID}"
+KEY2_NAME="spend-hist-key-2-${RUN_ID}"
+STRIPE_CUSTOMER_ID="cus_local_e2e_${RUN_ID}"
+STRIPE_SUB_ID="sub_local_e2e_${RUN_ID}"
+STRIPE_EVENT_ID="evt_local_e2e_${RUN_ID}"
+STRIPE_INVOICE_ID="in_local_e2e_${RUN_ID}"
+
+say "Creating PERIODIC team"
+api POST "/teams/" "$(jq -nc --arg n "$TEAM_NAME" --arg e "$TEAM_EMAIL" '{name:$n,admin_email:$e,budget_type:"periodic",require_purchase_for_requests:false}')"
+[[ "$HTTP_STATUS" == "201" ]] || fail "team create failed status=$HTTP_STATUS body=$HTTP_BODY"
+TEAM_ID="$(echo "$HTTP_BODY" | jq -r '.id')"
+say "Team created: id=${TEAM_ID}"
+
+say "Ensuring team is associated with region ${REGION_ID}"
+api POST "/regions/${REGION_ID}/teams/${TEAM_ID}" || true
+say "Associate status=${HTTP_STATUS}"
+
+say "Creating 2 team keys"
+api POST "/private-ai-keys/" "$(jq -nc --argjson rid "$REGION_ID" --argjson tid "$TEAM_ID" --arg name "$KEY1_NAME" '{region_id:$rid,name:$name,team_id:$tid}')"
+[[ "$HTTP_STATUS" == "200" ]] || fail "key1 create failed status=$HTTP_STATUS body=$HTTP_BODY"
+KEY1_ID="$(echo "$HTTP_BODY" | jq -r '.id')"
+KEY1_TOKEN="$(echo "$HTTP_BODY" | jq -r '.litellm_token')"
+
+api POST "/private-ai-keys/" "$(jq -nc --argjson rid "$REGION_ID" --argjson tid "$TEAM_ID" --arg name "$KEY2_NAME" '{region_id:$rid,name:$name,team_id:$tid}')"
+[[ "$HTTP_STATUS" == "200" ]] || fail "key2 create failed status=$HTTP_STATUS body=$HTTP_BODY"
+KEY2_ID="$(echo "$HTTP_BODY" | jq -r '.id')"
+KEY2_TOKEN="$(echo "$HTTP_BODY" | jq -r '.litellm_token')"
+
+say "Created keys: ${KEY1_ID}, ${KEY2_ID}"
+
+say "Sending mocked usage to LiteLLM for both keys"
+for token in "$KEY1_TOKEN" "$KEY2_TOKEN"; do
+  curl -sS http://localhost:4000/v1/chat/completions \
+    -H "Authorization: Bearer ${token}" \
+    -H "Content-Type: application/json" \
+    -d '{"model":"dummy-gpt-5-4","messages":[{"role":"user","content":"Hello"}],"mock_response":{"content":"Test response","usage":{"prompt_tokens":100,"completion_tokens":14900,"total_tokens":15000}}}' \
+    | jq '{id,model,usage}'
+done
+
+say "Current spend snapshot before webhook"
+api GET "/spend/${REGION_ID}/team/${TEAM_ID}"
+echo "$HTTP_BODY" | jq '{team_id,region_id,total_spend,key_count,keys: [.keys[]|{key_id,spend}]}'
+
+say "Setting stripe_customer_id on team in API DB"
+docker exec "$BACKEND_CONTAINER" sh -lc "cd /app && python3 - <<'PY'
+from sqlalchemy.orm import sessionmaker
+from app.db.database import engine
+from app.db.models import DBTeam
+TEAM_ID = ${TEAM_ID}
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+db = SessionLocal()
+team = db.query(DBTeam).filter(DBTeam.id == TEAM_ID).first()
+team.stripe_customer_id = '${STRIPE_CUSTOMER_ID}'
+db.add(team)
+db.commit()
+print('updated', team.id, team.stripe_customer_id)
+db.close()
+PY"
+
+say "Resolving Stripe webhook secret"
+WEBHOOK_SECRET="$(docker exec "$BACKEND_CONTAINER" sh -lc 'printenv WEBHOOK_SIG' | tr -d '\r')"
+if [[ -z "$WEBHOOK_SECRET" ]]; then
+  WEBHOOK_SECRET="$(docker exec "$POSTGRES_CONTAINER" psql -U postgres -d "$DB_NAME" -tAc "select value from system_secrets where key='stripe_webhook_secret' order by id desc limit 1;" | tr -d '[:space:]')"
+fi
+[[ -n "$WEBHOOK_SECRET" ]] || fail "Unable to resolve webhook secret (WEBHOOK_SIG/system_secrets)"
+say "Webhook secret resolved"
+
+say "Building fake Stripe invoice.paid event payload"
+NOW_TS="$(date +%s)"
+PERIOD_END="$NOW_TS"
+PERIOD_START="$((NOW_TS - 2592000))"
+PAYLOAD_FILE="$TMP_DIR/stripe_event.json"
+cat > "$PAYLOAD_FILE" <<JSON
+{
+  "id": "${STRIPE_EVENT_ID}",
+  "object": "event",
+  "type": "invoice.paid",
+  "data": {
+    "object": {
+      "id": "${STRIPE_INVOICE_ID}",
+      "object": "invoice",
+      "customer": "${STRIPE_CUSTOMER_ID}",
+      "period_start": ${PERIOD_START},
+      "period_end": ${PERIOD_END},
+      "parent": {
+        "subscription_details": {
+          "subscription": "${STRIPE_SUB_ID}"
+        }
+      }
+    }
+  }
+}
+JSON
+PAYLOAD="$(cat "$PAYLOAD_FILE")"
+
+TS="$(date +%s)"
+SIGNED_PAYLOAD="${TS}.${PAYLOAD}"
+SIG="$(printf '%s' "$SIGNED_PAYLOAD" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" -hex | awk '{print $2}')"
+STRIPE_SIGNATURE="t=${TS},v1=${SIG}"
+
+say "Posting fake Stripe webhook to /billing/events"
+WEBHOOK_RESP_FILE="$TMP_DIR/webhook_resp.txt"
+WEBHOOK_STATUS=$(curl -sS -o "$WEBHOOK_RESP_FILE" -w "%{http_code}" -X POST "${BASE_URL}/billing/events" \
+  -H "Content-Type: application/json" \
+  -H "stripe-signature: ${STRIPE_SIGNATURE}" \
+  --data-binary @"$PAYLOAD_FILE")
+echo "Webhook status=${WEBHOOK_STATUS}"
+cat "$WEBHOOK_RESP_FILE"
+[[ "$WEBHOOK_STATUS" == "200" ]] || fail "webhook call failed"
+
+say "Waiting for background processing"
+sleep 3
+
+say "Querying new historical endpoint"
+api GET "/spend/${REGION_ID}/team/${TEAM_ID}/history"
+HISTORY="$HTTP_BODY"
+echo "$HISTORY" | jq '{team_id,region_id,period_count:(.periods|length),latest:(.periods[0] // null)}'
+
+EVENT_MATCH="$(echo "$HISTORY" | jq -r --arg eid "$STRIPE_EVENT_ID" '[.periods[]? | select(.stripe_event_id==$eid)] | length')"
+[[ "$EVENT_MATCH" -ge 1 ]] || fail "No history period found for stripe_event_id=${STRIPE_EVENT_ID}"
+
+say "Inspecting API DB persisted rows"
+docker exec "$POSTGRES_CONTAINER" psql -U postgres -d "$DB_NAME" -c "select id,team_id,region_id,budget_type,period_start,period_end,total_spend,stripe_event_id,stripe_invoice_id from team_spend_periods where team_id=${TEAM_ID} order by id desc limit 5;"
+docker exec "$POSTGRES_CONTAINER" psql -U postgres -d "$DB_NAME" -c "select team_spend_period_id,key_id,key_name_snapshot,spend,total_tokens from team_spend_period_keys where team_spend_period_id in (select id from team_spend_periods where team_id=${TEAM_ID}) order by id desc limit 10;"
+
+say "Inspecting LiteLLM DB spend logs for team eu-west_${TEAM_ID}"
+docker exec amazeeai-litellm_db-1 sh -lc "psql -U llmproxy -d litellm -c \"select api_key,team_id,model,total_tokens,prompt_tokens,completion_tokens,spend,\\\"startTime\\\" from \\\"LiteLLM_SpendLogs\\\" where team_id='eu-west_${TEAM_ID}' order by \\\"startTime\\\" desc limit 5;\""
+
+say "E2E completed successfully"
+echo "Artifacts: team_id=${TEAM_ID} key_ids=${KEY1_ID},${KEY2_ID} stripe_event_id=${STRIPE_EVENT_ID}"

--- a/scripts/local/e2e_spend_history_periodic_webhook_local.sh
+++ b/scripts/local/e2e_spend_history_periodic_webhook_local.sh
@@ -17,9 +17,48 @@ TEAM_ID=""
 KEY1_ID=""
 KEY2_ID=""
 
+pass() { say "✅ $*"; }
+fail_msg() { say "❌ $*"; }
+
+assert_status() {
+  local got="$1" expected="$2" label="$3"
+  if [[ "$got" == "$expected" ]]; then
+    pass "$label (status=$got)"
+  else
+    fail_msg "$label (status=$got, expected=$expected)"
+    exit 1
+  fi
+}
+
+float_gt_zero() {
+  python3 - "$1" <<'PY'
+import sys
+v=float(sys.argv[1])
+print(1 if v > 0 else 0)
+PY
+}
+
+wait_for_team_spend_gt_zero() {
+  local region_id="$1" team_id="$2" timeout="${3:-20}"
+  local i=0
+  while (( i < timeout )); do
+    api GET "/spend/${region_id}/team/${team_id}"
+    local spend
+    spend="$(echo "$HTTP_BODY" | jq -r '.total_spend // 0')"
+    if [[ "$(float_gt_zero "$spend")" == "1" ]]; then
+      echo "$spend"
+      return 0
+    fi
+    sleep 1
+    i=$((i+1))
+  done
+  echo "0"
+  return 1
+}
+
 cleanup() {
-  rm -rf "$TMP_DIR"
   if [[ "$CLEANUP_CREATED" != "1" ]]; then
+    rm -rf "$TMP_DIR"
     return
   fi
 
@@ -55,6 +94,8 @@ PY" >/dev/null 2>&1 || true
     api DELETE "/teams/${TEAM_ID}" || true
     say "Delete team id=${TEAM_ID} status=${HTTP_STATUS:-n/a}"
   fi
+
+  rm -rf "$TMP_DIR"
 }
 
 trap cleanup EXIT
@@ -93,6 +134,7 @@ api POST "/teams/" "$(jq -nc --arg n "$TEAM_NAME" --arg e "$TEAM_EMAIL" '{name:$
 [[ "$HTTP_STATUS" == "201" ]] || fail "team create failed status=$HTTP_STATUS body=$HTTP_BODY"
 TEAM_ID="$(echo "$HTTP_BODY" | jq -r '.id')"
 say "Team created: id=${TEAM_ID}"
+pass "Team created"
 
 say "Ensuring team is associated with region ${REGION_ID}"
 api POST "/regions/${REGION_ID}/teams/${TEAM_ID}" || true
@@ -100,12 +142,12 @@ say "Associate status=${HTTP_STATUS}"
 
 say "Creating 2 team keys"
 api POST "/private-ai-keys/" "$(jq -nc --argjson rid "$REGION_ID" --argjson tid "$TEAM_ID" --arg name "$KEY1_NAME" '{region_id:$rid,name:$name,team_id:$tid}')"
-[[ "$HTTP_STATUS" == "200" ]] || fail "key1 create failed status=$HTTP_STATUS body=$HTTP_BODY"
+assert_status "$HTTP_STATUS" "200" "Key 1 created"
 KEY1_ID="$(echo "$HTTP_BODY" | jq -r '.id')"
 KEY1_TOKEN="$(echo "$HTTP_BODY" | jq -r '.litellm_token')"
 
 api POST "/private-ai-keys/" "$(jq -nc --argjson rid "$REGION_ID" --argjson tid "$TEAM_ID" --arg name "$KEY2_NAME" '{region_id:$rid,name:$name,team_id:$tid}')"
-[[ "$HTTP_STATUS" == "200" ]] || fail "key2 create failed status=$HTTP_STATUS body=$HTTP_BODY"
+assert_status "$HTTP_STATUS" "200" "Key 2 created"
 KEY2_ID="$(echo "$HTTP_BODY" | jq -r '.id')"
 KEY2_TOKEN="$(echo "$HTTP_BODY" | jq -r '.litellm_token')"
 
@@ -119,6 +161,13 @@ for token in "$KEY1_TOKEN" "$KEY2_TOKEN"; do
     -d '{"model":"dummy-gpt-5-4","messages":[{"role":"user","content":"Hello"}],"mock_response":{"content":"Test response","usage":{"prompt_tokens":100,"completion_tokens":14900,"total_tokens":15000}}}' \
     | jq '{id,model,usage}'
 done
+
+say "Waiting for spend propagation to API /spend endpoint"
+if PRE_SPEND="$(wait_for_team_spend_gt_zero "$REGION_ID" "$TEAM_ID" 30)"; then
+  pass "Spend propagated before webhook (total_spend=${PRE_SPEND})"
+else
+  fail_msg "Spend still zero after waiting. Continuing, but history will likely also be zero."
+fi
 
 say "Current spend snapshot before webhook"
 api GET "/spend/${REGION_ID}/team/${TEAM_ID}"
@@ -189,7 +238,7 @@ WEBHOOK_STATUS=$(curl -sS -o "$WEBHOOK_RESP_FILE" -w "%{http_code}" -X POST "${B
   --data-binary @"$PAYLOAD_FILE")
 echo "Webhook status=${WEBHOOK_STATUS}"
 cat "$WEBHOOK_RESP_FILE"
-[[ "$WEBHOOK_STATUS" == "200" ]] || fail "webhook call failed"
+assert_status "$WEBHOOK_STATUS" "200" "Fake Stripe webhook accepted"
 
 say "Waiting for background processing"
 sleep 3
@@ -201,6 +250,7 @@ echo "$HISTORY" | jq '{team_id,region_id,period_count:(.periods|length),latest:(
 
 EVENT_MATCH="$(echo "$HISTORY" | jq -r --arg eid "$STRIPE_EVENT_ID" '[.periods[]? | select(.stripe_event_id==$eid)] | length')"
 [[ "$EVENT_MATCH" -ge 1 ]] || fail "No history period found for stripe_event_id=${STRIPE_EVENT_ID}"
+pass "History row created for stripe_event_id=${STRIPE_EVENT_ID}"
 
 say "Inspecting API DB persisted rows"
 docker exec "$POSTGRES_CONTAINER" psql -U postgres -d "$DB_NAME" -c "select id,team_id,region_id,budget_type,period_start,period_end,total_spend,stripe_event_id,stripe_invoice_id from team_spend_periods where team_id=${TEAM_ID} order by id desc limit 5;"

--- a/scripts/local/e2e_spend_history_periodic_webhook_local.sh
+++ b/scripts/local/e2e_spend_history_periodic_webhook_local.sh
@@ -7,12 +7,57 @@ REGION_ID="${REGION_ID:-1}"
 BACKEND_CONTAINER="${BACKEND_CONTAINER:-amazeeai-backend-1}"
 POSTGRES_CONTAINER="${POSTGRES_CONTAINER:-amazeeai-postgres-1}"
 DB_NAME="${DB_NAME:-postgres_service}"
+CLEANUP_CREATED=1
 
 need_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "Missing command: $1" >&2; exit 1; }; }
 for c in curl jq openssl python3 docker; do need_cmd "$c"; done
 
 TMP_DIR="$(mktemp -d /tmp/e2e_spend_history.XXXXXX)"
-trap 'rm -rf "$TMP_DIR"' EXIT
+TEAM_ID=""
+KEY1_ID=""
+KEY2_ID=""
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+  if [[ "$CLEANUP_CREATED" != "1" ]]; then
+    return
+  fi
+
+  echo
+  say "Cleanup: deleting created entities"
+
+  if [[ -n "$KEY1_ID" ]]; then
+    api DELETE "/private-ai-keys/${KEY1_ID}" || true
+    say "Delete key1 id=${KEY1_ID} status=${HTTP_STATUS:-n/a}"
+  fi
+  if [[ -n "$KEY2_ID" ]]; then
+    api DELETE "/private-ai-keys/${KEY2_ID}" || true
+    say "Delete key2 id=${KEY2_ID} status=${HTTP_STATUS:-n/a}"
+  fi
+
+  if [[ -n "$TEAM_ID" ]]; then
+    docker exec "$BACKEND_CONTAINER" sh -lc "cd /app && python3 - <<'PY'
+from sqlalchemy.orm import sessionmaker
+from app.db.database import engine
+from app.db.models import DBTeam
+TEAM_ID = ${TEAM_ID}
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+db = SessionLocal()
+team = db.query(DBTeam).filter(DBTeam.id == TEAM_ID).first()
+if team is not None:
+    team.stripe_customer_id = None
+    db.add(team)
+    db.commit()
+print('stripe_customer_id_reset', TEAM_ID)
+db.close()
+PY" >/dev/null 2>&1 || true
+
+    api DELETE "/teams/${TEAM_ID}" || true
+    say "Delete team id=${TEAM_ID} status=${HTTP_STATUS:-n/a}"
+  fi
+}
+
+trap cleanup EXIT
 
 api() {
   local method="$1"; local path="$2"; local data="${3:-}"

--- a/scripts/local/e2e_spend_history_periodic_webhook_local.sh
+++ b/scripts/local/e2e_spend_history_periodic_webhook_local.sh
@@ -92,6 +92,10 @@ db.close()
 PY" >/dev/null 2>&1 || true
 
     api DELETE "/teams/${TEAM_ID}" || true
+    if [[ "${HTTP_STATUS:-}" == "500" ]]; then
+      api POST "/teams/${TEAM_ID}/soft-delete" || true
+      say "Soft-delete team fallback id=${TEAM_ID} status=${HTTP_STATUS:-n/a}"
+    fi
     say "Delete team id=${TEAM_ID} status=${HTTP_STATUS:-n/a}"
   fi
 
@@ -176,14 +180,46 @@ db.close()
 PY"
 
 say "Resolving Stripe webhook secret"
-WEBHOOK_SECRET="$(docker exec "$BACKEND_CONTAINER" sh -lc 'printenv WEBHOOK_SIG' | tr -d '\r')"
+WEBHOOK_SECRET="$(docker exec "$BACKEND_CONTAINER" sh -lc 'printenv WEBHOOK_SIG' 2>/dev/null | tr -d '\r' || true)"
 if [[ -z "$WEBHOOK_SECRET" ]]; then
-  WEBHOOK_SECRET="$(docker exec "$POSTGRES_CONTAINER" psql -U postgres -d "$DB_NAME" -tAc "select value from system_secrets where key='stripe_webhook_secret' order by id desc limit 1;" | tr -d '[:space:]')"
+  WEBHOOK_SECRET="$(docker exec "$POSTGRES_CONTAINER" sh -lc "psql -U postgres -d '$DB_NAME' -tAc \"select value from system_secrets where key='stripe_webhook_secret' order by id desc limit 1;\" 2>/dev/null || true" | tr -d '[:space:]' || true)"
+fi
+if [[ -z "$WEBHOOK_SECRET" ]]; then
+  WEBHOOK_SECRET="$(docker exec "$BACKEND_CONTAINER" sh -lc "cd /app && python3 - <<'PY'
+from sqlalchemy.orm import sessionmaker
+from app.db.database import engine
+from app.db.models import DBSystemSecret
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+db = SessionLocal()
+row = db.query(DBSystemSecret).filter(DBSystemSecret.key == 'stripe_webhook_secret').order_by(DBSystemSecret.id.desc()).first()
+print(row.value if row else '')
+db.close()
+PY" | tr -d '[:space:]' || true)"
+fi
+if [[ -z "$WEBHOOK_SECRET" ]]; then
+  say "No webhook secret found; creating local test secret in API DB"
+  WEBHOOK_SECRET="whsec_local_${RUN_ID}"
+  docker exec "$BACKEND_CONTAINER" sh -lc "cd /app && python3 - <<'PY'
+from sqlalchemy.orm import sessionmaker
+from app.db.database import engine
+from app.db.models import DBSystemSecret
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+db = SessionLocal()
+row = db.query(DBSystemSecret).filter(DBSystemSecret.key == 'stripe_webhook_secret').first()
+if row is None:
+    row = DBSystemSecret(key='stripe_webhook_secret', value='${WEBHOOK_SECRET}', description='local e2e webhook secret')
+else:
+    row.value = '${WEBHOOK_SECRET}'
+db.add(row)
+db.commit()
+print('secret_upserted')
+db.close()
+PY" >/dev/null
 fi
 [[ -n "$WEBHOOK_SECRET" ]] || fail "Unable to resolve webhook secret (WEBHOOK_SIG/system_secrets)"
 say "Webhook secret resolved"
 
-say "Building and sending first fake Stripe invoice.paid webhook ($5)"
+say "Building and sending first fake Stripe invoice.paid webhook (\$5)"
 NOW_TS="$(date +%s)"
 P1_START="$((NOW_TS - 5184000))"
 P1_END="$((NOW_TS - 2592000))"
@@ -217,9 +253,16 @@ JSON
 PAYLOAD_1="$(cat "$PAYLOAD_FILE_1")"
 
 TS="$(date +%s)"
-SIGNED_PAYLOAD_1="${TS}.${PAYLOAD_1}"
-SIG_1="$(printf '%s' "$SIGNED_PAYLOAD_1" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" -hex | awk '{print $2}')"
-STRIPE_SIGNATURE_1="t=${TS},v1=${SIG_1}"
+STRIPE_SIGNATURE_1="$(python3 - "$WEBHOOK_SECRET" "$TS" "$PAYLOAD_FILE_1" <<'PY'
+import hmac, hashlib, sys
+secret = sys.argv[1].encode()
+ts = sys.argv[2]
+payload = open(sys.argv[3], 'rb').read()
+signed = ts.encode() + b'.' + payload
+sig = hmac.new(secret, signed, hashlib.sha256).hexdigest()
+print(f"t={ts},v1={sig}")
+PY
+)"
 
 say "Posting first fake Stripe webhook to /billing/events"
 WEBHOOK_RESP_FILE="$TMP_DIR/webhook_resp.txt"
@@ -247,7 +290,7 @@ else
   fail_msg "Spend still zero after waiting. Continuing, but second snapshot may be zero."
 fi
 
-say "Building and sending second fake Stripe invoice.paid webhook ($5, new period)"
+say "Building and sending second fake Stripe invoice.paid webhook (\$5, new period)"
 PAYLOAD_FILE_2="$TMP_DIR/stripe_event_2.json"
 cat > "$PAYLOAD_FILE_2" <<JSON
 {
@@ -274,9 +317,16 @@ cat > "$PAYLOAD_FILE_2" <<JSON
 JSON
 PAYLOAD_2="$(cat "$PAYLOAD_FILE_2")"
 TS2="$(date +%s)"
-SIGNED_PAYLOAD_2="${TS2}.${PAYLOAD_2}"
-SIG_2="$(printf '%s' "$SIGNED_PAYLOAD_2" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" -hex | awk '{print $2}')"
-STRIPE_SIGNATURE_2="t=${TS2},v1=${SIG_2}"
+STRIPE_SIGNATURE_2="$(python3 - "$WEBHOOK_SECRET" "$TS2" "$PAYLOAD_FILE_2" <<'PY'
+import hmac, hashlib, sys
+secret = sys.argv[1].encode()
+ts = sys.argv[2]
+payload = open(sys.argv[3], 'rb').read()
+signed = ts.encode() + b'.' + payload
+sig = hmac.new(secret, signed, hashlib.sha256).hexdigest()
+print(f"t={ts},v1={sig}")
+PY
+)"
 
 WEBHOOK_STATUS2=$(curl -sS -o "$WEBHOOK_RESP_FILE" -w "%{http_code}" -X POST "${BASE_URL}/billing/events" \
   -H "Content-Type: application/json" \
@@ -311,8 +361,9 @@ DB_SNAPSHOT2_SPEND="$(docker exec "$POSTGRES_CONTAINER" psql -U postgres -d "$DB
 if python3 - "$EP_SNAPSHOT2_SPEND" "$DB_SNAPSHOT2_SPEND" <<'PY'
 import sys
 a=float(sys.argv[1]); b=float(sys.argv[2])
-print('ok' if abs(a-b) < 1e-9 else 'bad')
-sys.exit(0 if abs(a-b) < 1e-9 else 1)
+tol = 1e-4
+print('ok' if abs(a-b) <= tol else 'bad')
+sys.exit(0 if abs(a-b) <= tol else 1)
 PY
 then
   pass "Endpoint and DB total_spend match for second snapshot (${EP_SNAPSHOT2_SPEND})"

--- a/scripts/local/e2e_spend_history_periodic_webhook_local.sh
+++ b/scripts/local/e2e_spend_history_periodic_webhook_local.sh
@@ -372,11 +372,11 @@ else
 fi
 
 say "Inspecting API DB persisted rows"
-docker exec "$POSTGRES_CONTAINER" psql -U postgres -d "$DB_NAME" -c "select id,team_id,region_id,budget_type,period_start,period_end,total_spend,stripe_event_id,stripe_invoice_id from team_spend_periods where team_id=${TEAM_ID} order by id desc limit 5;"
-docker exec "$POSTGRES_CONTAINER" psql -U postgres -d "$DB_NAME" -c "select team_spend_period_id,key_id,key_name_snapshot,spend,total_tokens from team_spend_period_keys where team_spend_period_id in (select id from team_spend_periods where team_id=${TEAM_ID}) order by id desc limit 10;"
+docker exec "$POSTGRES_CONTAINER" sh -lc "psql -U postgres -d '$DB_NAME' -tAc \"select coalesce(json_agg(t), '[]'::json) from (select id,team_id,region_id,budget_type,period_start,period_end,total_spend,stripe_event_id,stripe_invoice_id,stripe_subscription_id from team_spend_periods where team_id=${TEAM_ID} order by id desc limit 5) t;\"" | jq '.'
+docker exec "$POSTGRES_CONTAINER" sh -lc "psql -U postgres -d '$DB_NAME' -tAc \"select coalesce(json_agg(t), '[]'::json) from (select team_spend_period_id,key_id,owner_id,key_name_snapshot,spend,total_tokens from team_spend_period_keys where team_spend_period_id in (select id from team_spend_periods where team_id=${TEAM_ID}) order by id desc limit 10) t;\"" | jq '.'
 
 say "Inspecting LiteLLM DB spend logs for team eu-west_${TEAM_ID}"
-docker exec amazeeai-litellm_db-1 sh -lc "psql -U llmproxy -d litellm -c \"select api_key,team_id,model,total_tokens,prompt_tokens,completion_tokens,spend,\\\"startTime\\\" from \\\"LiteLLM_SpendLogs\\\" where team_id='eu-west_${TEAM_ID}' order by \\\"startTime\\\" desc limit 5;\""
+docker exec amazeeai-litellm_db-1 sh -lc "psql -U llmproxy -d litellm -tAc \"select coalesce(json_agg(t), '[]'::json) from (select api_key,team_id,model,total_tokens,prompt_tokens,completion_tokens,spend,\\\"startTime\\\" from \\\"LiteLLM_SpendLogs\\\" where team_id='eu-west_${TEAM_ID}' order by \\\"startTime\\\" desc limit 5) t;\"" | jq '.'
 
 say "E2E completed successfully"
 echo "Artifacts: team_id=${TEAM_ID} key_ids=${KEY1_ID},${KEY2_ID} stripe_event_ids=${STRIPE_EVENT_ID_1},${STRIPE_EVENT_ID_2}"

--- a/scripts/local/e2e_spend_history_periodic_webhook_local.sh
+++ b/scripts/local/e2e_spend_history_periodic_webhook_local.sh
@@ -126,8 +126,10 @@ KEY1_NAME="spend-hist-key-1-${RUN_ID}"
 KEY2_NAME="spend-hist-key-2-${RUN_ID}"
 STRIPE_CUSTOMER_ID="cus_local_e2e_${RUN_ID}"
 STRIPE_SUB_ID="sub_local_e2e_${RUN_ID}"
-STRIPE_EVENT_ID="evt_local_e2e_${RUN_ID}"
-STRIPE_INVOICE_ID="in_local_e2e_${RUN_ID}"
+STRIPE_EVENT_ID_1="evt_local_e2e_${RUN_ID}_1"
+STRIPE_EVENT_ID_2="evt_local_e2e_${RUN_ID}_2"
+STRIPE_INVOICE_ID_1="in_local_e2e_${RUN_ID}_1"
+STRIPE_INVOICE_ID_2="in_local_e2e_${RUN_ID}_2"
 
 say "Creating PERIODIC team"
 api POST "/teams/" "$(jq -nc --arg n "$TEAM_NAME" --arg e "$TEAM_EMAIL" '{name:$n,admin_email:$e,budget_type:"periodic",require_purchase_for_requests:false}')"
@@ -153,23 +155,7 @@ KEY2_TOKEN="$(echo "$HTTP_BODY" | jq -r '.litellm_token')"
 
 say "Created keys: ${KEY1_ID}, ${KEY2_ID}"
 
-say "Sending mocked usage to LiteLLM for both keys"
-for token in "$KEY1_TOKEN" "$KEY2_TOKEN"; do
-  curl -sS http://localhost:4000/v1/chat/completions \
-    -H "Authorization: Bearer ${token}" \
-    -H "Content-Type: application/json" \
-    -d '{"model":"dummy-gpt-5-4","messages":[{"role":"user","content":"Hello"}],"mock_response":{"content":"Test response","usage":{"prompt_tokens":100,"completion_tokens":14900,"total_tokens":15000}}}' \
-    | jq '{id,model,usage}'
-done
-
-say "Waiting for spend propagation to API /spend endpoint"
-if PRE_SPEND="$(wait_for_team_spend_gt_zero "$REGION_ID" "$TEAM_ID" 30)"; then
-  pass "Spend propagated before webhook (total_spend=${PRE_SPEND})"
-else
-  fail_msg "Spend still zero after waiting. Continuing, but history will likely also be zero."
-fi
-
-say "Current spend snapshot before webhook"
+say "Current spend snapshot before any webhook"
 api GET "/spend/${REGION_ID}/team/${TEAM_ID}"
 echo "$HTTP_BODY" | jq '{team_id,region_id,total_spend,key_count,keys: [.keys[]|{key_id,spend}]}'
 
@@ -197,23 +183,28 @@ fi
 [[ -n "$WEBHOOK_SECRET" ]] || fail "Unable to resolve webhook secret (WEBHOOK_SIG/system_secrets)"
 say "Webhook secret resolved"
 
-say "Building fake Stripe invoice.paid event payload"
+say "Building and sending first fake Stripe invoice.paid webhook ($5)"
 NOW_TS="$(date +%s)"
-PERIOD_END="$NOW_TS"
-PERIOD_START="$((NOW_TS - 2592000))"
-PAYLOAD_FILE="$TMP_DIR/stripe_event.json"
-cat > "$PAYLOAD_FILE" <<JSON
+P1_START="$((NOW_TS - 5184000))"
+P1_END="$((NOW_TS - 2592000))"
+P2_START="$P1_END"
+P2_END="$NOW_TS"
+
+PAYLOAD_FILE_1="$TMP_DIR/stripe_event_1.json"
+cat > "$PAYLOAD_FILE_1" <<JSON
 {
-  "id": "${STRIPE_EVENT_ID}",
+  "id": "${STRIPE_EVENT_ID_1}",
   "object": "event",
   "type": "invoice.paid",
   "data": {
     "object": {
-      "id": "${STRIPE_INVOICE_ID}",
+      "id": "${STRIPE_INVOICE_ID_1}",
       "object": "invoice",
       "customer": "${STRIPE_CUSTOMER_ID}",
-      "period_start": ${PERIOD_START},
-      "period_end": ${PERIOD_END},
+      "amount_paid": 500,
+      "currency": "usd",
+      "period_start": ${P1_START},
+      "period_end": ${P1_END},
       "parent": {
         "subscription_details": {
           "subscription": "${STRIPE_SUB_ID}"
@@ -223,34 +214,109 @@ cat > "$PAYLOAD_FILE" <<JSON
   }
 }
 JSON
-PAYLOAD="$(cat "$PAYLOAD_FILE")"
+PAYLOAD_1="$(cat "$PAYLOAD_FILE_1")"
 
 TS="$(date +%s)"
-SIGNED_PAYLOAD="${TS}.${PAYLOAD}"
-SIG="$(printf '%s' "$SIGNED_PAYLOAD" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" -hex | awk '{print $2}')"
-STRIPE_SIGNATURE="t=${TS},v1=${SIG}"
+SIGNED_PAYLOAD_1="${TS}.${PAYLOAD_1}"
+SIG_1="$(printf '%s' "$SIGNED_PAYLOAD_1" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" -hex | awk '{print $2}')"
+STRIPE_SIGNATURE_1="t=${TS},v1=${SIG_1}"
 
-say "Posting fake Stripe webhook to /billing/events"
+say "Posting first fake Stripe webhook to /billing/events"
 WEBHOOK_RESP_FILE="$TMP_DIR/webhook_resp.txt"
 WEBHOOK_STATUS=$(curl -sS -o "$WEBHOOK_RESP_FILE" -w "%{http_code}" -X POST "${BASE_URL}/billing/events" \
   -H "Content-Type: application/json" \
-  -H "stripe-signature: ${STRIPE_SIGNATURE}" \
-  --data-binary @"$PAYLOAD_FILE")
+  -H "stripe-signature: ${STRIPE_SIGNATURE_1}" \
+  --data-binary @"$PAYLOAD_FILE_1")
 echo "Webhook status=${WEBHOOK_STATUS}"
 cat "$WEBHOOK_RESP_FILE"
-assert_status "$WEBHOOK_STATUS" "200" "Fake Stripe webhook accepted"
+assert_status "$WEBHOOK_STATUS" "200" "First fake Stripe webhook accepted"
+
+say "Creating mocked usage in current period (between webhook 1 and webhook 2)"
+for token in "$KEY1_TOKEN" "$KEY2_TOKEN"; do
+  curl -sS http://localhost:4000/v1/chat/completions \
+    -H "Authorization: Bearer ${token}" \
+    -H "Content-Type: application/json" \
+    -d '{"model":"dummy-gpt-5-4","messages":[{"role":"user","content":"Hello"}],"mock_response":{"content":"Test response","usage":{"prompt_tokens":100,"completion_tokens":14900,"total_tokens":15000}}}' \
+    | jq '{id,model,usage}'
+done
+
+say "Waiting for spend propagation to API /spend endpoint"
+if PRE_SPEND="$(wait_for_team_spend_gt_zero "$REGION_ID" "$TEAM_ID" 30)"; then
+  pass "Spend propagated before second webhook (total_spend=${PRE_SPEND})"
+else
+  fail_msg "Spend still zero after waiting. Continuing, but second snapshot may be zero."
+fi
+
+say "Building and sending second fake Stripe invoice.paid webhook ($5, new period)"
+PAYLOAD_FILE_2="$TMP_DIR/stripe_event_2.json"
+cat > "$PAYLOAD_FILE_2" <<JSON
+{
+  "id": "${STRIPE_EVENT_ID_2}",
+  "object": "event",
+  "type": "invoice.paid",
+  "data": {
+    "object": {
+      "id": "${STRIPE_INVOICE_ID_2}",
+      "object": "invoice",
+      "customer": "${STRIPE_CUSTOMER_ID}",
+      "amount_paid": 500,
+      "currency": "usd",
+      "period_start": ${P2_START},
+      "period_end": ${P2_END},
+      "parent": {
+        "subscription_details": {
+          "subscription": "${STRIPE_SUB_ID}"
+        }
+      }
+    }
+  }
+}
+JSON
+PAYLOAD_2="$(cat "$PAYLOAD_FILE_2")"
+TS2="$(date +%s)"
+SIGNED_PAYLOAD_2="${TS2}.${PAYLOAD_2}"
+SIG_2="$(printf '%s' "$SIGNED_PAYLOAD_2" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" -hex | awk '{print $2}')"
+STRIPE_SIGNATURE_2="t=${TS2},v1=${SIG_2}"
+
+WEBHOOK_STATUS2=$(curl -sS -o "$WEBHOOK_RESP_FILE" -w "%{http_code}" -X POST "${BASE_URL}/billing/events" \
+  -H "Content-Type: application/json" \
+  -H "stripe-signature: ${STRIPE_SIGNATURE_2}" \
+  --data-binary @"$PAYLOAD_FILE_2")
+echo "Webhook2 status=${WEBHOOK_STATUS2}"
+cat "$WEBHOOK_RESP_FILE"
+assert_status "$WEBHOOK_STATUS2" "200" "Second fake Stripe webhook accepted"
 
 say "Waiting for background processing"
-sleep 3
+sleep 4
 
 say "Querying new historical endpoint"
 api GET "/spend/${REGION_ID}/team/${TEAM_ID}/history"
 HISTORY="$HTTP_BODY"
+say "Full history endpoint JSON response"
+echo "$HISTORY" | jq '.'
 echo "$HISTORY" | jq '{team_id,region_id,period_count:(.periods|length),latest:(.periods[0] // null)}'
 
-EVENT_MATCH="$(echo "$HISTORY" | jq -r --arg eid "$STRIPE_EVENT_ID" '[.periods[]? | select(.stripe_event_id==$eid)] | length')"
-[[ "$EVENT_MATCH" -ge 1 ]] || fail "No history period found for stripe_event_id=${STRIPE_EVENT_ID}"
-pass "History row created for stripe_event_id=${STRIPE_EVENT_ID}"
+EVENT1_MATCH="$(echo "$HISTORY" | jq -r --arg eid "$STRIPE_EVENT_ID_1" '[.periods[]? | select(.stripe_event_id==$eid)] | length')"
+EVENT2_MATCH="$(echo "$HISTORY" | jq -r --arg eid "$STRIPE_EVENT_ID_2" '[.periods[]? | select(.stripe_event_id==$eid)] | length')"
+[[ "$EVENT1_MATCH" -ge 1 ]] || fail "No history period found for stripe_event_id=${STRIPE_EVENT_ID_1}"
+[[ "$EVENT2_MATCH" -ge 1 ]] || fail "No history period found for stripe_event_id=${STRIPE_EVENT_ID_2}"
+pass "History rows created for both webhook events"
+
+EP_SNAPSHOT2_SPEND="$(echo "$HISTORY" | jq -r --arg eid "$STRIPE_EVENT_ID_2" '[.periods[] | select(.stripe_event_id==$eid)][0].total_spend // 0')"
+DB_SNAPSHOT2_SPEND="$(docker exec "$POSTGRES_CONTAINER" psql -U postgres -d "$DB_NAME" -tAc "select total_spend from team_spend_periods where team_id=${TEAM_ID} and stripe_event_id='${STRIPE_EVENT_ID_2}' limit 1;" | tr -d '[:space:]')"
+[[ -n "$DB_SNAPSHOT2_SPEND" ]] || fail "DB row missing for second webhook snapshot"
+
+if python3 - "$EP_SNAPSHOT2_SPEND" "$DB_SNAPSHOT2_SPEND" <<'PY'
+import sys
+a=float(sys.argv[1]); b=float(sys.argv[2])
+print('ok' if abs(a-b) < 1e-9 else 'bad')
+sys.exit(0 if abs(a-b) < 1e-9 else 1)
+PY
+then
+  pass "Endpoint and DB total_spend match for second snapshot (${EP_SNAPSHOT2_SPEND})"
+else
+  fail "Mismatch endpoint vs DB spend: endpoint=${EP_SNAPSHOT2_SPEND} db=${DB_SNAPSHOT2_SPEND}"
+fi
 
 say "Inspecting API DB persisted rows"
 docker exec "$POSTGRES_CONTAINER" psql -U postgres -d "$DB_NAME" -c "select id,team_id,region_id,budget_type,period_start,period_end,total_spend,stripe_event_id,stripe_invoice_id from team_spend_periods where team_id=${TEAM_ID} order by id desc limit 5;"
@@ -260,4 +326,4 @@ say "Inspecting LiteLLM DB spend logs for team eu-west_${TEAM_ID}"
 docker exec amazeeai-litellm_db-1 sh -lc "psql -U llmproxy -d litellm -c \"select api_key,team_id,model,total_tokens,prompt_tokens,completion_tokens,spend,\\\"startTime\\\" from \\\"LiteLLM_SpendLogs\\\" where team_id='eu-west_${TEAM_ID}' order by \\\"startTime\\\" desc limit 5;\""
 
 say "E2E completed successfully"
-echo "Artifacts: team_id=${TEAM_ID} key_ids=${KEY1_ID},${KEY2_ID} stripe_event_id=${STRIPE_EVENT_ID}"
+echo "Artifacts: team_id=${TEAM_ID} key_ids=${KEY1_ID},${KEY2_ID} stripe_event_ids=${STRIPE_EVENT_ID_1},${STRIPE_EVENT_ID_2}"

--- a/scripts/local/e2e_spend_history_pool_purchase_local.sh
+++ b/scripts/local/e2e_spend_history_pool_purchase_local.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:8800}"
+AUTH_TOKEN="${AUTH_TOKEN:-LOCALBT}"
+REGION_ID="${REGION_ID:-1}"
+CLEANUP_CREATED=1
+TMP_DIR="$(mktemp -d /tmp/e2e_spend_history_pool.XXXXXX)"
+TEAM_ID=""; KEY1_ID=""; KEY2_ID=""
+
+need_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "Missing command: $1" >&2; exit 1; }; }
+for c in curl jq python3; do need_cmd "$c"; done
+
+say(){ echo "[$(date +%H:%M:%S)] $*"; }
+pass(){ say "✅ $*"; }
+fail(){ echo "ERROR: $*" >&2; exit 1; }
+
+api(){
+  local method="$1" path="$2" data="${3:-}" out="$TMP_DIR/body.json"
+  if [[ -n "$data" ]]; then
+    HTTP_STATUS=$(curl -sS -o "$out" -w "%{http_code}" -X "$method" "${BASE_URL}${path}" -H "Authorization: Bearer ${AUTH_TOKEN}" -H "Content-Type: application/json" -d "$data")
+  else
+    HTTP_STATUS=$(curl -sS -o "$out" -w "%{http_code}" -X "$method" "${BASE_URL}${path}" -H "Authorization: Bearer ${AUTH_TOKEN}")
+  fi
+  HTTP_BODY="$(cat "$out")"
+}
+
+cleanup(){
+  if [[ "$CLEANUP_CREATED" == "1" ]]; then
+    [[ -n "$KEY1_ID" ]] && api DELETE "/private-ai-keys/${KEY1_ID}" || true
+    [[ -n "$KEY2_ID" ]] && api DELETE "/private-ai-keys/${KEY2_ID}" || true
+    if [[ -n "$TEAM_ID" ]]; then
+      api DELETE "/teams/${TEAM_ID}" || true
+      if [[ "${HTTP_STATUS:-}" == "500" ]]; then api POST "/teams/${TEAM_ID}/soft-delete" || true; fi
+    fi
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+wait_spend_gt_zero(){
+  local i=0
+  while (( i < 30 )); do
+    api GET "/spend/${REGION_ID}/team/${TEAM_ID}"
+    local s="$(echo "$HTTP_BODY" | jq -r '.total_spend // 0')"
+    if python3 - "$s" <<'PY'
+import sys
+sys.exit(0 if float(sys.argv[1])>0 else 1)
+PY
+    then echo "$s"; return 0; fi
+    sleep 1; i=$((i+1))
+  done
+  return 1
+}
+
+RUN_ID="$(date +%s)"
+TEAM_NAME="spend-hist-pool-e2e-${RUN_ID}"
+TEAM_EMAIL="spend-hist-pool-e2e-${RUN_ID}@example.com"
+
+say "Create POOL team"
+api POST "/teams/" "$(jq -nc --arg n "$TEAM_NAME" --arg e "$TEAM_EMAIL" '{name:$n,admin_email:$e,budget_type:"pool",require_purchase_for_requests:true}')"
+[[ "$HTTP_STATUS" == "201" ]] || fail "team create failed: $HTTP_STATUS $HTTP_BODY"
+TEAM_ID="$(echo "$HTTP_BODY" | jq -r '.id')"
+pass "Team created id=${TEAM_ID}"
+
+api POST "/regions/${REGION_ID}/teams/${TEAM_ID}" || true
+
+say "Create 2 team keys"
+api POST "/private-ai-keys/" "$(jq -nc --argjson rid "$REGION_ID" --argjson tid "$TEAM_ID" --arg name "pool-hist-key-1-${RUN_ID}" '{region_id:$rid,name:$name,team_id:$tid}')"
+[[ "$HTTP_STATUS" == "200" ]] || fail "key1 create failed"
+KEY1_ID="$(echo "$HTTP_BODY"|jq -r '.id')"; KEY1_TOKEN="$(echo "$HTTP_BODY"|jq -r '.litellm_token')"
+api POST "/private-ai-keys/" "$(jq -nc --argjson rid "$REGION_ID" --argjson tid "$TEAM_ID" --arg name "pool-hist-key-2-${RUN_ID}" '{region_id:$rid,name:$name,team_id:$tid}')"
+[[ "$HTTP_STATUS" == "200" ]] || fail "key2 create failed"
+KEY2_ID="$(echo "$HTTP_BODY"|jq -r '.id')"; KEY2_TOKEN="$(echo "$HTTP_BODY"|jq -r '.litellm_token')"
+
+say "First POOL purchase (opens cycle)"
+PAY1="pool-e2e-${RUN_ID}-1"
+api POST "/budgets/region/${REGION_ID}/teams/${TEAM_ID}/purchase" "$(jq -nc --arg sid "$PAY1" '{amount_cents:500,currency:"USD",purchased_at:(now|todateiso8601),stripe_payment_id:$sid}')"
+[[ "$HTTP_STATUS" == "201" ]] || fail "purchase1 failed: $HTTP_STATUS $HTTP_BODY"
+pass "Purchase #1 accepted"
+
+say "Generate usage between purchases"
+for tok in "$KEY1_TOKEN" "$KEY2_TOKEN"; do
+  curl -sS http://localhost:4000/v1/chat/completions -H "Authorization: Bearer ${tok}" -H "Content-Type: application/json" -d '{"model":"dummy-gpt-5-4","messages":[{"role":"user","content":"Hello"}],"mock_response":{"content":"x","usage":{"prompt_tokens":100,"completion_tokens":14900,"total_tokens":15000}}}' | jq '{id,model,usage}'
+done
+
+SPEND_NOW="$(wait_spend_gt_zero || true)"
+[[ -n "$SPEND_NOW" ]] && pass "Spend propagated: ${SPEND_NOW}" || say "❌ Spend still zero before purchase2"
+
+say "Second POOL purchase (captures pre-purchase spend snapshot)"
+PAY2="pool-e2e-${RUN_ID}-2"
+api POST "/budgets/region/${REGION_ID}/teams/${TEAM_ID}/purchase" "$(jq -nc --arg sid "$PAY2" '{amount_cents:500,currency:"USD",purchased_at:(now|todateiso8601),stripe_payment_id:$sid}')"
+[[ "$HTTP_STATUS" == "201" ]] || fail "purchase2 failed: $HTTP_STATUS $HTTP_BODY"
+pass "Purchase #2 accepted"
+
+say "Fetch history endpoint (raw + pretty)"
+api GET "/spend/${REGION_ID}/team/${TEAM_ID}/history"
+H="$HTTP_BODY"
+say "Raw history response"
+echo "$H"
+say "Pretty history response"
+echo "$H" | jq '.'
+
+say "Assert at least one POOL period row exists"
+COUNT="$(echo "$H" | jq -r '[.periods[] | select(.budget_type=="pool")] | length')"
+[[ "$COUNT" -ge 1 ]] || fail "No pool history periods found"
+pass "Found $COUNT pool history period(s)"
+
+say "Inspect API DB rows as JSON"
+python3 - <<PY
+import json,subprocess
+team_id=${TEAM_ID}
+q1=f"select coalesce(json_agg(t),'[]'::json) from (select id,team_id,region_id,budget_type,period_start,period_end,total_spend,stripe_invoice_id from team_spend_periods where team_id={team_id} order by id desc limit 5) t;"
+q2=f"select coalesce(json_agg(t),'[]'::json) from (select team_spend_period_id,key_id,owner_id,spend,total_tokens from team_spend_period_keys where team_spend_period_id in (select id from team_spend_periods where team_id={team_id}) order by id desc limit 10) t;"
+for q in (q1,q2):
+    out=subprocess.check_output(["docker","exec","amazeeai-postgres-1","sh","-lc",f"psql -U postgres -d postgres_service -tAc \"{q}\""]).decode().strip()
+    print(json.dumps(json.loads(out or "[]"), indent=2))
+PY
+
+pass "POOL E2E complete"

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -2264,6 +2264,7 @@ def test_get_team_spend_history_includes_key_rows(
     assert len(keys) == 1
     assert keys[0]["key_id"] == key.id
     assert keys[0]["owner_id"] == test_team_user.id
+    assert keys[0]["key_name_snapshot"] == "hist-key"
     assert keys[0]["spend"] == 7.5
     assert keys[0]["max_budget"] == 50.0
 

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -2153,6 +2153,7 @@ def test_get_user_spend_db_key_cap_beats_member_cap_beats_litellm_for_purchased_
 # /spend/{region_id}/team/{team_id}/history tests
 # ---------------------------------------------------------------------------
 
+
 def test_get_team_spend_history_returns_empty_for_no_periods(
     client, team_admin_token, test_team, test_region
 ):

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -2147,3 +2147,164 @@ def test_get_user_spend_db_key_cap_beats_member_cap_beats_litellm_for_purchased_
     assert max_budget_by_name[key_with_key_cap.name] == 12.0
     # DB member cap wins over LiteLLM after purchase
     assert max_budget_by_name[key_with_member_cap.name] == 8.0
+
+
+# ---------------------------------------------------------------------------
+# /spend/{region_id}/team/{team_id}/history tests
+# ---------------------------------------------------------------------------
+
+def test_get_team_spend_history_returns_empty_for_no_periods(
+    client, team_admin_token, test_team, test_region
+):
+    """Endpoint returns an empty periods list when no snapshots exist."""
+    response = client.get(
+        f"/spend/{test_region.id}/team/{test_team.id}/history",
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["team_id"] == test_team.id
+    assert data["region_id"] == test_region.id
+    assert data["periods"] == []
+
+
+def test_get_team_spend_history_returns_periods_ordered_desc(
+    client, team_admin_token, test_team, test_region, db
+):
+    """Periods are returned newest-first (period_end desc)."""
+    from datetime import UTC, datetime
+    from app.db.models import DBTeamSpendPeriod
+
+    p1 = DBTeamSpendPeriod(
+        team_id=test_team.id,
+        region_id=test_region.id,
+        budget_type="periodic",
+        period_start=datetime(2026, 3, 1, tzinfo=UTC),
+        period_end=datetime(2026, 4, 1, tzinfo=UTC),
+        total_spend=5.0,
+        source="test",
+    )
+    p2 = DBTeamSpendPeriod(
+        team_id=test_team.id,
+        region_id=test_region.id,
+        budget_type="periodic",
+        period_start=datetime(2026, 4, 1, tzinfo=UTC),
+        period_end=datetime(2026, 5, 1, tzinfo=UTC),
+        total_spend=10.0,
+        source="test",
+    )
+    db.add_all([p1, p2])
+    db.commit()
+
+    response = client.get(
+        f"/spend/{test_region.id}/team/{test_team.id}/history",
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["periods"]) == 2
+    # Newest period (April→May) must come first
+    assert data["periods"][0]["total_spend"] == 10.0
+    assert data["periods"][1]["total_spend"] == 5.0
+
+
+def test_get_team_spend_history_includes_key_rows(
+    client, team_admin_token, test_team, test_region, test_team_user, db
+):
+    """Key-level spend rows are embedded inside each period."""
+    from datetime import UTC, datetime
+    from app.db.models import DBTeamSpendPeriod, DBTeamSpendPeriodKey, DBPrivateAIKey
+
+    key = DBPrivateAIKey(
+        name="hist-key",
+        litellm_token="hist-token",
+        region_id=test_region.id,
+        team_id=test_team.id,
+        owner_id=test_team_user.id,
+    )
+    db.add(key)
+    db.commit()
+
+    period = DBTeamSpendPeriod(
+        team_id=test_team.id,
+        region_id=test_region.id,
+        budget_type="periodic",
+        period_start=datetime(2026, 4, 1, tzinfo=UTC),
+        period_end=datetime(2026, 5, 1, tzinfo=UTC),
+        total_spend=7.5,
+        source="test",
+    )
+    db.add(period)
+    db.flush()
+
+    db.add(
+        DBTeamSpendPeriodKey(
+            team_spend_period_id=period.id,
+            key_id=key.id,
+            owner_id=test_team_user.id,
+            key_name_snapshot="hist-key",
+            spend=7.5,
+            max_budget=50.0,
+            prompt_tokens=100,
+            completion_tokens=50,
+            total_tokens=150,
+        )
+    )
+    db.commit()
+
+    response = client.get(
+        f"/spend/{test_region.id}/team/{test_team.id}/history",
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["periods"]) == 1
+    keys = data["periods"][0]["keys"]
+    assert len(keys) == 1
+    assert keys[0]["key_id"] == key.id
+    assert keys[0]["owner_id"] == test_team_user.id
+    assert keys[0]["spend"] == 7.5
+    assert keys[0]["max_budget"] == 50.0
+
+
+def test_get_team_spend_history_access_denied_for_other_team(
+    client, team_admin_token, test_region, db
+):
+    """Team admin cannot access history of a different team."""
+    from app.db.models import DBTeam
+
+    other_team = DBTeam(
+        name="Other Team",
+        admin_email="other@example.com",
+        is_active=True,
+    )
+    db.add(other_team)
+    db.commit()
+
+    response = client.get(
+        f"/spend/{test_region.id}/team/{other_team.id}/history",
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code in (403, 404)
+
+
+def test_get_team_spend_history_404_for_nonexistent_team(
+    client, admin_token, test_region
+):
+    """Returns 404 when the requested team does not exist."""
+    response = client.get(
+        f"/spend/{test_region.id}/team/999999/history",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 404
+
+
+def test_get_team_spend_history_admin_can_access_any_team(
+    client, admin_token, test_team, test_region
+):
+    """Site admins can access history for any team."""
+    response = client.get(
+        f"/spend/{test_region.id}/team/{test_team.id}/history",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200

--- a/tests/test_spend_period_service.py
+++ b/tests/test_spend_period_service.py
@@ -71,7 +71,9 @@ def test_upsert_team_spend_period_creates_parent_and_keys(db, test_team, test_re
     assert len(keys) == 2
 
 
-def test_upsert_team_spend_period_is_idempotent_for_same_window(db, test_team, test_region):
+def test_upsert_team_spend_period_is_idempotent_for_same_window(
+    db, test_team, test_region
+):
     period_start = datetime(2026, 4, 1, tzinfo=UTC)
     period_end = datetime(2026, 5, 1, tzinfo=UTC)
 

--- a/tests/test_spend_period_service.py
+++ b/tests/test_spend_period_service.py
@@ -1,0 +1,112 @@
+from datetime import UTC, datetime
+
+from app.core.spend_period_service import upsert_team_spend_period
+from app.db.models import DBTeamSpendPeriod, DBTeamSpendPeriodKey
+
+
+def test_upsert_team_spend_period_creates_parent_and_keys(db, test_team, test_region):
+    period_start = datetime(2026, 4, 1, tzinfo=UTC)
+    period_end = datetime(2026, 5, 1, tzinfo=UTC)
+
+    snapshot = {
+        "total_spend": 12.34,
+        "total_budget": 50.0,
+        "total_prompt_tokens": 100,
+        "total_completion_tokens": 200,
+        "total_tokens": 300,
+        "keys": [
+            {
+                "key_id": None,
+                "owner_id": None,
+                "key_name_snapshot": "k1",
+                "spend": 10.0,
+                "max_budget": 25.0,
+                "prompt_tokens": 10,
+                "completion_tokens": 20,
+                "total_tokens": 30,
+            },
+            {
+                "key_id": None,
+                "owner_id": 1,
+                "key_name_snapshot": "k2",
+                "spend": 2.34,
+                "max_budget": None,
+                "prompt_tokens": None,
+                "completion_tokens": None,
+                "total_tokens": None,
+            },
+        ],
+    }
+
+    upsert_team_spend_period(
+        db=db,
+        team=test_team,
+        region_id=test_region.id,
+        period_start=period_start,
+        period_end=period_end,
+        source="test",
+        snapshot=snapshot,
+        stripe_event_id="evt_1",
+    )
+    db.commit()
+
+    row = (
+        db.query(DBTeamSpendPeriod)
+        .filter(
+            DBTeamSpendPeriod.team_id == test_team.id,
+            DBTeamSpendPeriod.region_id == test_region.id,
+            DBTeamSpendPeriod.period_start == period_start,
+            DBTeamSpendPeriod.period_end == period_end,
+        )
+        .first()
+    )
+    assert row is not None
+    assert row.total_spend == 12.34
+
+    keys = (
+        db.query(DBTeamSpendPeriodKey)
+        .filter(DBTeamSpendPeriodKey.team_spend_period_id == row.id)
+        .all()
+    )
+    assert len(keys) == 2
+
+
+def test_upsert_team_spend_period_is_idempotent_for_same_window(db, test_team, test_region):
+    period_start = datetime(2026, 4, 1, tzinfo=UTC)
+    period_end = datetime(2026, 5, 1, tzinfo=UTC)
+
+    snapshot1 = {"total_spend": 5.0, "keys": []}
+    snapshot2 = {"total_spend": 7.0, "keys": []}
+
+    upsert_team_spend_period(
+        db=db,
+        team=test_team,
+        region_id=test_region.id,
+        period_start=period_start,
+        period_end=period_end,
+        source="test",
+        snapshot=snapshot1,
+    )
+    upsert_team_spend_period(
+        db=db,
+        team=test_team,
+        region_id=test_region.id,
+        period_start=period_start,
+        period_end=period_end,
+        source="test",
+        snapshot=snapshot2,
+    )
+    db.commit()
+
+    rows = (
+        db.query(DBTeamSpendPeriod)
+        .filter(
+            DBTeamSpendPeriod.team_id == test_team.id,
+            DBTeamSpendPeriod.region_id == test_region.id,
+            DBTeamSpendPeriod.period_start == period_start,
+            DBTeamSpendPeriod.period_end == period_end,
+        )
+        .all()
+    )
+    assert len(rows) == 1
+    assert rows[0].total_spend == 7.0

--- a/tests/test_spend_period_service.py
+++ b/tests/test_spend_period_service.py
@@ -4,7 +4,9 @@ from app.core.spend_period_service import upsert_team_spend_period
 from app.db.models import DBTeamSpendPeriod, DBTeamSpendPeriodKey
 
 
-def test_upsert_team_spend_period_creates_parent_and_keys(db, test_team, test_region):
+def test_upsert_team_spend_period_creates_parent_and_keys(
+    db, test_team, test_region, test_team_user
+):
     period_start = datetime(2026, 4, 1, tzinfo=UTC)
     period_end = datetime(2026, 5, 1, tzinfo=UTC)
 
@@ -27,7 +29,7 @@ def test_upsert_team_spend_period_creates_parent_and_keys(db, test_team, test_re
             },
             {
                 "key_id": None,
-                "owner_id": 1,
+                "owner_id": test_team_user.id,
                 "key_name_snapshot": "k2",
                 "spend": 2.34,
                 "max_budget": None,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3508,3 +3508,123 @@ async def test_monitor_teams_continues_processing_after_error(
     assert mock_reconcile_products.call_count == 4  # test_team + 3 new teams
     # reconcile_team_keys should have been called for all teams except the failing one
     assert mock_reconcile.call_count == 3  # 4 teams - 1 failing = 3 successful
+
+
+# ---------------------------------------------------------------------------
+# Spend period snapshot capture tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@patch("app.core.worker.get_product_id_from_subscription", new_callable=AsyncMock)
+@patch("app.core.worker.apply_product_for_team", new_callable=AsyncMock)
+async def test_subscription_success_does_not_capture_spend(
+    mock_apply_product, mock_get_product, db, test_team, test_product
+):
+    """
+    GIVEN: A customer.subscription.updated event (SUBSCRIPTION_SUCCESS)
+    WHEN:  handle_stripe_event_background is called
+    THEN:  No spend-period snapshot is captured (subscriptions lack period_start/end)
+           and no warning is logged about missing period fields.
+    """
+    from app.db.models import DBTeamSpendPeriod
+
+    test_team.stripe_customer_id = "cus_sub_ok"
+    db.add(test_team)
+    db.commit()
+
+    mock_get_product.return_value = test_product.id
+    mock_apply_product.return_value = None
+
+    mock_event = Mock()
+    mock_event.type = "customer.subscription.updated"
+    mock_event.id = "evt_sub_ok"
+    sub_obj = Mock()
+    sub_obj.customer = "cus_sub_ok"
+    sub_obj.id = "sub_ok"
+    sub_obj.start_date = 1_700_000_000
+    # Subscriptions do NOT have period_start / period_end – mimic that by NOT
+    # setting those attributes (Mock raises AttributeError instead of None).
+    mock_event.data.object = sub_obj
+    mock_event.data.object.customer = "cus_sub_ok"
+
+    with patch("app.core.worker.capture_periodic_team_spend_for_invoice") as mock_capture:
+        await handle_stripe_event_background(mock_event)
+        # capture_periodic_team_spend_for_invoice must NOT be called for subscription events
+        mock_capture.assert_not_called()
+
+    # No spend period rows should exist
+    count = db.query(DBTeamSpendPeriod).filter(
+        DBTeamSpendPeriod.team_id == test_team.id
+    ).count()
+    assert count == 0
+
+
+@pytest.mark.asyncio
+@patch("app.core.worker.fetch_team_spend_snapshot_for_region", new_callable=AsyncMock)
+@patch("app.core.worker.get_product_id_from_subscription", new_callable=AsyncMock)
+@patch("app.core.worker.apply_product_for_team", new_callable=AsyncMock)
+async def test_invoice_payment_success_captures_spend_period(
+    mock_apply_product,
+    mock_get_product,
+    mock_fetch_snapshot,
+    db,
+    test_team,
+    test_product,
+    test_region,
+):
+    """
+    GIVEN: An invoice.payment_succeeded event (INVOICE_SUCCESS)
+    WHEN:  handle_stripe_event_background is called
+    THEN:  A spend-period snapshot is persisted to the DB for each region the team
+           has keys in.
+    """
+    from app.db.models import DBTeamSpendPeriod, DBPrivateAIKey
+
+    test_team.stripe_customer_id = "cus_inv_ok"
+    db.add(test_team)
+    # Give the team a key in the test region so keys_by_region is non-empty
+    key = DBPrivateAIKey(
+        name="inv-test-key",
+        litellm_token="inv-test-token",
+        region_id=test_region.id,
+        team_id=test_team.id,
+    )
+    db.add(key)
+    db.commit()
+
+    mock_get_product.return_value = test_product.id
+    mock_apply_product.return_value = None
+    mock_fetch_snapshot.return_value = {
+        "total_spend": 42.0,
+        "total_budget": 100.0,
+        "total_prompt_tokens": 500,
+        "total_completion_tokens": 200,
+        "total_tokens": 700,
+        "keys": [],
+    }
+
+    period_start_ts = 1_700_000_000
+    period_end_ts = 1_702_678_400
+
+    mock_event = Mock()
+    mock_event.type = "invoice.payment_succeeded"
+    mock_event.id = "evt_inv_ok"
+    inv_obj = Mock()
+    inv_obj.customer = "cus_inv_ok"
+    inv_obj.id = "inv_ok"
+    inv_obj.period_start = period_start_ts
+    inv_obj.period_end = period_end_ts
+    # parent.subscription_details.subscription for subscription ID extraction
+    inv_obj.parent.subscription_details.subscription = "sub_ok"
+    mock_event.data.object = inv_obj
+
+    await handle_stripe_event_background(mock_event)
+
+    # A spend period row must have been written
+    rows = db.query(DBTeamSpendPeriod).filter(
+        DBTeamSpendPeriod.team_id == test_team.id,
+        DBTeamSpendPeriod.region_id == test_region.id,
+    ).all()
+    assert len(rows) == 1
+    assert rows[0].total_spend == 42.0
+    assert rows[0].stripe_event_id == "evt_inv_ok"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3578,7 +3578,7 @@ async def test_invoice_payment_success_captures_spend_period(
     test_region,
 ):
     """
-    GIVEN: An invoice.payment_succeeded event (INVOICE_SUCCESS)
+    GIVEN: An invoice.paid event (INVOICE_SUCCESS)
     WHEN:  handle_stripe_event_background is called
     THEN:  A spend-period snapshot is persisted to the DB for each region the team
            has keys in.
@@ -3612,7 +3612,7 @@ async def test_invoice_payment_success_captures_spend_period(
     period_end_ts = 1_702_678_400
 
     mock_event = Mock()
-    mock_event.type = "invoice.payment_succeeded"
+    mock_event.type = "invoice.paid"
     mock_event.id = "evt_inv_ok"
     inv_obj = Mock()
     inv_obj.customer = "cus_inv_ok"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3514,6 +3514,7 @@ async def test_monitor_teams_continues_processing_after_error(
 # Spend period snapshot capture tests
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 @patch("app.core.worker.get_product_id_from_subscription", new_callable=AsyncMock)
 @patch("app.core.worker.apply_product_for_team", new_callable=AsyncMock)
@@ -3547,15 +3548,19 @@ async def test_subscription_success_does_not_capture_spend(
     mock_event.data.object = sub_obj
     mock_event.data.object.customer = "cus_sub_ok"
 
-    with patch("app.core.worker.capture_periodic_team_spend_for_invoice") as mock_capture:
+    with patch(
+        "app.core.worker.capture_periodic_team_spend_for_invoice"
+    ) as mock_capture:
         await handle_stripe_event_background(mock_event)
         # capture_periodic_team_spend_for_invoice must NOT be called for subscription events
         mock_capture.assert_not_called()
 
     # No spend period rows should exist
-    count = db.query(DBTeamSpendPeriod).filter(
-        DBTeamSpendPeriod.team_id == test_team.id
-    ).count()
+    count = (
+        db.query(DBTeamSpendPeriod)
+        .filter(DBTeamSpendPeriod.team_id == test_team.id)
+        .count()
+    )
     assert count == 0
 
 
@@ -3621,10 +3626,14 @@ async def test_invoice_payment_success_captures_spend_period(
     await handle_stripe_event_background(mock_event)
 
     # A spend period row must have been written
-    rows = db.query(DBTeamSpendPeriod).filter(
-        DBTeamSpendPeriod.team_id == test_team.id,
-        DBTeamSpendPeriod.region_id == test_region.id,
-    ).all()
+    rows = (
+        db.query(DBTeamSpendPeriod)
+        .filter(
+            DBTeamSpendPeriod.team_id == test_team.id,
+            DBTeamSpendPeriod.region_id == test_region.id,
+        )
+        .all()
+    )
     assert len(rows) == 1
     assert rows[0].total_spend == 42.0
     assert rows[0].stripe_event_id == "evt_inv_ok"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3524,8 +3524,8 @@ async def test_subscription_success_does_not_capture_spend(
     """
     GIVEN: A customer.subscription.updated event (SUBSCRIPTION_SUCCESS)
     WHEN:  handle_stripe_event_background is called
-    THEN:  No spend-period snapshot is captured (subscriptions lack period_start/end)
-           and no warning is logged about missing period fields.
+    THEN:  No spend-period snapshot is captured (subscriptions lack period_start/end
+           and capture_periodic_team_spend_for_invoice is not called).
     """
     from app.db.models import DBTeamSpendPeriod
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces spend-period snapshotting: on each Stripe invoice event and pool purchase, LiteLLM spend data is fetched and persisted to two new tables (`team_spend_periods` / `team_spend_period_keys`), and a new history endpoint exposes those snapshots.

- **New tables & migrations**: `DBTeamSpendPeriod` and `DBTeamSpendPeriodKey` are added with a unique window constraint on the parent and a partial unique index (added in the follow-up migration) to guard against duplicate unmatched-key rows where `key_id IS NULL`.
- **Spend capture service**: `spend_period_service.py` provides `fetch_team_spend_snapshot_for_region` (LiteLLM API call + DB key resolution) and `upsert_team_spend_period` (savepoint-guarded upsert + delete-reinsert of key rows).
- **Integration points**: `worker.py` captures before `apply_product_for_team` on every `INVOICE_SUCCESS` event; `budgets.py` captures the closing POOL period before mutating budget state, with the deduplication flush correctly moved before external calls.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge if the key-matching collision in spend_period_service.py is acceptable as a logged non-blocking failure, but it silently loses spend snapshots for teams with multiple unmatched LiteLLM keys.

The key-matching logic in fetch_team_spend_snapshot_for_region falls back to candidates[0] when no metadata filters apply, meaning two or more unmatched LiteLLM keys on the same team get the same key_id. The resulting IntegrityError on flush rolls back and logs the error, so no data is corrupted — but the spend snapshot for that region and invoice period is permanently lost without any alerting beyond a log line.

app/core/spend_period_service.py — the key-matching block around line 306 needs a guard to set key_id = None when the candidate set is ambiguous (more than one match remains after filtering).
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/core/spend_period_service.py | New service for snapshotting team spend periods. Contains a key-matching ambiguity bug (multiple unmatched LiteLLM keys → same DB key_id → IntegrityError on flush) and retains the team-level token isdigit() pattern flagged in prior reviews. |
| app/core/worker.py | Adds capture_periodic_team_spend_for_invoice() called before apply_product_for_team() on INVOICE_SUCCESS events. Per-region errors are caught and logged; previously flagged issue (unguarded outer DB query can still block apply_product_for_team) remains. |
| app/api/budgets.py | Moves db.flush() earlier (before external LiteLLM calls) and adds pool-purchase spend snapshot capture; spend capture failure is intentionally non-blocking. |
| app/api/spend.py | Adds GET /{region_id}/team/{team_id}/history endpoint returning historical spend periods with per-key breakdown, ordered newest-first. |
| app/db/models.py | Adds DBTeamSpendPeriod and DBTeamSpendPeriodKey models with appropriate FK cascades, a unique window constraint, and a partial index for unmatched-key deduplication (key_id IS NULL). |
| app/migrations/versions/20260512_170000_9d1a2b3c4d5e_add_team_spend_period_tables.py | Creates team_spend_periods and team_spend_period_keys tables with all required indexes and constraints; downgrade path drops tables in correct dependency order. |
| app/migrations/versions/20260513_113000_2f7c9d1e4aab_enforce_unique_unmatched_spend_period_key.py | Adds the partial unique index on (team_spend_period_id, owner_id, key_name_snapshot) WHERE key_id IS NULL to prevent duplicate unmatched-key rows. |
| app/schemas/models.py | Adds TeamSpendHistoryKeyItem, TeamSpendHistoryPeriodItem, and TeamSpendHistoryResponse Pydantic schemas matching the new history endpoint. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Stripe
    participant Worker as worker.py
    participant SpendSvc as spend_period_service.py
    participant LiteLLM
    participant DB

    Stripe->>Worker: invoice.paid webhook
    Worker->>Worker: capture_periodic_team_spend_for_invoice()
    loop per region
        Worker->>SpendSvc: fetch_team_spend_snapshot_for_region()
        SpendSvc->>LiteLLM: get_team_info(team_id)
        LiteLLM-->>SpendSvc: team_data (spend, keys[])
        SpendSvc->>DB: query DBPrivateAIKey (preload)
        SpendSvc->>SpendSvc: match LiteLLM keys → DB key IDs
        SpendSvc-->>Worker: snapshot dict
        Worker->>SpendSvc: upsert_team_spend_period()
        SpendSvc->>DB: savepoint INSERT DBTeamSpendPeriod
        SpendSvc->>DB: DELETE old DBTeamSpendPeriodKey rows
        SpendSvc->>DB: INSERT new DBTeamSpendPeriodKey rows
        SpendSvc->>DB: flush()
        Worker->>DB: commit()
    end
    Worker->>Worker: apply_product_for_team()
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (6)</h3></summary>

1. `app/core/spend_period_service.py`, line 316-326 ([link](https://github.com/amazeeio/amazee.ai/blob/42f7354e704df9025519ea0933327e6d1f3eeeb6/app/core/spend_period_service.py#L316-L326)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Token count parsing silently discards float values**

   `str(value).isdigit()` returns `False` for any float string (e.g., `"1500.0"`), so when LiteLLM returns token counts as floats the values are silently stored as `None`. The same pattern is repeated for `completion_tokens` and `total_tokens` on both the key rows (lines 316–326) and the team-level summary (lines 335–344). The existing `_to_int_or_none` helper in `spend.py` uses a `try/except int(value)` which handles floats correctly — using it here would avoid the silent data loss.

2. `app/core/spend_period_service.py`, line 435-437 ([link](https://github.com/amazeeio/amazee.ai/blob/42f7354e704df9025519ea0933327e6d1f3eeeb6/app/core/spend_period_service.py#L435-L437)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **DELETE + re-INSERT not protected by the savepoint**

   The savepoint block (lines 400–415) correctly handles concurrent INSERT of the parent `DBTeamSpendPeriod` row. However, once past that block, the DELETE of all `DBTeamSpendPeriodKey` rows followed by the bulk re-INSERT has no concurrency guard. When Stripe replays the same event (at-least-once delivery) and two handler coroutines race past the savepoint, both execute the DELETE and then both INSERT the full key set, doubling the key rows for the period. Consider wrapping the delete+insert in a second `db.begin_nested()` savepoint, or acquiring a row-level lock on the parent row before the delete.

3. `app/core/worker.py`, line 233-242 ([link](https://github.com/amazeeio/amazee.ai/blob/42f7354e704df9025519ea0933327e6d1f3eeeb6/app/core/worker.py#L233-L242)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Uncaught exception in capture blocks `apply_product_for_team`**

   `capture_periodic_team_spend_for_invoice` wraps each *region* in a try/except, but its outer logic — the team DB query and the `get_team_keys_by_region` call — is not guarded. If either raises (e.g. a DB connection hiccup), the exception propagates into `handle_stripe_event_background`'s top-level `except Exception` handler, which logs and returns — permanently skipping `apply_product_for_team`. The subscription renewal silently fails. Wrapping just the capture call in its own try/except would keep the two concerns independent.

4. `app/db/models.py`, line 664-671 ([link](https://github.com/amazeeio/amazee.ai/blob/42f7354e704df9025519ea0933327e6d1f3eeeb6/app/db/models.py#L664-L671)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Unique constraint is ineffective when `key_id` is NULL**

   In PostgreSQL, `NULL` values are never considered equal by unique constraints, so `UniqueConstraint("team_spend_period_id", "key_id")` allows any number of rows that share the same `team_spend_period_id` when `key_id` is `NULL`. A period where several LiteLLM keys can't be resolved to a DB record will produce multiple unguarded rows. The delete-then-reinsert pattern in `upsert_team_spend_period` keeps sequential calls correct, but the constraint itself provides no protection for concurrent writes or future call sites that skip the delete step.

5. `app/api/spend.py`, line 153-179 ([link](https://github.com/amazeeio/amazee.ai/blob/42f7354e704df9025519ea0933327e6d1f3eeeb6/app/api/spend.py#L153-L179)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **No pagination on the history endpoint**

   The query returns all `DBTeamSpendPeriod` rows for a team/region with no `limit` or cursor. For long-running teams billed monthly, this will keep growing without bound. Consider adding `limit`/`offset` or cursor-based query parameters before this endpoint is used in production.

6. `app/core/spend_period_service.py`, line 306-312 ([link](https://github.com/amazeeio/amazee.ai/blob/4ce15b6906db923c73cebf7a057100d08efa9be3/app/core/spend_period_service.py#L306-L312)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Ambiguous key matching silently collapses multiple LiteLLM keys onto the same DB key ID**

   When a LiteLLM key carries no `amazeeai_private_ai_key_name` metadata and no `user_id`, neither filter is applied, so `candidates` stays as the full `all_region_team_keys` list and `candidates[0]` (the highest-ID DB key) is used for every such LiteLLM key. If a team has two or more such unmatched LiteLLM keys they all receive the same `key_id`, and the subsequent `db.flush()` in `upsert_team_spend_period` raises an `IntegrityError` against `uq_team_spend_period_key`. The outer `except Exception` in `capture_periodic_team_spend_for_invoice` catches it, rolls back, and logs an error — silently losing the entire region's spend snapshot for that invoice period.

   The fix is to treat a key as unmatched (`key_id = None`) whenever the filtered candidate set is still larger than 1 (i.e., the metadata wasn't precise enough to identify a single key), rather than picking an arbitrary winner. The partial index on `(team_spend_period_id, owner_id, key_name_snapshot) WHERE key_id IS NULL` already handles deduplication for that case.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["feat: add helper function to convert val..."](https://github.com/amazeeio/amazee.ai/commit/4ce15b6906db923c73cebf7a057100d08efa9be3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31918048)</sub>

<!-- /greptile_comment -->