### PR TITLE
AI-458: Align POOL Team Lifecycle: No Trial Expiry, No Retention Deletion

### DIFF
--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -1046,9 +1046,9 @@ async def monitor_teams(db: Session):
                 team_label = (str(team.id), team.name)
                 current_team_labels.add(team_label)
 
-                # Reconcile product associations with Stripe for non-POOL teams only.
-                # POOL teams follow a separate purchase-gated lifecycle.
-                if team.budget_type != BudgetType.POOL:
+                # Reconcile product associations with Stripe, skipping only purchase-gated
+                # POOL teams which follow a separate purchase-gated lifecycle.
+                if not team.requires_pool_purchase_gate:
                     await reconcile_team_product_associations(db, team)
 
                 # Check if team has any products
@@ -1063,8 +1063,7 @@ async def monitor_teams(db: Session):
                 await _check_team_retention_policy(db, team, current_time, ses_service)
 
                 # Now handle trial expiry notifications and key expiry (after retention checks)
-                is_pool_team = team.budget_type == BudgetType.POOL
-                days_remaining = None
+                is_purchase_gated_pool_team = team.requires_pool_purchase_gate
 
                 # Check if team was monitored within 24 hours
                 should_send_notifications = settings.ENABLE_LIMITS
@@ -1074,11 +1073,11 @@ async def monitor_teams(db: Session):
                     ).total_seconds() / 3600
                     should_send_notifications = hours_since_monitored >= 24
 
-                # POOL teams are managed by pool-specific lifecycle jobs;
-                # skip trial freshness and expiry notifications.
-                if not is_pool_team:
-                    team_freshness = _monitor_team_freshness(team, db)
-                    days_remaining = TRIAL_OVER_DAYS - team_freshness
+                # Always compute freshness to emit team_freshness_days metrics for all teams;
+                # only skip trial notifications for purchase-gated POOL teams.
+                team_freshness = _monitor_team_freshness(team, db)
+                days_remaining = TRIAL_OVER_DAYS - team_freshness
+                if not is_purchase_gated_pool_team:
                     _send_expiry_notification(
                         db,
                         team,
@@ -1094,11 +1093,10 @@ async def monitor_teams(db: Session):
                 expire_keys = False
 
                 # Expire if team trial has expired (if team has a product, expiry will be handled by Stripe)
-                # POOL teams are always exempt from trial expiration.
+                # Purchase-gated POOL teams are always exempt from trial expiration.
                 if (
                     not has_products
-                    and not is_pool_team
-                    and days_remaining is not None
+                    and not is_purchase_gated_pool_team
                     and days_remaining <= 0
                     and should_send_notifications
                 ):

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -1086,21 +1086,15 @@ async def monitor_teams(db: Session):
                 keys_by_region = get_team_keys_by_region(db, team.id)
                 expire_keys = False
 
-                # Pool teams with purchases should never be treated as expired trials.
+                # POOL teams should never be treated as expired trials.
                 # Their budget lifecycle is managed separately by sync_pool_team_budgets.
-                has_active_pool_purchase = (
-                    team.budget_type == BudgetType.POOL
-                    and db.query(DBPoolPurchase)
-                    .filter(DBPoolPurchase.team_id == team.id)
-                    .first()
-                    is not None
-                )
+                is_pool_team = team.budget_type == BudgetType.POOL
 
                 # Expire if team trial has expired (if team has a product, expiry will be handled by Stripe)
-                # Pool teams with purchases are exempt — they are not trial users.
+                # POOL teams are always exempt from trial expiration.
                 if (
                     not has_products
-                    and not has_active_pool_purchase
+                    and not is_pool_team
                     and days_remaining <= 0
                     and should_send_notifications
                 ):

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -870,13 +870,7 @@ def _send_expiry_notification(
     should_send_notifications: bool,
     days_remaining: int,
     ses_service: Optional[SESService],
-    is_pool_team: bool = False,
 ):
-    # POOL teams have their own budget lifecycle managed by sync_pool_team_budgets.
-    # They should never receive trial expiry notifications.
-    if is_pool_team:
-        return
-
     # Check for notification conditions for teams still in the trial (only if not recently monitored)
     if not has_products and should_send_notifications:
         # Find the admin email for the team
@@ -1068,7 +1062,7 @@ async def monitor_teams(db: Session):
                 await _check_team_retention_policy(db, team, current_time, ses_service)
 
                 # Now handle trial expiry notifications and key expiry (after retention checks)
-                is_purchase_gated_pool_team = team.requires_pool_purchase_gate
+                is_pool_team = team.budget_type == BudgetType.POOL
 
                 # Check if team was monitored within 24 hours
                 should_send_notifications = settings.ENABLE_LIMITS
@@ -1078,11 +1072,11 @@ async def monitor_teams(db: Session):
                     ).total_seconds() / 3600
                     should_send_notifications = hours_since_monitored >= 24
 
-                # Always compute freshness to emit team_freshness_days metrics for all teams;
-                # only skip trial notifications for purchase-gated POOL teams.
+                # Always compute freshness to emit team_freshness_days metrics for all teams.
+                # POOL teams have their own lifecycle and are excluded from trial notifications.
                 team_freshness = _monitor_team_freshness(team, db)
                 days_remaining = TRIAL_OVER_DAYS - team_freshness
-                if not is_purchase_gated_pool_team:
+                if not is_pool_team:
                     _send_expiry_notification(
                         db,
                         team,
@@ -1090,7 +1084,6 @@ async def monitor_teams(db: Session):
                         should_send_notifications,
                         days_remaining,
                         ses_service,
-                        is_pool_team=False,
                     )
 
                 # Get all keys for the team grouped by region
@@ -1098,10 +1091,10 @@ async def monitor_teams(db: Session):
                 expire_keys = False
 
                 # Expire if team trial has expired (if team has a product, expiry will be handled by Stripe)
-                # Purchase-gated POOL teams are always exempt from trial expiration.
+                # POOL teams are always exempt from trial expiration.
                 if (
                     not has_products
-                    and not is_purchase_gated_pool_team
+                    and not is_pool_team
                     and days_remaining <= 0
                     and should_send_notifications
                 ):

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -1046,8 +1046,10 @@ async def monitor_teams(db: Session):
                 team_label = (str(team.id), team.name)
                 current_team_labels.add(team_label)
 
-                # Reconcile product associations with Stripe before any other processing
-                await reconcile_team_product_associations(db, team)
+                # Reconcile product associations with Stripe for non-POOL teams only.
+                # POOL teams follow a separate purchase-gated lifecycle.
+                if team.budget_type != BudgetType.POOL:
+                    await reconcile_team_product_associations(db, team)
 
                 # Check if team has any products
                 has_products = (

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -746,6 +746,11 @@ async def _check_team_retention_policy(
         current_time: Current timestamp
         ses_service: SES service instance for sending emails
     """
+    # POOL teams are always considered active per product policy.
+    # They are excluded from inactivity-based retention checks.
+    if team.budget_type == BudgetType.POOL:
+        return
+
     # Check team retention policy (only for non-deleted teams)
     if team.deleted_at:
         return  # Team already soft-deleted, skip retention check

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -1063,8 +1063,8 @@ async def monitor_teams(db: Session):
                 await _check_team_retention_policy(db, team, current_time, ses_service)
 
                 # Now handle trial expiry notifications and key expiry (after retention checks)
-                team_freshness = _monitor_team_freshness(team, db)
-                days_remaining = TRIAL_OVER_DAYS - team_freshness
+                is_pool_team = team.budget_type == BudgetType.POOL
+                days_remaining = None
 
                 # Check if team was monitored within 24 hours
                 should_send_notifications = settings.ENABLE_LIMITS
@@ -1074,29 +1074,31 @@ async def monitor_teams(db: Session):
                     ).total_seconds() / 3600
                     should_send_notifications = hours_since_monitored >= 24
 
-                _send_expiry_notification(
-                    db,
-                    team,
-                    has_products,
-                    should_send_notifications,
-                    days_remaining,
-                    ses_service,
-                    is_pool_team=team.budget_type == BudgetType.POOL,
-                )
+                # POOL teams are managed by pool-specific lifecycle jobs;
+                # skip trial freshness and expiry notifications.
+                if not is_pool_team:
+                    team_freshness = _monitor_team_freshness(team, db)
+                    days_remaining = TRIAL_OVER_DAYS - team_freshness
+                    _send_expiry_notification(
+                        db,
+                        team,
+                        has_products,
+                        should_send_notifications,
+                        days_remaining,
+                        ses_service,
+                        is_pool_team=False,
+                    )
 
                 # Get all keys for the team grouped by region
                 keys_by_region = get_team_keys_by_region(db, team.id)
                 expire_keys = False
-
-                # POOL teams should never be treated as expired trials.
-                # Their budget lifecycle is managed separately by sync_pool_team_budgets.
-                is_pool_team = team.budget_type == BudgetType.POOL
 
                 # Expire if team trial has expired (if team has a product, expiry will be handled by Stripe)
                 # POOL teams are always exempt from trial expiration.
                 if (
                     not has_products
                     and not is_pool_team
+                    and days_remaining is not None
                     and days_remaining <= 0
                     and should_send_notifications
                 ):

--- a/scripts/initialise_resources.py
+++ b/scripts/initialise_resources.py
@@ -113,13 +113,13 @@ def _restamp_to_safe_revision(
 
     # If we get here, all revisions look applied but schema still fails.
     # Fall back to base to let alembic replay everything.
-    print("All migrations appear applied but schema still has gaps - re-stamping to base")
+    print(
+        "All migrations appear applied but schema still has gaps - re-stamping to base"
+    )
     alembic.command.stamp(alembic_cfg, "base")
 
 
-def _migration_has_missing_ops(
-    source: str, db_tables: set, get_columns
-) -> bool:
+def _migration_has_missing_ops(source: str, db_tables: set, get_columns) -> bool:
     """Return True when migration schema operations appear unapplied."""
     import ast
 
@@ -180,9 +180,8 @@ def _migration_has_missing_ops(
                 old_col_name = node.args[1].value
                 new_col_name = None
                 for kwarg in node.keywords:
-                    if (
-                        kwarg.arg == "new_column_name"
-                        and isinstance(kwarg.value, ast.Constant)
+                    if kwarg.arg == "new_column_name" and isinstance(
+                        kwarg.value, ast.Constant
                     ):
                         new_col_name = kwarg.value.value
                         break

--- a/tests/test_team_retention.py
+++ b/tests/test_team_retention.py
@@ -11,6 +11,7 @@ from app.db.models import (
     DBProduct,
     DBRegion,
 )
+from app.schemas.models import BudgetType
 from app.core.worker import (
     _calculate_last_team_activity,
     _send_retention_warning,
@@ -255,6 +256,29 @@ async def test_check_team_retention_policy_warning_sent(
 
     # Verify warning was sent
     mock_send_warning.assert_called_once_with(db, test_team, None)
+
+
+@patch("app.core.worker.soft_delete_team", new_callable=AsyncMock)
+@patch("app.core.worker._send_retention_warning")
+@pytest.mark.asyncio
+async def test_check_team_retention_policy_skips_pool_teams(
+    mock_send_warning, mock_soft_delete, db: Session, test_team
+):
+    """
+    Given: A POOL team that would otherwise qualify for retention actions
+    When: Checking the team retention policy
+    Then: No warning or soft deletion should be triggered
+    """
+    test_team.budget_type = BudgetType.POOL
+    test_team.retention_warning_sent_at = datetime.now(UTC) - timedelta(days=20)
+    db.add(test_team)
+    db.commit()
+
+    current_time = datetime.now(UTC)
+    await _check_team_retention_policy(db, test_team, current_time, None)
+
+    mock_send_warning.assert_not_called()
+    mock_soft_delete.assert_not_called()
 
 
 @patch("app.core.worker.soft_delete_team", new_callable=AsyncMock)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -903,6 +903,7 @@ async def test_monitor_teams_pool_team_with_purchase_not_expired(
     # Setup: pool team, 31 days old (past trial), but with a pool purchase
     test_team.created_at = datetime.now(UTC) - timedelta(days=31)
     test_team.budget_type = BudgetType.POOL
+    test_team.require_purchase_for_requests = True
     test_team.last_pool_purchase = datetime.now(UTC) - timedelta(days=1)
     db.add(test_team)
     db.commit()
@@ -974,6 +975,7 @@ async def test_monitor_teams_pool_team_without_purchase_not_expired(
     # Setup: pool team, 31 days old (past trial), no purchases
     test_team.created_at = datetime.now(UTC) - timedelta(days=31)
     test_team.budget_type = BudgetType.POOL
+    test_team.require_purchase_for_requests = True
     db.add(test_team)
     db.commit()
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -959,7 +959,7 @@ async def test_monitor_teams_pool_team_with_purchase_not_expired(
 @patch("app.core.worker.SESService")
 @patch("app.core.worker.LiteLLMService")
 @patch("app.core.config.settings.ENABLE_LIMITS", True)
-async def test_monitor_teams_pool_team_without_purchase_is_expired(
+async def test_monitor_teams_pool_team_without_purchase_not_expired(
     mock_litellm,
     mock_ses,
     mock_limit_service,
@@ -969,7 +969,7 @@ async def test_monitor_teams_pool_team_without_purchase_is_expired(
     test_team_key_creator,
 ):
     """
-    Test that pool teams WITHOUT purchases are still expired as trials.
+    Test that pool teams WITHOUT purchases are NOT expired as trials.
     """
     # Setup: pool team, 31 days old (past trial), no purchases
     test_team.created_at = datetime.now(UTC) - timedelta(days=31)
@@ -1008,10 +1008,8 @@ async def test_monitor_teams_pool_team_without_purchase_is_expired(
     # Run monitoring
     await monitor_teams(db)
 
-    # Key SHOULD have been expired (no purchase, past trial)
-    mock_litellm_instance.update_key_duration.assert_called_once_with(
-        "pool_no_purchase_token", "0d"
-    )
+    # Key should NOT have been expired
+    mock_litellm_instance.update_key_duration.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR aligns the POOL team lifecycle so that all POOL teams are fully exempt from inactivity-based retention deletion and trial-expiry key expiration, regardless of whether they have a purchase or have `require_purchase_for_requests` set.

- `_check_team_retention_policy` now short-circuits on `budget_type == POOL`, preventing warning emails and soft-deletion for any POOL team; a new test covers the case where `retention_warning_sent_at` is already set.
- `_send_expiry_notification` drops its `is_pool_team` parameter; the guard moves to the call site in `monitor_teams` (`if not is_pool_team`), and key expiry now uses the same broad `is_pool_team` flag instead of the narrower `has_active_pool_purchase` DB query.
- Stripe reconciliation is selectively skipped only for purchase-gated POOL teams (`requires_pool_purchase_gate`), leaving non-purchase-gated POOL teams still reconciled — consistent with the comment that they may hold Stripe product associations.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the core logic change is correct and the retention/expiry exemption for all POOL teams is consistently applied across the three guard points.

The three guard points (retention, expiry notification, key expiry) are now all consistently keyed on team.budget_type == BudgetType.POOL, and the new retention test covers the edge case where retention_warning_sent_at is already populated. The Stripe reconciliation guard stays narrower (requires_pool_purchase_gate) by design. The only gap is that neither worker test exercises the POOL + require_purchase_for_requests=False combination for key-expiry exemption, but the production code path is straightforward and the flag used is the same one tested in the retention suite.

The test coverage in tests/test_worker.py does not exercise POOL teams where require_purchase_for_requests is False; a future reader changing the guard expression could regress that path silently.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/core/worker.py | Core logic change: POOL teams are now fully exempt from retention deletion and trial expiry; _send_expiry_notification loses its is_pool_team param, guard is lifted to the call site; key-expiry check switches from has_active_pool_purchase DB query to the broader is_pool_team flag; Stripe reconciliation is selectively skipped only for purchase-gated POOL teams. |
| tests/test_team_retention.py | New test verifies POOL teams are fully skipped by the retention policy even when retention_warning_sent_at is already set, covering the early-return guard added to _check_team_retention_policy. |
| tests/test_worker.py | Tests updated to reflect new all-POOL-teams-exempt-from-trial-expiry policy; both scenarios add require_purchase_for_requests=True which implicitly skips Stripe reconciliation, leaving the POOL+require_purchase_for_requests=False branch untested for key-expiry exemption. |
| scripts/initialise_resources.py | Cosmetic reformatting only (line-length wrapping), no functional changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[monitor_teams: iterate team] --> B{requires_pool_purchase_gate?}
    B -- Yes --> C[Skip Stripe reconciliation]
    B -- No --> D[reconcile_team_product_associations]
    C --> E[Check has_products]
    D --> E
    E --> F[_check_team_retention_policy]
    F --> G{budget_type == POOL?}
    G -- Yes --> H[Return early — no retention action]
    G -- No --> I[Evaluate inactivity / warning / soft-delete]
    H --> J[Compute team_freshness metrics]
    I --> J
    J --> K{budget_type == POOL?}
    K -- Yes --> L[Skip _send_expiry_notification]
    K -- No --> M[_send_expiry_notification]
    L --> N{budget_type == POOL?}
    M --> N
    N -- Yes --> O[Skip key expiry]
    N -- No --> P{not has_products AND days_remaining <= 0?}
    P -- Yes --> Q[expire_keys = True]
    P -- No --> R[expire_keys = False]
    O --> S[reconcile_team_keys]
    Q --> S
    R --> S
```
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(worker): simplify pool team not..."](https://github.com/amazeeio/amazee.ai/commit/7d7b69a4f9d2edd233b6c2f4d5f65d40a14b9b89) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31920566)</sub>

<!-- /greptile_comment -->