### PR TITLE
feat(migrations): add checks for existing tables and indexes in migra…

### DIFF
--- a/app/migrations/versions/20260512_170000_9d1a2b3c4d5e_add_team_spend_period_tables.py
+++ b/app/migrations/versions/20260512_170000_9d1a2b3c4d5e_add_team_spend_period_tables.py
@@ -16,113 +16,162 @@ branch_labels = None
 depends_on = None
 
 
-def upgrade() -> None:
-    op.create_table(
-        "team_spend_periods",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("team_id", sa.Integer(), nullable=False),
-        sa.Column("region_id", sa.Integer(), nullable=False),
-        sa.Column("budget_type", sa.String(), nullable=False),
-        sa.Column("period_start", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("period_end", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("currency", sa.String(), nullable=True),
-        sa.Column("total_spend", sa.Float(), nullable=False),
-        sa.Column("total_budget", sa.Float(), nullable=True),
-        sa.Column("total_prompt_tokens", sa.Integer(), nullable=True),
-        sa.Column("total_completion_tokens", sa.Integer(), nullable=True),
-        sa.Column("total_tokens", sa.Integer(), nullable=True),
-        sa.Column("source", sa.String(), nullable=False),
-        sa.Column("stripe_event_id", sa.String(), nullable=True),
-        sa.Column("stripe_invoice_id", sa.String(), nullable=True),
-        sa.Column("stripe_subscription_id", sa.String(), nullable=True),
-        sa.Column("raw_payload", sa.JSON(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
-        sa.ForeignKeyConstraint(["region_id"], ["regions.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["team_id"], ["teams.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint(
-            "team_id",
-            "region_id",
-            "budget_type",
-            "period_start",
-            "period_end",
-            name="uq_team_spend_period_unique_window",
-        ),
-    )
-    op.create_index(
-        op.f("ix_team_spend_periods_id"), "team_spend_periods", ["id"], unique=False
-    )
-    op.create_index(
-        op.f("ix_team_spend_periods_team_id"),
-        "team_spend_periods",
-        ["team_id"],
-        unique=False,
-    )
-    op.create_index(
-        op.f("ix_team_spend_periods_region_id"),
-        "team_spend_periods",
-        ["region_id"],
-        unique=False,
-    )
-    op.create_index(
-        op.f("ix_team_spend_periods_budget_type"),
-        "team_spend_periods",
-        ["budget_type"],
-        unique=False,
-    )
-    op.create_index(
-        op.f("ix_team_spend_periods_period_start"),
-        "team_spend_periods",
-        ["period_start"],
-        unique=False,
-    )
-    op.create_index(
-        op.f("ix_team_spend_periods_period_end"),
-        "team_spend_periods",
-        ["period_end"],
-        unique=False,
-    )
-    op.create_index(
-        op.f("ix_team_spend_periods_stripe_event_id"),
-        "team_spend_periods",
-        ["stripe_event_id"],
-        unique=False,
-    )
+def _table_exists(bind, table_name: str) -> bool:
+    return sa.inspect(bind).has_table(table_name)
 
-    op.create_table(
+
+def _index_exists(bind, table_name: str, index_name: str) -> bool:
+    insp = sa.inspect(bind)
+    try:
+        indexes = insp.get_indexes(table_name)
+    except Exception:
+        return False
+    return any(idx.get("name") == index_name for idx in indexes)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    if not _table_exists(bind, "team_spend_periods"):
+        op.create_table(
+            "team_spend_periods",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("team_id", sa.Integer(), nullable=False),
+            sa.Column("region_id", sa.Integer(), nullable=False),
+            sa.Column("budget_type", sa.String(), nullable=False),
+            sa.Column("period_start", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("period_end", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("currency", sa.String(), nullable=True),
+            sa.Column("total_spend", sa.Float(), nullable=False),
+            sa.Column("total_budget", sa.Float(), nullable=True),
+            sa.Column("total_prompt_tokens", sa.Integer(), nullable=True),
+            sa.Column("total_completion_tokens", sa.Integer(), nullable=True),
+            sa.Column("total_tokens", sa.Integer(), nullable=True),
+            sa.Column("source", sa.String(), nullable=False),
+            sa.Column("stripe_event_id", sa.String(), nullable=True),
+            sa.Column("stripe_invoice_id", sa.String(), nullable=True),
+            sa.Column("stripe_subscription_id", sa.String(), nullable=True),
+            sa.Column("raw_payload", sa.JSON(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(["region_id"], ["regions.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["team_id"], ["teams.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(
+                "team_id",
+                "region_id",
+                "budget_type",
+                "period_start",
+                "period_end",
+                name="uq_team_spend_period_unique_window",
+            ),
+        )
+
+    if not _index_exists(bind, "team_spend_periods", op.f("ix_team_spend_periods_id")):
+        op.create_index(
+            op.f("ix_team_spend_periods_id"),
+            "team_spend_periods",
+            ["id"],
+            unique=False,
+        )
+    if not _index_exists(
+        bind, "team_spend_periods", op.f("ix_team_spend_periods_team_id")
+    ):
+        op.create_index(
+            op.f("ix_team_spend_periods_team_id"),
+            "team_spend_periods",
+            ["team_id"],
+            unique=False,
+        )
+    if not _index_exists(
+        bind, "team_spend_periods", op.f("ix_team_spend_periods_region_id")
+    ):
+        op.create_index(
+            op.f("ix_team_spend_periods_region_id"),
+            "team_spend_periods",
+            ["region_id"],
+            unique=False,
+        )
+    if not _index_exists(
+        bind, "team_spend_periods", op.f("ix_team_spend_periods_budget_type")
+    ):
+        op.create_index(
+            op.f("ix_team_spend_periods_budget_type"),
+            "team_spend_periods",
+            ["budget_type"],
+            unique=False,
+        )
+    if not _index_exists(
+        bind, "team_spend_periods", op.f("ix_team_spend_periods_period_start")
+    ):
+        op.create_index(
+            op.f("ix_team_spend_periods_period_start"),
+            "team_spend_periods",
+            ["period_start"],
+            unique=False,
+        )
+    if not _index_exists(
+        bind, "team_spend_periods", op.f("ix_team_spend_periods_period_end")
+    ):
+        op.create_index(
+            op.f("ix_team_spend_periods_period_end"),
+            "team_spend_periods",
+            ["period_end"],
+            unique=False,
+        )
+    if not _index_exists(
+        bind, "team_spend_periods", op.f("ix_team_spend_periods_stripe_event_id")
+    ):
+        op.create_index(
+            op.f("ix_team_spend_periods_stripe_event_id"),
+            "team_spend_periods",
+            ["stripe_event_id"],
+            unique=False,
+        )
+
+    if not _table_exists(bind, "team_spend_period_keys"):
+        op.create_table(
+            "team_spend_period_keys",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("team_spend_period_id", sa.Integer(), nullable=False),
+            sa.Column("key_id", sa.Integer(), nullable=True),
+            sa.Column("owner_id", sa.Integer(), nullable=True),
+            sa.Column("key_name_snapshot", sa.String(), nullable=True),
+            sa.Column("spend", sa.Float(), nullable=False),
+            sa.Column("max_budget", sa.Float(), nullable=True),
+            sa.Column("prompt_tokens", sa.Integer(), nullable=True),
+            sa.Column("completion_tokens", sa.Integer(), nullable=True),
+            sa.Column("total_tokens", sa.Integer(), nullable=True),
+            sa.ForeignKeyConstraint(["key_id"], ["ai_tokens.id"], ondelete="SET NULL"),
+            sa.ForeignKeyConstraint(["owner_id"], ["users.id"], ondelete="SET NULL"),
+            sa.ForeignKeyConstraint(
+                ["team_spend_period_id"], ["team_spend_periods.id"], ondelete="CASCADE"
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(
+                "team_spend_period_id", "key_id", name="uq_team_spend_period_key"
+            ),
+        )
+
+    if not _index_exists(
+        bind, "team_spend_period_keys", op.f("ix_team_spend_period_keys_id")
+    ):
+        op.create_index(
+            op.f("ix_team_spend_period_keys_id"),
+            "team_spend_period_keys",
+            ["id"],
+            unique=False,
+        )
+    if not _index_exists(
+        bind,
         "team_spend_period_keys",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("team_spend_period_id", sa.Integer(), nullable=False),
-        sa.Column("key_id", sa.Integer(), nullable=True),
-        sa.Column("owner_id", sa.Integer(), nullable=True),
-        sa.Column("key_name_snapshot", sa.String(), nullable=True),
-        sa.Column("spend", sa.Float(), nullable=False),
-        sa.Column("max_budget", sa.Float(), nullable=True),
-        sa.Column("prompt_tokens", sa.Integer(), nullable=True),
-        sa.Column("completion_tokens", sa.Integer(), nullable=True),
-        sa.Column("total_tokens", sa.Integer(), nullable=True),
-        sa.ForeignKeyConstraint(["key_id"], ["ai_tokens.id"], ondelete="SET NULL"),
-        sa.ForeignKeyConstraint(["owner_id"], ["users.id"], ondelete="SET NULL"),
-        sa.ForeignKeyConstraint(
-            ["team_spend_period_id"], ["team_spend_periods.id"], ondelete="CASCADE"
-        ),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint(
-            "team_spend_period_id", "key_id", name="uq_team_spend_period_key"
-        ),
-    )
-    op.create_index(
-        op.f("ix_team_spend_period_keys_id"),
-        "team_spend_period_keys",
-        ["id"],
-        unique=False,
-    )
-    op.create_index(
         op.f("ix_team_spend_period_keys_team_spend_period_id"),
-        "team_spend_period_keys",
-        ["team_spend_period_id"],
-        unique=False,
-    )
+    ):
+        op.create_index(
+            op.f("ix_team_spend_period_keys_team_spend_period_id"),
+            "team_spend_period_keys",
+            ["team_spend_period_id"],
+            unique=False,
+        )
 
 
 def downgrade() -> None:

--- a/app/migrations/versions/20260512_170000_9d1a2b3c4d5e_add_team_spend_period_tables.py
+++ b/app/migrations/versions/20260512_170000_9d1a2b3c4d5e_add_team_spend_period_tables.py
@@ -24,7 +24,7 @@ def _index_exists(bind, table_name: str, index_name: str) -> bool:
     insp = sa.inspect(bind)
     try:
         indexes = insp.get_indexes(table_name)
-    except Exception:
+    except sa.exc.NoSuchTableError:
         return False
     return any(idx.get("name") == index_name for idx in indexes)
 


### PR DESCRIPTION
…tion

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds existence guards (`IF NOT EXISTS`-style checks) around all `create_table` and `create_index` calls in the `team_spend_periods` / `team_spend_period_keys` migration, making the `upgrade()` path idempotent for environments where these objects were created ahead of the migration being stamped.

- Two helper functions (`_table_exists`, `_index_exists`) are introduced and applied consistently to all DDL operations in `upgrade()`, following the pattern already established in other repair migrations in this codebase.
- `downgrade()` is left unchanged and unconditionally drops all indexes and tables, creating an asymmetry: if `upgrade` was a no-op because the tables pre-existed, `downgrade` will still destroy them and all their data.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The upgrade path is safe; the downgrade path can destroy pre-existing tables and data in environments this migration was applied to idempotently.

The asymmetry between the guarded upgrade and the unconditional downgrade means a rollback on any environment where the tables predated this migration would drop those tables entirely. This is a real data-loss risk on any non-fresh database that received this migration as a no-op stamp.

app/migrations/versions/20260512_170000_9d1a2b3c4d5e_add_team_spend_period_tables.py — specifically the downgrade() function
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/migrations/versions/20260512_170000_9d1a2b3c4d5e_add_team_spend_period_tables.py | Wraps all `create_table` and `create_index` calls in existence guards to make the upgrade idempotent, but `downgrade()` is left unconditional — rolling back on an environment where the tables pre-existed will drop them and their data. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/migrations/versions/20260512_170000_9d1a2b3c4d5e_add_team_spend_period_tables.py`, line 177-206 ([link](https://github.com/amazeeio/amazee.ai/blob/e507096dcf09d19be83eb78e36acf957381fe0c1/app/migrations/versions/20260512_170000_9d1a2b3c4d5e_add_team_spend_period_tables.py#L177-L206)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Destructive downgrade after idempotent upgrade**

   `downgrade()` unconditionally drops all indexes and tables, but `upgrade()` now skips creation when objects pre-exist. If this migration is applied to an environment where `team_spend_periods` or `team_spend_period_keys` already existed (upgrade is a no-op), running `downgrade` will still `DROP TABLE` on both, destroying all data in those tables even though this migration never created them. The existence-guarded upgrade and the unconditional downgrade are asymmetric, making rollback unsafe in any environment that had these tables before this revision was stamped.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(migrations): add checks for existin..."](https://github.com/amazeeio/amazee.ai/commit/e507096dcf09d19be83eb78e36acf957381fe0c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32277973)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->