### PR TITLE
Hotfix/ai 475 migration

### DIFF
--- a/app/migrations/versions/20260510_140000_a474_periodic_payments.py
+++ b/app/migrations/versions/20260510_140000_a474_periodic_payments.py
@@ -16,43 +16,68 @@ revision: str = "a474_periodic_payments"
 down_revision: Union[str, None] = "f1c2d3e4a5b6"
 
 
+def _table_exists(bind, table_name: str) -> bool:
+    return sa.inspect(bind).has_table(table_name)
+
+
+def _index_exists(bind, table_name: str, index_name: str) -> bool:
+    insp = sa.inspect(bind)
+    try:
+        indexes = insp.get_indexes(table_name)
+    except sa.exc.NoSuchTableError:
+        return False
+    return any(idx.get("name") == index_name for idx in indexes)
+
+
 def upgrade() -> None:
-    op.create_table(
-        "periodic_payments",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("team_id", sa.Integer(), nullable=False),
-        sa.Column("stripe_payment_id", sa.String(), nullable=False),
-        sa.Column("amount_cents", sa.Integer(), nullable=False),
-        sa.Column("currency", sa.String(), nullable=False),
-        sa.Column("payment_type", sa.String(), nullable=False),
-        sa.Column("status", sa.String(), nullable=False),
-        sa.Column("sync_status", sa.String(), nullable=False, server_default="pending"),
-        sa.Column("error_log", sa.Text(), nullable=True),
-        sa.Column("payment_date", sa.DateTime(timezone=True), nullable=False),
-        sa.Column(
-            "created_at",
-            sa.DateTime(timezone=True),
-            nullable=False,
-            server_default=sa.func.now(),
-        ),
-        sa.ForeignKeyConstraint(["team_id"], ["teams.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index(
-        op.f("ix_periodic_payments_id"), "periodic_payments", ["id"], unique=False
-    )
-    op.create_index(
-        op.f("ix_periodic_payments_stripe_payment_id"),
-        "periodic_payments",
-        ["stripe_payment_id"],
-        unique=True,
-    )
-    op.create_index(
-        op.f("ix_periodic_payments_team_id"),
-        "periodic_payments",
-        ["team_id"],
-        unique=False,
-    )
+    bind = op.get_bind()
+
+    if not _table_exists(bind, "periodic_payments"):
+        op.create_table(
+            "periodic_payments",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("team_id", sa.Integer(), nullable=False),
+            sa.Column("stripe_payment_id", sa.String(), nullable=False),
+            sa.Column("amount_cents", sa.Integer(), nullable=False),
+            sa.Column("currency", sa.String(), nullable=False),
+            sa.Column("payment_type", sa.String(), nullable=False),
+            sa.Column("status", sa.String(), nullable=False),
+            sa.Column(
+                "sync_status", sa.String(), nullable=False, server_default="pending"
+            ),
+            sa.Column("error_log", sa.Text(), nullable=True),
+            sa.Column("payment_date", sa.DateTime(timezone=True), nullable=False),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.ForeignKeyConstraint(["team_id"], ["teams.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+        )
+    if not _index_exists(bind, "periodic_payments", op.f("ix_periodic_payments_id")):
+        op.create_index(
+            op.f("ix_periodic_payments_id"), "periodic_payments", ["id"], unique=False
+        )
+    if not _index_exists(
+        bind, "periodic_payments", op.f("ix_periodic_payments_stripe_payment_id")
+    ):
+        op.create_index(
+            op.f("ix_periodic_payments_stripe_payment_id"),
+            "periodic_payments",
+            ["stripe_payment_id"],
+            unique=True,
+        )
+    if not _index_exists(
+        bind, "periodic_payments", op.f("ix_periodic_payments_team_id")
+    ):
+        op.create_index(
+            op.f("ix_periodic_payments_team_id"),
+            "periodic_payments",
+            ["team_id"],
+            unique=False,
+        )
 
 
 def downgrade() -> None:

--- a/app/migrations/versions/20260510_140000_a474_periodic_payments.py
+++ b/app/migrations/versions/20260510_140000_a474_periodic_payments.py
@@ -81,9 +81,19 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_index(op.f("ix_periodic_payments_team_id"), table_name="periodic_payments")
     op.drop_index(
-        op.f("ix_periodic_payments_stripe_payment_id"), table_name="periodic_payments"
+        op.f("ix_periodic_payments_team_id"),
+        table_name="periodic_payments",
+        if_exists=True,
     )
-    op.drop_index(op.f("ix_periodic_payments_id"), table_name="periodic_payments")
-    op.drop_table("periodic_payments")
+    op.drop_index(
+        op.f("ix_periodic_payments_stripe_payment_id"),
+        table_name="periodic_payments",
+        if_exists=True,
+    )
+    op.drop_index(
+        op.f("ix_periodic_payments_id"),
+        table_name="periodic_payments",
+        if_exists=True,
+    )
+    op.drop_table("periodic_payments", if_exists=True)

--- a/scripts/initialise_resources.py
+++ b/scripts/initialise_resources.py
@@ -11,7 +11,6 @@ import alembic.command
 import asyncio
 import glob
 from sqlalchemy import inspect
-from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.orm import sessionmaker, Session
 from app.db.database import engine
 from app.db.models import Base, DBUser
@@ -52,151 +51,6 @@ def verify_schema_matches_models() -> None:
         raise RuntimeError("Schema verification failed - " + "; ".join(details))
 
 
-def _restamp_to_safe_revision(
-    alembic_cfg: alembic.config.Config, inspector: Inspector
-) -> None:
-    """Re-stamp alembic to the ``down_revision`` of the first migration
-    (walking from head backwards) whose schema effects are missing.
-
-    This handles the case where ``alembic_version`` was stamped past
-    migrations that never actually ran (e.g. a ``create_all`` +
-    ``stamp('head')`` on a previous deploy that missed later migrations).
-    """
-    from alembic.script import ScriptDirectory
-    import pathlib
-
-    script = ScriptDirectory.from_config(alembic_cfg)
-    db_tables = set(inspector.get_table_names())
-    db_columns_cache: dict[str, set[str]] = {}
-
-    def _get_columns(table_name: str) -> set[str]:
-        if table_name not in db_columns_cache:
-            db_columns_cache[table_name] = {
-                col["name"] for col in inspector.get_columns(table_name)
-            }
-        return db_columns_cache[table_name]
-
-    # Walk linearly from head backwards.  Find the first revision (from
-    # head) whose schema effects are NOT present.  Stamp to its
-    # down_revision so ``upgrade head`` can replay it and everything after.
-    revision = script.get_current_head()
-    if revision is None:
-        print("Could not determine alembic head revision - skipping re-stamp")
-        return
-
-    while revision:
-        rev_obj = script.get_revision(revision)
-        if rev_obj is None:
-            break
-
-        try:
-            source = pathlib.Path(rev_obj.module.__file__).read_text()
-        except Exception:
-            break
-
-        if _migration_has_missing_ops(source, db_tables, _get_columns):
-            # This revision hasn't been applied – stamp to its parent
-            # so ``upgrade head`` will replay from there.
-            down = rev_obj.down_revision
-            if isinstance(down, tuple):
-                down = down[0]
-            stamp_target = down or "base"
-            print(f"Re-stamping alembic to revision: {stamp_target}")
-            alembic.command.stamp(alembic_cfg, stamp_target)
-            return
-
-        # This revision is applied – keep walking back
-        down = rev_obj.down_revision
-        if isinstance(down, tuple):
-            down = down[0]
-        revision = down
-
-    # If we get here, all revisions look applied but schema still fails.
-    # Fall back to base to let alembic replay everything.
-    print(
-        "All migrations appear applied but schema still has gaps - re-stamping to base"
-    )
-    alembic.command.stamp(alembic_cfg, "base")
-
-
-def _migration_has_missing_ops(source: str, db_tables: set, get_columns) -> bool:
-    """Return True when migration schema operations appear unapplied."""
-    import ast
-
-    try:
-        tree = ast.parse(source)
-    except SyntaxError:
-        return True
-
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        func = node.func
-        if not isinstance(func, ast.Attribute):
-            continue
-
-        if func.attr == "create_table":
-            # First positional arg is the table name
-            if node.args and isinstance(node.args[0], ast.Constant):
-                if node.args[0].value not in db_tables:
-                    return True
-
-        elif func.attr == "add_column":
-            # First arg = table name, second arg = Column with name
-            if (
-                len(node.args) >= 2
-                and isinstance(node.args[0], ast.Constant)
-                and isinstance(node.args[1], ast.Call)
-            ):
-                table_name = node.args[0].value
-                col_arg = node.args[1]
-                if (
-                    table_name in db_tables
-                    and isinstance(col_arg.func, ast.Attribute)
-                    and col_arg.func.attr == "Column"
-                    and col_arg.args
-                    and isinstance(col_arg.args[0], ast.Constant)
-                ):
-                    col_name = col_arg.args[0].value
-                    if col_name not in get_columns(table_name):
-                        return True
-
-        elif func.attr == "rename_table":
-            if (
-                len(node.args) >= 2
-                and isinstance(node.args[0], ast.Constant)
-                and isinstance(node.args[1], ast.Constant)
-            ):
-                old_name = node.args[0].value
-                new_name = node.args[1].value
-                if old_name in db_tables and new_name not in db_tables:
-                    return True
-
-        elif func.attr == "alter_column":
-            if len(node.args) >= 2 and isinstance(node.args[0], ast.Constant):
-                table_name = node.args[0].value
-                if not isinstance(node.args[1], ast.Constant):
-                    continue
-                old_col_name = node.args[1].value
-                new_col_name = None
-                for kwarg in node.keywords:
-                    if kwarg.arg == "new_column_name" and isinstance(
-                        kwarg.value, ast.Constant
-                    ):
-                        new_col_name = kwarg.value.value
-                        break
-
-                if new_col_name and table_name in db_tables:
-                    existing_columns = get_columns(table_name)
-                    if (
-                        old_col_name in existing_columns
-                        and new_col_name not in existing_columns
-                    ):
-                        return True
-
-    return False
-
-
 def init_database() -> Session:
     # Check if database is empty (no tables exist)
     inspector = inspect(engine)
@@ -223,20 +77,9 @@ def init_database() -> Session:
     else:
         print("Tables already exist - running migrations...")
 
-        # Guard against stale alembic stamps: if the DB reports it is at
-        # head but the actual schema is missing tables/columns, re-stamp
-        # to a safe point so ``upgrade head`` can replay missing migrations.
-        # We walk backwards from head, checking each revision's upgrade()
-        # effects until we find one that has already been applied.
-        try:
-            verify_schema_matches_models()
-        except RuntimeError as exc:
-            print(
-                f"Schema gap detected ({exc}) "
-                f"- finding safe alembic stamp point to replay migrations"
-            )
-            _restamp_to_safe_revision(alembic_cfg, inspector)
-
+        # Always move forward in migration history.
+        # Backward re-stamping/replay can trigger duplicate DDL in partially
+        # migrated databases and break rollout readiness.
         alembic.command.upgrade(alembic_cfg, "head")
         print("Database migrations completed successfully!")
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This hotfix makes the `a474_periodic_payments` migration fully idempotent to handle environments where the `periodic_payments` table already existed before the migration was stamped. It also removes the complex `_restamp_to_safe_revision` logic from `initialise_resources.py` in favour of a simpler forward-only upgrade path with a post-upgrade schema verification.

- **Migration idempotency (`upgrade`)**: `create_table` and each `create_index` are now guarded by `_table_exists` / `_index_exists` checks, so re-running on a database that already has the table and indexes is safe and produces no errors.
- **`downgrade` safety**: All three `drop_index` calls and the `drop_table` call now use `if_exists=True` (valid since Alembic 1.13.3; project pins 1.18.4), matching the idempotency intent of `upgrade` and addressing the data-loss risk flagged in the previous review.
- **Simplified init flow**: `_restamp_to_safe_revision` (backward re-stamping) is removed because it could trigger duplicate DDL on partially-migrated databases; `verify_schema_matches_models` still runs as a post-upgrade safety net, failing loudly if the schema is not as expected.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the downgrade data-loss issue flagged in the previous review has been fully resolved, and the simplified init flow fails loudly on schema mismatches rather than silently accepting a broken state.

Both changed files make targeted, well-reasoned fixes. The migration is now idempotent in both directions: upgrade skips objects that already exist, and downgrade uses if_exists=True on every drop (supported by Alembic 1.13.3+; project pins 1.18.4). The removal of the backward re-stamping logic is clearly intentional and documented in a code comment, and verify_schema_matches_models still acts as a post-upgrade safety net.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/migrations/versions/20260510_140000_a474_periodic_payments.py | Made upgrade() idempotent with table/index existence guards and fixed downgrade() to use if_exists=True on all drop operations — addressing the previously-flagged destructive downgrade issue. |
| scripts/initialise_resources.py | Removed _restamp_to_safe_revision and _migration_has_missing_ops helpers along with the pre-upgrade schema-gap detection; now simply calls alembic upgrade head and relies on verify_schema_matches_models post-check. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[init_database called] --> B{existing_tables empty?}
    B -- Yes --> C[Base.metadata.create_all]
    C --> D[alembic stamp head]
    B -- No --> E[alembic upgrade head]
    E --> F{upgrade migration runs}
    F --> G{periodic_payments table exists?}
    G -- No --> H[create_table periodic_payments]
    G -- Yes --> I[skip create_table]
    H --> J{ix_periodic_payments_id exists?}
    I --> J
    J -- No --> K[create_index id]
    J -- Yes --> L[skip]
    K --> M{ix_periodic_payments_stripe_payment_id exists?}
    L --> M
    M -- No --> N[create_index stripe_payment_id unique]
    M -- Yes --> O[skip]
    N --> P{ix_periodic_payments_team_id exists?}
    O --> P
    P -- No --> Q[create_index team_id]
    P -- Yes --> R[skip]
    Q --> S[verify_schema_matches_models]
    R --> S
    D --> S
    S -- pass --> T[initialization continues]
    S -- fail --> U[RuntimeError — manual intervention needed]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/migrations/versions/20260510_140000_a474_periodic_payments.py`, line 83-89 ([link](https://github.com/amazeeio/amazee.ai/blob/5032a69a7ba46a043f61704c166ba05ba4f8a19a/app/migrations/versions/20260510_140000_a474_periodic_payments.py#L83-L89)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`downgrade()` not updated to match `upgrade()` idempotency**

   `upgrade()` was explicitly made idempotent to handle environments where `periodic_payments` already existed before this migration was stamped. `downgrade()`, however, still drops the table and all three indexes unconditionally. If the table pre-existed (i.e., `upgrade()` skipped `create_table`), a subsequent `downgrade()` would silently destroy a table that this migration never actually created, causing data loss. The guards added to `upgrade()` should be mirrored here with `IF EXISTS` or equivalent checks (e.g., `op.drop_index(..., if_exists=True)` / `op.drop_table(..., if_exists=True)`) to prevent destructive drops of pre-existing objects.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["refactor(migration): update downgrade me..."](https://github.com/amazeeio/amazee.ai/commit/7957fde143b69bcaf78337960aef37f4e3979884) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32284770)</sub>

<!-- /greptile_comment -->