### PR TITLE
feat(migration): enforce unique index creation for null key_id entries

### DIFF
--- a/app/migrations/versions/20260513_113000_2f7c9d1e4aab_enforce_unique_unmatched_spend_period_key.py
+++ b/app/migrations/versions/20260513_113000_2f7c9d1e4aab_enforce_unique_unmatched_spend_period_key.py
@@ -16,19 +16,32 @@ branch_labels = None
 depends_on = None
 
 
+def _index_exists(bind, table_name: str, index_name: str) -> bool:
+    insp = sa.inspect(bind)
+    try:
+        indexes = insp.get_indexes(table_name)
+    except sa.exc.NoSuchTableError:
+        return False
+    return any(idx.get("name") == index_name for idx in indexes)
+
+
 def upgrade() -> None:
-    op.create_index(
-        "uq_team_spend_period_key_null_key_id",
-        "team_spend_period_keys",
-        ["team_spend_period_id", "owner_id", "key_name_snapshot"],
-        unique=True,
-        postgresql_where=sa.text("key_id IS NULL"),
-        sqlite_where=sa.text("key_id IS NULL"),
-    )
+    bind = op.get_bind()
+    index_name = "uq_team_spend_period_key_null_key_id"
+    if not _index_exists(bind, "team_spend_period_keys", index_name):
+        op.create_index(
+            index_name,
+            "team_spend_period_keys",
+            ["team_spend_period_id", "owner_id", "key_name_snapshot"],
+            unique=True,
+            postgresql_where=sa.text("key_id IS NULL"),
+            sqlite_where=sa.text("key_id IS NULL"),
+        )
 
 
 def downgrade() -> None:
     op.drop_index(
         "uq_team_spend_period_key_null_key_id",
         table_name="team_spend_period_keys",
+        if_exists=True,
     )


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This migration patches the previous `9d1a2b3c4d5e` migration to make both the `upgrade` and `downgrade` paths idempotent, addressing environments where the partial unique index `uq_team_spend_period_key_null_key_id` may already exist.

- **Upgrade guard**: A `_index_exists` helper (mirroring the pattern from the parent migration) is used to skip `create_index` if the index is already present, preventing `duplicate index` errors on re-runs.
- **Downgrade guard**: `if_exists=True` is added to `op.drop_index`, which is valid since Alembic 1.12.0 and translates to `DROP INDEX IF EXISTS` on both PostgreSQL and SQLite.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change makes both upgrade and downgrade paths re-runnable without adding any new schema alterations.

The upgrade now guards against duplicate-index errors by checking existence before creation, following the exact same helper pattern already present in the parent migration. The downgrade uses `if_exists=True`, which is natively supported by Alembic since 1.12.0 and translates cleanly to `DROP INDEX IF EXISTS` on both PostgreSQL and SQLite. No new columns, tables, or constraints are introduced, and the underlying partial-index definition is unchanged.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/migrations/versions/20260513_113000_2f7c9d1e4aab_enforce_unique_unmatched_spend_period_key.py | Adds idempotency check before partial unique index creation and if_exists guard on drop; both patterns mirror the parent migration and are safe. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Alembic
    participant DB as Database

    Note over Alembic,DB: upgrade()
    Alembic->>DB: op.get_bind() → Connection
    Alembic->>DB: inspect(bind).get_indexes("team_spend_period_keys")
    DB-->>Alembic: index list
    alt index "uq_team_spend_period_key_null_key_id" NOT found
        Alembic->>DB: CREATE UNIQUE INDEX ... WHERE key_id IS NULL
        DB-->>Alembic: OK
    else index already exists
        Note over Alembic: skip (idempotent)
    end

    Note over Alembic,DB: downgrade()
    Alembic->>DB: DROP INDEX IF EXISTS uq_team_spend_period_key_null_key_id
    DB-->>Alembic: OK (no-op if absent)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(migration): enforce unique index cr..."](https://github.com/amazeeio/amazee.ai/commit/c034b783412271401a734aae3c96a6629d6ade4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32300606)</sub>

<!-- /greptile_comment -->