### PR TITLE
chore: remove key-level budget editing and show team-level budget in admin UI

### DIFF
--- a/frontend/src/app/admin/private-ai-keys/page.tsx
+++ b/frontend/src/app/admin/private-ai-keys/page.tsx
@@ -7,7 +7,7 @@ import { usePrivateAIKeysData } from "@/hooks/use-private-ai-keys-data";
 import { useTeams } from "@/hooks/use-teams";
 import { useToast } from "@/hooks/use-toast";
 import { PrivateAIKey } from "@/types/private-ai-key";
-import { get, del, put, post } from "@/utils/api";
+import { get, del, post } from "@/utils/api";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 export default function PrivateAIKeysPage() {
@@ -90,37 +90,6 @@ export default function PrivateAIKeysPage() {
     },
   });
 
-  const updateBudgetPeriodMutation = useMutation({
-    mutationFn: async ({
-      keyId,
-      budgetDuration,
-    }: {
-      keyId: number;
-      budgetDuration: string;
-    }) => {
-      const response = await put(`/private-ai-keys/${keyId}/budget-period`, {
-        budget_duration: budgetDuration,
-      });
-      return response.json();
-    },
-    onSuccess: (data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: ["private-ai-key-spend", variables.keyId],
-      });
-      toast({
-        title: "Success",
-        description: "Budget period updated successfully",
-      });
-    },
-    onError: (error: Error) => {
-      toast({
-        title: "Error",
-        description: error.message,
-        variant: "destructive",
-      });
-    },
-  });
-
   return (
     <div className="space-y-4">
       <div className="flex justify-between items-center">
@@ -148,10 +117,6 @@ export default function PrivateAIKeysPage() {
         isDeleting={deletePrivateAIKeyMutation.isPending}
         allowModification={true}
         showOwner={true}
-        onUpdateBudget={(keyId, budgetDuration) => {
-          updateBudgetPeriodMutation.mutate({ keyId, budgetDuration });
-        }}
-        isUpdatingBudget={updateBudgetPeriodMutation.isPending}
         teamDetails={teamDetails}
         teamMembers={teamMembers}
       />

--- a/frontend/src/app/admin/teams/_components/team-expansion-row.tsx
+++ b/frontend/src/app/admin/teams/_components/team-expansion-row.tsx
@@ -1,4 +1,4 @@
-import { Loader2, UserPlus, Plus } from "lucide-react";
+import { Loader2, UserPlus, Plus, Info } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -21,6 +21,12 @@ import {
 } from "@/components/ui/table";
 import { TableActionButtons } from "@/components/ui/table-action-buttons";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useTeams } from "@/hooks/use-teams";
 import { PrivateAIKey } from "@/types/private-ai-key";
 import { Product } from "@/types/product";
@@ -532,6 +538,28 @@ export function TeamExpansionRow({
                   </TabsContent>
                   <TabsContent value="shared-keys" className="mt-4">
                     <div className="space-y-4">
+                      {/* Team-level budget info */}
+                      {(() => {
+                        const teamBudgetLimit = teamLimits.find(
+                          (l) =>
+                            l.resource === "max_budget" &&
+                            l.limit_type === "data_plane",
+                        );
+                        return (
+                          <div className="flex items-center gap-2 rounded-md border bg-muted/50 p-3 text-sm">
+                            <Info className="h-4 w-4 text-muted-foreground shrink-0" />
+                            <span>
+                              <strong>Team Budget:</strong>{" "}
+                              {teamBudgetLimit
+                                ? `$${teamBudgetLimit.max_value.toFixed(2)} (${teamBudgetLimit.limited_by})`
+                                : "Not set"}{" "}
+                              — Budget is enforced at the team level and
+                              overrides individual key budgets. Edit it in the{" "}
+                              <strong>Limits</strong> tab.
+                            </span>
+                          </div>
+                        );
+                      })()}
                       {isLoadingTeamAIKeys ? (
                         <div className="flex justify-center items-center py-8">
                           <Loader2 className="h-8 w-8 animate-spin" />
@@ -547,7 +575,24 @@ export function TeamExpansionRow({
                                 <TableHead>Database</TableHead>
                                 <TableHead>Created At</TableHead>
                                 <TableHead>Spend</TableHead>
-                                <TableHead>Budget</TableHead>
+                                <TableHead>
+                                  <div className="flex items-center gap-1">
+                                    Budget (Team)
+                                    <TooltipProvider>
+                                      <Tooltip>
+                                        <TooltipTrigger>
+                                          <Info className="h-3 w-3 text-muted-foreground" />
+                                        </TooltipTrigger>
+                                        <TooltipContent>
+                                          <p>
+                                            Budget is set at team level and
+                                            overrides key-level budgets.
+                                          </p>
+                                        </TooltipContent>
+                                      </Tooltip>
+                                    </TooltipProvider>
+                                  </div>
+                                </TableHead>
                               </TableRow>
                             </TableHeader>
                             <TableBody>
@@ -595,15 +640,25 @@ export function TeamExpansionRow({
                                       )}
                                     </TableCell>
                                     <TableCell>
-                                      {spendInfo?.max_budget ? (
-                                        <span>
-                                          ${spendInfo.max_budget.toFixed(2)}
-                                        </span>
-                                      ) : (
-                                        <span className="text-muted-foreground">
-                                          No limit
-                                        </span>
-                                      )}
+                                      {(() => {
+                                        const teamBudgetLimit = teamLimits.find(
+                                          (l) =>
+                                            l.resource === "max_budget" &&
+                                            l.limit_type === "data_plane",
+                                        );
+                                        return teamBudgetLimit ? (
+                                          <span>
+                                            $
+                                            {teamBudgetLimit.max_value.toFixed(
+                                              2,
+                                            )}
+                                          </span>
+                                        ) : (
+                                          <span className="text-muted-foreground">
+                                            No limit
+                                          </span>
+                                        );
+                                      })()}
                                     </TableCell>
                                   </TableRow>
                                 );

--- a/frontend/src/app/admin/teams/_components/team-expansion-row.tsx
+++ b/frontend/src/app/admin/teams/_components/team-expansion-row.tsx
@@ -157,6 +157,10 @@ export function TeamExpansionRow({
     return new Date(team.last_payment) < thirtyDaysAgo;
   };
 
+  const teamBudgetLimit = teamLimits.find(
+    (l) => l.resource === "max_budget" && l.limit_type === "data_plane",
+  );
+
   return (
     <TableRow>
       <TableCell colSpan={7} className="p-0">
@@ -539,27 +543,18 @@ export function TeamExpansionRow({
                   <TabsContent value="shared-keys" className="mt-4">
                     <div className="space-y-4">
                       {/* Team-level budget info */}
-                      {(() => {
-                        const teamBudgetLimit = teamLimits.find(
-                          (l) =>
-                            l.resource === "max_budget" &&
-                            l.limit_type === "data_plane",
-                        );
-                        return (
-                          <div className="flex items-center gap-2 rounded-md border bg-muted/50 p-3 text-sm">
-                            <Info className="h-4 w-4 text-muted-foreground shrink-0" />
-                            <span>
-                              <strong>Team Budget:</strong>{" "}
-                              {teamBudgetLimit
-                                ? `$${teamBudgetLimit.max_value.toFixed(2)} (${teamBudgetLimit.limited_by})`
-                                : "Not set"}{" "}
-                              — Budget is enforced at the team level and
-                              overrides individual key budgets. Edit it in the{" "}
-                              <strong>Limits</strong> tab.
-                            </span>
-                          </div>
-                        );
-                      })()}
+                      <div className="flex items-center gap-2 rounded-md border bg-muted/50 p-3 text-sm">
+                        <Info className="h-4 w-4 text-muted-foreground shrink-0" />
+                        <span>
+                          <strong>Team Budget:</strong>{" "}
+                          {teamBudgetLimit
+                            ? `$${teamBudgetLimit.max_value.toFixed(2)} (${teamBudgetLimit.limited_by})`
+                            : "Not set"}{" "}
+                          — Budget is enforced at the team level and
+                          overrides individual key budgets. Edit it in the{" "}
+                          <strong>Limits</strong> tab.
+                        </span>
+                      </div>
                       {isLoadingTeamAIKeys ? (
                         <div className="flex justify-center items-center py-8">
                           <Loader2 className="h-8 w-8 animate-spin" />
@@ -640,25 +635,16 @@ export function TeamExpansionRow({
                                       )}
                                     </TableCell>
                                     <TableCell>
-                                      {(() => {
-                                        const teamBudgetLimit = teamLimits.find(
-                                          (l) =>
-                                            l.resource === "max_budget" &&
-                                            l.limit_type === "data_plane",
-                                        );
-                                        return teamBudgetLimit ? (
-                                          <span>
-                                            $
-                                            {teamBudgetLimit.max_value.toFixed(
-                                              2,
-                                            )}
-                                          </span>
-                                        ) : (
-                                          <span className="text-muted-foreground">
-                                            No limit
-                                          </span>
-                                        );
-                                      })()}
+                                      {teamBudgetLimit ? (
+                                        <span>
+                                          $
+                                          {teamBudgetLimit.max_value.toFixed(2)}
+                                        </span>
+                                      ) : (
+                                        <span className="text-muted-foreground">
+                                          No limit
+                                        </span>
+                                      )}
                                     </TableCell>
                                   </TableRow>
                                 );

--- a/frontend/src/app/private-ai-keys/page.tsx
+++ b/frontend/src/app/private-ai-keys/page.tsx
@@ -52,39 +52,6 @@ export default function DashboardPage() {
     new Set(),
   );
 
-  // Update budget period mutation
-  const updateBudgetMutation = useMutation({
-    mutationFn: async ({
-      keyId,
-      budgetDuration,
-    }: {
-      keyId: number;
-      budgetDuration: string;
-    }) => {
-      const response = await post(`/private-ai-keys/${keyId}/budget-period`, {
-        budget_duration: budgetDuration,
-      });
-      return response.json();
-    },
-    onSuccess: (_, { keyId }) => {
-      // Invalidate the specific key's spend query to refresh the data
-      queryClient.invalidateQueries({
-        queryKey: ["private-ai-key-spend", keyId],
-      });
-      toast({
-        title: "Success",
-        description: "Budget period updated successfully",
-      });
-    },
-    onError: () => {
-      toast({
-        title: "Error",
-        description: "Failed to update budget period",
-        variant: "destructive",
-      });
-    },
-  });
-
   // Delete key mutation
   const deleteKeyMutation = useMutation({
     mutationFn: async (keyId: number) => {
@@ -209,11 +176,7 @@ export default function DashboardPage() {
         isLoading={createKeyMutation.isPending}
         showOwner={true}
         allowModification={mutatingRoles.includes(getUserRole(user))}
-        onUpdateBudget={(keyId, budgetDuration) =>
-          updateBudgetMutation.mutate({ keyId, budgetDuration })
-        }
         isDeleting={deleteKeyMutation.isPending}
-        isUpdatingBudget={updateBudgetMutation.isPending}
         teamDetails={teamDetails}
         teamMembers={teamMembers}
       />

--- a/frontend/src/app/team-admin/private-ai-keys/page.tsx
+++ b/frontend/src/app/team-admin/private-ai-keys/page.tsx
@@ -8,7 +8,7 @@ import { usePrivateAIKeysData } from "@/hooks/use-private-ai-keys-data";
 import { useToast } from "@/hooks/use-toast";
 import { PrivateAIKey } from "@/types/private-ai-key";
 import { User } from "@/types/user";
-import { get, post, del, put } from "@/utils/api";
+import { get, post, del } from "@/utils/api";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 export default function TeamAIKeysPage() {
@@ -94,37 +94,6 @@ export default function TeamAIKeysPage() {
     },
   });
 
-  const updateBudgetPeriodMutation = useMutation({
-    mutationFn: async ({
-      keyId,
-      budgetDuration,
-    }: {
-      keyId: number;
-      budgetDuration: string;
-    }) => {
-      const response = await put(`private-ai-keys/${keyId}/budget-period`, {
-        budget_duration: budgetDuration,
-      });
-      return response.json();
-    },
-    onSuccess: (data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: ["private-ai-key-spend", variables.keyId],
-      });
-      toast({
-        title: "Success",
-        description: "Budget period updated successfully",
-      });
-    },
-    onError: (error: Error) => {
-      toast({
-        title: "Error",
-        description: error.message,
-        variant: "destructive",
-      });
-    },
-  });
-
   const handleCreateKey = (data: {
     name: string;
     region_id: number;
@@ -164,10 +133,6 @@ export default function TeamAIKeysPage() {
         isDeleting={deleteKeyMutation.isPending}
         allowModification={true}
         showOwner={true}
-        onUpdateBudget={(keyId, budgetDuration) => {
-          updateBudgetPeriodMutation.mutate({ keyId, budgetDuration });
-        }}
-        isUpdatingBudget={updateBudgetPeriodMutation.isPending}
         teamDetails={teamDetails}
         teamMembers={teamMembers}
       />

--- a/frontend/src/components/private-ai-key-spend-cell.tsx
+++ b/frontend/src/components/private-ai-key-spend-cell.tsx
@@ -9,7 +9,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { formatTimeUntil } from "@/lib/utils";
 import { get } from "@/utils/api";
 import { useQuery } from "@tanstack/react-query";
 
@@ -106,46 +105,34 @@ export function PrivateAIKeySpendCell({
   }
 
   return (
-    <div className="flex flex-col gap-1">
-      <div className="flex items-center gap-2">
-        <span className="text-sm font-medium">
-          ${spendData.spend.toFixed(2)}
-        </span>
-        <span className="text-xs text-muted-foreground">
-          {spendData.max_budget !== null
-            ? `/ $${spendData.max_budget.toFixed(2)}`
-            : "(No budget)"}
-        </span>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-4 w-4"
-          onClick={handleRefreshSpend}
-          disabled={isRefreshing}
-        >
-          {isRefreshing ? (
-            <Loader2 className="h-3 w-3 animate-spin" />
-          ) : (
-            <RefreshCw className="h-3 w-3" />
-          )}
-        </Button>
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Info className="h-3 w-3 text-muted-foreground" />
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>Budget is managed at the team level.</p>
-              <p>To change it, edit the team&apos;s limits.</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      </div>
-      <span className="text-xs text-muted-foreground">
-        {spendData.budget_duration || "No budget period"}
-        {spendData.budget_reset_at &&
-          ` • Resets ${formatTimeUntil(spendData.budget_reset_at)}`}
+    <div className="flex items-center gap-2">
+      <span className="text-sm font-medium">
+        ${spendData.spend.toFixed(2)}
       </span>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-4 w-4"
+        onClick={handleRefreshSpend}
+        disabled={isRefreshing}
+      >
+        {isRefreshing ? (
+          <Loader2 className="h-3 w-3 animate-spin" />
+        ) : (
+          <RefreshCw className="h-3 w-3" />
+        )}
+      </Button>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Info className="h-3 w-3 text-muted-foreground" />
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Budget is managed at the team level.</p>
+            <p>To change it, edit the team&apos;s limits.</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     </div>
   );
 }

--- a/frontend/src/components/private-ai-key-spend-cell.tsx
+++ b/frontend/src/components/private-ai-key-spend-cell.tsx
@@ -1,19 +1,14 @@
 "use client";
 
-import { Loader2, RefreshCw, Pencil } from "lucide-react";
+import { Loader2, RefreshCw, Info } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { formatTimeUntil } from "@/lib/utils";
 import { get } from "@/utils/api";
 import { useQuery } from "@tanstack/react-query";
@@ -31,21 +26,14 @@ interface SpendInfo {
 interface PrivateAIKeySpendCellProps {
   keyId: number;
   hasLiteLLMToken: boolean;
-  allowModification?: boolean;
-  onUpdateBudget?: (keyId: number, budgetDuration: string) => void;
-  isUpdatingBudget?: boolean;
 }
 
 export function PrivateAIKeySpendCell({
   keyId,
   hasLiteLLMToken,
-  allowModification = false,
-  onUpdateBudget,
-  isUpdatingBudget = false,
 }: PrivateAIKeySpendCellProps) {
   const [isLoaded, setIsLoaded] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const [openBudgetDialog, setOpenBudgetDialog] = useState(false);
 
   // Query for spend data - only enabled when isLoaded is true
   const {
@@ -141,62 +129,22 @@ export function PrivateAIKeySpendCell({
             <RefreshCw className="h-3 w-3" />
           )}
         </Button>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className="h-3 w-3 text-muted-foreground" />
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Budget is managed at the team level.</p>
+              <p>To change it, edit the team&apos;s limits.</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       </div>
       <span className="text-xs text-muted-foreground">
         {spendData.budget_duration || "No budget period"}
         {spendData.budget_reset_at &&
           ` • Resets ${formatTimeUntil(spendData.budget_reset_at)}`}
-        {allowModification && onUpdateBudget && (
-          <Dialog open={openBudgetDialog} onOpenChange={setOpenBudgetDialog}>
-            <DialogTrigger asChild>
-              <Button variant="ghost" size="icon" className="h-4 w-4 ml-1">
-                <Pencil className="h-3 w-3" />
-              </Button>
-            </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Update Budget Period</DialogTitle>
-                <DialogDescription>
-                  Set the budget period for this key. Examples: &quot;30d&quot;
-                  (30 days), &quot;24h&quot; (24 hours), &quot;60m&quot; (60
-                  minutes)
-                </DialogDescription>
-              </DialogHeader>
-              <div className="grid gap-4 py-4">
-                <div className="grid gap-2">
-                  <Label htmlFor="budget-duration">Budget Period</Label>
-                  <Input
-                    id="budget-duration"
-                    defaultValue={spendData.budget_duration || ""}
-                    placeholder="e.g. 30d"
-                  />
-                </div>
-              </div>
-              <DialogFooter>
-                <Button
-                  onClick={() => {
-                    const input = document.getElementById(
-                      "budget-duration",
-                    ) as HTMLInputElement;
-                    if (input) {
-                      onUpdateBudget(keyId, input.value);
-                    }
-                  }}
-                  disabled={isUpdatingBudget}
-                >
-                  {isUpdatingBudget ? (
-                    <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Updating...
-                    </>
-                  ) : (
-                    "Update"
-                  )}
-                </Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
-        )}
       </span>
     </div>
   );

--- a/frontend/src/components/private-ai-keys-table.tsx
+++ b/frontend/src/components/private-ai-keys-table.tsx
@@ -29,9 +29,7 @@ interface PrivateAIKeysTableProps {
   isLoading?: boolean;
   showOwner?: boolean;
   allowModification?: boolean;
-  onUpdateBudget?: (keyId: number, budgetDuration: string) => void;
   isDeleting?: boolean;
-  isUpdatingBudget?: boolean;
   teamDetails?: Record<number, { name: string }>;
   teamMembers?: User[];
 }
@@ -42,9 +40,7 @@ export function PrivateAIKeysTable({
   isLoading = false,
   showOwner = false,
   allowModification = false,
-  onUpdateBudget,
   isDeleting = false,
-  isUpdatingBudget = false,
   teamDetails = {},
   teamMembers = [],
 }: PrivateAIKeysTableProps) {
@@ -446,9 +442,6 @@ export function PrivateAIKeysTable({
                   <PrivateAIKeySpendCell
                     keyId={key.id}
                     hasLiteLLMToken={!!key.litellm_token}
-                    allowModification={allowModification}
-                    onUpdateBudget={onUpdateBudget}
-                    isUpdatingBudget={isUpdatingBudget}
                   />
                 </TableCell>
                 {allowModification && (


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes key-level budget editing from all three AI-key pages (admin, team-admin, user) and surfaces the team-level budget in the admin teams UI instead, reflecting a policy change where budgets are now enforced at the team level.

- **Budget mutation removed**: `updateBudgetPeriodMutation` (and its `put`/`post` calls) is deleted from all three page components, and the corresponding `onUpdateBudget`/`isUpdatingBudget` props are stripped from `PrivateAIKeysTable` and `PrivateAIKeySpendCell`.
- **Team-budget display added**: `team-expansion-row.tsx` gains an info banner and a renamed \"Budget (Team)\" column that reads from `teamLimits` instead of the per-key spend response.
- **Spend cell updated**: The edit dialog is replaced with a tooltip pointing users to the team's Limits tab.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for most users, but the spend cell continues showing the old key-level budget figure while claiming budget is managed at the team level — these two numbers will diverge for any key that still has a key-level budget set.

The spend cell retains the `spendData.max_budget` display (key-level) directly next to a tooltip that says "Budget is managed at the team level." Any key with a pre-existing key-level budget will show a different dollar figure than the team budget shown in the info banner and Budget (Team) column, leaving users uncertain about which limit is actually enforced. All three pages remove the mutation cleanly and there are no API or data-integrity risks from the deletions themselves.

frontend/src/components/private-ai-key-spend-cell.tsx warrants a second look — the key-level `max_budget` display was not removed alongside the budget-editing feature.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/components/private-ai-key-spend-cell.tsx | Removes budget-editing dialog and props; adds an info tooltip — but the key-level `max_budget` display is retained, contradicting the new "team-managed" messaging. |
| frontend/src/app/admin/teams/_components/team-expansion-row.tsx | Adds team-budget info banner and renames Budget column to "Budget (Team)" with tooltip; `teamBudgetLimit` is redundantly re-derived inside each table row. |
| frontend/src/components/private-ai-keys-table.tsx | Drops `onUpdateBudget`, `isUpdatingBudget` props and stops passing them to `PrivateAIKeySpendCell`; clean removal with no issues. |
| frontend/src/app/admin/private-ai-keys/page.tsx | Removes `updateBudgetPeriodMutation` and related `put` import; straightforward cleanup. |
| frontend/src/app/private-ai-keys/page.tsx | Removes `updateBudgetMutation` and its props; also removes an inconsistent `post` (vs `put` used in admin) call that was already a pre-existing bug. |
| frontend/src/app/team-admin/private-ai-keys/page.tsx | Removes `updateBudgetPeriodMutation` and `put` import; clean deletion with no new issues. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `frontend/src/components/private-ai-key-spend-cell.tsx`, line 114-118 ([link](https://github.com/amazeeio/amazee.ai/blob/2c47f26b415420b989fe56f054b01f92775273a5/frontend/src/components/private-ai-key-spend-cell.tsx#L114-L118)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Stale key-level budget still displayed alongside "team-managed" tooltip**

   The spend cell still renders `spendData.max_budget` (the LiteLLM key-level budget from the `/spend` endpoint) next to the spend figure. The tooltip added in this same PR tells users "Budget is managed at the team level." When a key has a non-null `max_budget` set from before this change, users will see e.g. `$5.00 / $100.00` with a tooltip contradicting the displayed figure. The banner and Budget (Team) column in `team-expansion-row.tsx` may show a completely different value, leaving users uncertain about which limit is actually enforced.


2. `frontend/src/app/admin/teams/_components/team-expansion-row.tsx`, line 598-602 ([link](https://github.com/amazeeio/amazee.ai/blob/2c47f26b415420b989fe56f054b01f92775273a5/frontend/src/app/admin/teams/_components/team-expansion-row.tsx#L598-L602)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`teamBudgetLimit` recomputed inside every row via IIFE**

   The `teamLimits.find(...)` call is wrapped in an IIFE inside the `.map()` loop, so it runs once per key row. Since `teamLimits` and the filter criteria are constant for the whole table, the result should be derived once before the `map` and referenced in each row.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["chore: remove key-level budget editing a..."](https://github.com/amazeeio/amazee.ai/commit/2c47f26b415420b989fe56f054b01f92775273a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32301123)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->