### PR TITLE
fix(budgets): make period_start offset-aware before comparison

### DIFF
--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -242,6 +242,8 @@ async def purchase_pool_budget(
     # are offset-naive while the request payload carries offset-aware ISO strings.
     if period_start is not None and period_start.tzinfo is None:
         period_start = period_start.replace(tzinfo=UTC)
+    if period_end is not None and period_end.tzinfo is None:
+        period_end = period_end.replace(tzinfo=UTC)
 
     # Insert the purchase record and flush BEFORE any external calls so that
     # stripe_payment_id uniqueness is enforced in the DB before side effects.
@@ -252,13 +254,13 @@ async def purchase_pool_budget(
         region_id=region_id,
         amount_cents=purchase.amount_cents,
         currency=purchase.currency,
-        purchased_at=purchase.purchased_at,
+        purchased_at=period_end,
         stripe_payment_id=purchase.stripe_payment_id,
         created_at=datetime.now(UTC),
     )
     db.add(purchase_record)
 
-    team.last_pool_purchase = purchase.purchased_at
+    team.last_pool_purchase = period_end
 
     try:
         db.flush()

--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -237,6 +237,12 @@ async def purchase_pool_budget(
     period_start = latest_purchase_at or team.created_at or purchase.purchased_at
     period_end = purchase.purchased_at
 
+    # Ensure period_start is offset-aware before comparing with period_end.
+    # DB-sourced datetimes (DBPoolPurchase.purchased_at, DBTeam.created_at)
+    # are offset-naive while the request payload carries offset-aware ISO strings.
+    if period_start is not None and period_start.tzinfo is None:
+        period_start = period_start.replace(tzinfo=UTC)
+
     # Insert the purchase record and flush BEFORE any external calls so that
     # stripe_payment_id uniqueness is enforced in the DB before side effects.
     # Concurrent duplicate requests will fail here rather than wasting an

--- a/tests/test_pool_purchases.py
+++ b/tests/test_pool_purchases.py
@@ -142,6 +142,8 @@ def test_create_pool_purchase_duplicate_payment_id(
 def test_create_pool_purchase_naive_purchased_at_does_not_fail_datetime_comparison(
     client, admin_token, db, test_team, test_region
 ):
+    """Regression test: naive purchased_at must not crash the offset-aware
+    period_start sourced from the DB (the bug fixed in #503)."""
     test_team.budget_type = "pool"
     db.add(
         DBPoolPurchase(
@@ -156,16 +158,20 @@ def test_create_pool_purchase_naive_purchased_at_does_not_fail_datetime_comparis
     )
     db.commit()
 
-    response = client.post(
-        f"/budgets/region/{test_region.id}/teams/{test_team.id}/purchase",
-        json={
-            "amount_cents": 2000,
-            "currency": "usd",
-            "purchased_at": "2026-03-13T10:00:00",
-            "stripe_payment_id": f"pi_naive_{int(time.time() * 1000000)}",
-        },
-        headers={"Authorization": f"Bearer {admin_token}"},
-    )
+    with patch(
+        "app.api.budgets.propagate_team_budget_to_keys", new_callable=AsyncMock
+    ) as mock_propagate:
+        mock_propagate.return_value = {"teams_updated": 1, "errors": []}
+        response = client.post(
+            f"/budgets/region/{test_region.id}/teams/{test_team.id}/purchase",
+            json={
+                "amount_cents": 2000,
+                "currency": "usd",
+                "purchased_at": "2026-03-13T10:00:00",
+                "stripe_payment_id": f"pi_naive_{int(time.time() * 1000000)}",
+            },
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
 
     assert response.status_code == 201
 

--- a/tests/test_pool_purchases.py
+++ b/tests/test_pool_purchases.py
@@ -139,6 +139,37 @@ def test_create_pool_purchase_duplicate_payment_id(
     assert "already exists" in response.json()["detail"]
 
 
+def test_create_pool_purchase_naive_purchased_at_does_not_fail_datetime_comparison(
+    client, admin_token, db, test_team, test_region
+):
+    test_team.budget_type = "pool"
+    db.add(
+        DBPoolPurchase(
+            team_id=test_team.id,
+            region_id=test_region.id,
+            amount_cents=1000,
+            currency="usd",
+            purchased_at=datetime(2026, 3, 10, 10, 0, 0, tzinfo=UTC),
+            stripe_payment_id=f"pi_existing_{int(time.time() * 1000000)}",
+            created_at=datetime.now(UTC),
+        )
+    )
+    db.commit()
+
+    response = client.post(
+        f"/budgets/region/{test_region.id}/teams/{test_team.id}/purchase",
+        json={
+            "amount_cents": 2000,
+            "currency": "usd",
+            "purchased_at": "2026-03-13T10:00:00",
+            "stripe_payment_id": f"pi_naive_{int(time.time() * 1000000)}",
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+
+    assert response.status_code == 201
+
+
 def test_create_pool_purchase_non_pool_team_rejected(
     client, admin_token, db, test_team, test_region
 ):


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a `TypeError` that occurs when comparing `period_start` (sourced from the DB as an offset-naive `datetime`) with `period_end` (`purchase.purchased_at` from the request payload, which carries timezone info). The fix normalizes `period_start` to UTC-aware before the comparison on line 274.

- Adds a guard that replaces `tzinfo=None` on `period_start` with `UTC` when the value comes from a DB-sourced field (`DBPoolPurchase.purchased_at` or `DBTeam.created_at`).
- `period_end` is not symmetrically normalized; the fix relies on the assumption that the request payload always supplies an offset-aware datetime, which is not enforced at the schema level in `PoolPurchaseRequest`.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change correctly resolves the reported datetime comparison crash for the common case; one edge case remains unguarded.

The core bug fix is sound — DB-sourced naive datetimes are now normalized to UTC before the `period_end > period_start` comparison. The only remaining risk is that `period_end` (`purchase.purchased_at`) is never normalized, so a caller that submits a naive `purchased_at` string would still trigger the same `TypeError` after the patch, and the `PoolPurchaseRequest` schema does not enforce timezone awareness to prevent it.

app/api/budgets.py — the asymmetric normalization around lines 243–244 and 274 warrants a second look.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/budgets.py | Adds UTC normalization for offset-naive `period_start` before comparison with `period_end`; fix is correct for the stated assumption but `period_end` is not symmetrically normalized, leaving a theoretical failure path if a naive datetime is submitted. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[purchase_pool_budget called] --> B[Query latest_purchase_at from DB]
    B --> C["period_start = latest_purchase_at OR team.created_at OR purchase.purchased_at"]
    C --> D["period_end = purchase.purchased_at (from request)"]
    D --> E{period_start.tzinfo is None?}
    E -- Yes --> F["period_start = period_start.replace(tzinfo=UTC)"]
    E -- No --> G[period_start already offset-aware]
    F --> H{period_end.tzinfo is None?}
    G --> H
    H -- "Yes (unenforced)" --> I["⚠️ TypeError: offset-naive vs offset-aware"]
    H -- No --> J["period_end > period_start comparison OK"]
    J --> K[Proceed with spend period capture]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(budgets): make period\_start offset-a..."](https://github.com/amazeeio/amazee.ai/commit/87e48e0477fb390398f306b28ff331fff7ede907) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32564889)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->