### PR TITLE
docs: add changelog to document notable project changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+This changelog uses a custom structure,
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Features
+
+- **Spend Snapshots**: Store spend snapshots for historical tracking (#488)
+- **Dedicated Regions**: Add script to convert dedicated regions to public (#485)
+- **Dedicated Regions Logging**: Add detailed logging for region conversion phases (#491)
+- **Region Access Control**: Implement user-scoped visibility and admin region support (#438)
+- **Pool Team Monitoring**: Add support for pool teams with purchases in monitoring (#464)
+- **Migration Safety**: Add checks for existing tables and indexes in migrations (#495)
+- **Migration Uniqueness**: Enforce unique index creation for null `key_id` entries (#497)
+- **Budget Clear**: Update budget clear functionality for `max_budget` and duration (#477)
+
+### Fixes
+
+- **Budget Timezone**: Make `period_start` offset-aware before comparison (#504)
+- **Budget Duration**: Normalize `period_end` timezone for purchase window checks (#475)
+- **Pool Team Lifecycle**: Align POOL team lifecycle — no trial expiry, no retention deletion (#490)
+- **DB Migrations**: Re-stamp alembic when schema gap detected before migration (#482)
+- **Key Creation Spend Cap**: Fix key creation and spend cap issues (#477)
+- **Spend Cap Deletion**: Pass `team_id` and `user_id` to `_delete_spend_cap` in clear key budget (#471)
+- **Key Deletion**: Add error handling and remove dependent spend caps on key deletion (#462)
+
+### Changed
+
+- **Admin UI**: Remove key-level budget editing and show team-level budget in admin UI (#498)
+
+### Dependencies
+
+- Bump npm dependencies (frontend) (#489, #467)
+
+### Documentation
+
+- Add doc check workflow (#444)
+
+---
+
+### Historical Note
+
+Development of this project began in February 2025. Changes prior to May 6, 2026
+are not individually listed in this changelog. Refer to the git history and
+closed pull requests for details on earlier changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
 
 ### Features
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a `CHANGELOG.md` to document notable project changes, adopting the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format with a Semantic Versioning declaration. The initial entry covers the `[Unreleased]` milestone and a historical note anchoring the project's start to February 2025.

- **Single `[Unreleased]` section** groups Features, Fixes, Changed, Dependencies, and Documentation entries, each referencing the corresponding PR number.
- **PR `#477` appears twice** — once under Features (\"Budget Clear\") and once under Fixes (\"Key Creation Spend Cap\") — which may be an intentional dual-purpose entry or a copy/paste error worth confirming.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change; safe to merge after clarifying the duplicate #477 reference.

The only change is adding a CHANGELOG.md. The sole concern is PR #477 appearing in both Features and Fixes with different descriptions — a minor documentation inconsistency that should be verified before the file is treated as authoritative history.

CHANGELOG.md — specifically the two entries attributed to #477.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | New CHANGELOG.md following Keep a Changelog format; PR #477 is listed twice (under Features and Fixes) with different descriptions, which may be intentional or an attribution error. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CHANGELOG.md created] --> B["[Unreleased] section"]
    B --> C[Features - 8 entries]
    B --> D[Fixes - 7 entries]
    B --> E[Changed - 1 entry]
    B --> F[Dependencies - 1 entry]
    B --> G[Documentation - 1 entry]
    C -->|"#477 Budget Clear"| H{{"⚠️ Duplicate PR #477"}}
    D -->|"#477 Key Creation Spend Cap"| H
    A --> I[Historical Note\nPre-May 6 2026 changes\nnot listed individually]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add changelog to document notable ..."](https://github.com/amazeeio/amazee.ai/commit/16a95af9d50aa43cd3db710e6626f1456f0eb328) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32759426)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->