### PR TITLE
chore: fix force_delete_key script

### DIFF
--- a/scripts/force_delete_key.py
+++ b/scripts/force_delete_key.py
@@ -7,7 +7,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from sqlalchemy.orm import Session, joinedload
 from app.db.database import SessionLocal
-from app.db.models import DBPrivateAIKey, DBUser, DBRegion
+from app.db.models import DBPrivateAIKey, DBUser, DBRegion, DBSpendCap
 
 
 def delete_key(
@@ -61,6 +61,8 @@ def delete_key(
         for key in keys_to_delete:
             region_str = key.region.name if key.region else "None"
             print(f"Deleting key: {key.name} (ID: {key.id}) from region: {region_str}")
+            # Delete associated spend_caps to avoid FK violation
+            db.query(DBSpendCap).filter(DBSpendCap.key_id == key.id).delete()
             db.delete(key)
 
         db.commit()


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a FK violation in the `force_delete_key.py` maintenance script that occurred when a `DBPrivateAIKey` had associated `spend_caps` rows — the `spend_caps.key_id` FK has no `ON DELETE CASCADE`, so deleting a key without first removing its spend caps would raise a constraint error.

- Adds a bulk DELETE of `DBSpendCap` rows filtered by `key_id` immediately before calling `db.delete(key)` in the deletion loop, ensuring FK constraints are satisfied before the parent row is removed.
- Imports `DBSpendCap` from the models module to support the new query.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is a targeted fix to a maintenance script and correctly resolves the FK constraint violation when deleting keys with associated spend caps.

The deletion order (spend_caps first, then key) is correct and the change covers the only unguarded FK reference to ai_tokens.id. The minor omission of synchronize_session=False is inconsistent with the rest of the codebase but unlikely to cause issues in practice for this script.

No files require special attention; the single changed file is a standalone maintenance script.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/force_delete_key.py | Adds manual deletion of DBSpendCap rows (via bulk DELETE) before removing the key, preventing FK violation; minor omission of synchronize_session=False on the bulk delete call. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Script as force_delete_key.py
    participant DB as Database Session
    participant SpendCaps as spend_caps table
    participant Keys as ai_tokens table

    Script->>DB: query DBPrivateAIKey (with filters)
    DB-->>Script: keys_to_delete[]
    Script->>Script: prompt user confirmation
    loop for each key
        Script->>DB: "DELETE FROM spend_caps WHERE key_id = key.id"
        DB->>SpendCaps: bulk DELETE
        SpendCaps-->>DB: rows removed
        Script->>DB: db.delete(key) — marks key for ORM deletion
    end
    Script->>DB: db.commit()
    DB->>Keys: DELETE FROM ai_tokens WHERE id IN (...)
    Keys-->>DB: rows removed (no FK violation)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix force\_delete\_key script"](https://github.com/amazeeio/amazee.ai/commit/e0554a94958710f5c5eca90b686fe3b8af3238b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32762738)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->