### PR TITLE
refactor(migrations): add if_exists parameter to drop operations

### DIFF
--- a/app/migrations/versions/20260512_170000_9d1a2b3c4d5e_add_team_spend_period_tables.py
+++ b/app/migrations/versions/20260512_170000_9d1a2b3c4d5e_add_team_spend_period_tables.py
@@ -178,29 +178,48 @@ def downgrade() -> None:
     op.drop_index(
         op.f("ix_team_spend_period_keys_team_spend_period_id"),
         table_name="team_spend_period_keys",
+        if_exists=True,
     )
     op.drop_index(
-        op.f("ix_team_spend_period_keys_id"), table_name="team_spend_period_keys"
+        op.f("ix_team_spend_period_keys_id"),
+        table_name="team_spend_period_keys",
+        if_exists=True,
     )
-    op.drop_table("team_spend_period_keys")
+    op.drop_table("team_spend_period_keys", if_exists=True)
 
     op.drop_index(
-        op.f("ix_team_spend_periods_stripe_event_id"), table_name="team_spend_periods"
+        op.f("ix_team_spend_periods_stripe_event_id"),
+        table_name="team_spend_periods",
+        if_exists=True,
     )
     op.drop_index(
-        op.f("ix_team_spend_periods_period_end"), table_name="team_spend_periods"
+        op.f("ix_team_spend_periods_period_end"),
+        table_name="team_spend_periods",
+        if_exists=True,
     )
     op.drop_index(
-        op.f("ix_team_spend_periods_period_start"), table_name="team_spend_periods"
+        op.f("ix_team_spend_periods_period_start"),
+        table_name="team_spend_periods",
+        if_exists=True,
     )
     op.drop_index(
-        op.f("ix_team_spend_periods_budget_type"), table_name="team_spend_periods"
+        op.f("ix_team_spend_periods_budget_type"),
+        table_name="team_spend_periods",
+        if_exists=True,
     )
     op.drop_index(
-        op.f("ix_team_spend_periods_region_id"), table_name="team_spend_periods"
+        op.f("ix_team_spend_periods_region_id"),
+        table_name="team_spend_periods",
+        if_exists=True,
     )
     op.drop_index(
-        op.f("ix_team_spend_periods_team_id"), table_name="team_spend_periods"
+        op.f("ix_team_spend_periods_team_id"),
+        table_name="team_spend_periods",
+        if_exists=True,
     )
-    op.drop_index(op.f("ix_team_spend_periods_id"), table_name="team_spend_periods")
-    op.drop_table("team_spend_periods")
+    op.drop_index(
+        op.f("ix_team_spend_periods_id"),
+        table_name="team_spend_periods",
+        if_exists=True,
+    )
+    op.drop_table("team_spend_periods", if_exists=True)


### PR DESCRIPTION
Addresses https://github.com/amazeeio/amazee.ai/pull/509#discussion_r3265173278

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `if_exists=True` to all `op.drop_index()` and `op.drop_table()` calls in the `downgrade()` function of the `add_team_spend_period_tables` migration, making the rollback idempotent and resilient to partially-applied states.

- All `if_exists=True` usages are valid: `op.drop_index(if_exists=...)` has been supported since Alembic 1.11.2/1.12.0, and `op.drop_table(if_exists=...)` since 1.13.3 — the project pins Alembic 1.18.4, so both are fully available.
- The operation order (child table `team_spend_period_keys` before parent `team_spend_periods`) is preserved correctly, and all index/table drops from the original `downgrade()` are still present with no omissions.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a straightforward robustness improvement to the downgrade path with no functional regressions.

The refactor only adds if_exists=True to existing drop operations in downgrade(). All operations are still present in the correct order (child table before parent), nothing was removed, and both op.drop_index(if_exists=...) and op.drop_table(if_exists=...) are fully supported by the pinned Alembic 1.18.4.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/migrations/versions/20260512_170000_9d1a2b3c4d5e_add_team_spend_period_tables.py | Adds if_exists=True to all drop operations in downgrade(); no operations removed or reordered; fully supported by the pinned Alembic 1.18.4. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[downgrade called] --> B[drop_index ix_team_spend_period_keys_team_spend_period_id if_exists=True]
    B --> C[drop_index ix_team_spend_period_keys_id if_exists=True]
    C --> D[drop_table team_spend_period_keys if_exists=True]
    D --> E[drop_index ix_team_spend_periods_stripe_event_id if_exists=True]
    E --> F[drop_index ix_team_spend_periods_period_end if_exists=True]
    F --> G[drop_index ix_team_spend_periods_period_start if_exists=True]
    G --> H[drop_index ix_team_spend_periods_budget_type if_exists=True]
    H --> I[drop_index ix_team_spend_periods_region_id if_exists=True]
    I --> J[drop_index ix_team_spend_periods_team_id if_exists=True]
    J --> K[drop_index ix_team_spend_periods_id if_exists=True]
    K --> L[drop_table team_spend_periods if_exists=True]
    L --> M[Done]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(migrations): add if\_exists para..."](https://github.com/amazeeio/amazee.ai/commit/f613803cd3c0f32c1e35a225448f42213d18fccf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32790330)</sub>

<!-- /greptile_comment -->