### PR TITLE
chore: re-add max_budget info on keys overview

### DIFF
--- a/frontend/src/components/private-ai-key-spend-cell.tsx
+++ b/frontend/src/components/private-ai-key-spend-cell.tsx
@@ -133,8 +133,8 @@ export function PrivateAIKeySpendCell({
             <Info className="h-3 w-3 text-muted-foreground" />
           </TooltipTrigger>
           <TooltipContent>
-            <p>Budget is managed at the team level.</p>
-            <p>To change it, edit the team&apos;s limits.</p>
+            <p>Shown budget is this key&apos;s cap.</p>
+            <p>Team-level budgets may override key caps.</p>
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>

--- a/frontend/src/components/private-ai-key-spend-cell.tsx
+++ b/frontend/src/components/private-ai-key-spend-cell.tsx
@@ -109,6 +109,11 @@ export function PrivateAIKeySpendCell({
       <span className="text-sm font-medium">
         ${spendData.spend.toFixed(2)}
       </span>
+      {spendData.max_budget != null && (
+        <span className="text-sm text-muted-foreground">
+          / ${spendData.max_budget.toFixed(2)}
+        </span>
+      )}
       <Button
         variant="ghost"
         size="icon"


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR re-adds the `max_budget` display in the private AI key spend cell, showing `/ $X.XX` next to the current spend when a budget limit is set.

- Renders the budget cap inline next to the spend amount, guarded by a `!= null` check that correctly handles both `null` and `undefined` values from the API.
- No logic changes to data fetching or refresh behavior; purely a UI addition to restore previously removed information.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal UI addition that restores previously available budget information.

The change adds five lines that conditionally render the max_budget value. The max_budget field is already typed as number | null in the SpendInfo interface, and the != null guard correctly prevents calling toFixed(2) on a null value. Formatting is consistent with the existing spend display. No data-fetching logic, state management, or API contracts are touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/src/components/private-ai-key-spend-cell.tsx | Adds conditional rendering of max_budget value alongside spend; null check is correct for the typed field, and toFixed(2) usage is consistent with the existing spend display. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant SpendCell as PrivateAIKeySpendCell
    participant API as /private-ai-keys/{id}/spend

    User->>SpendCell: Click "Load Spend"
    SpendCell->>API: GET spend data
    API-->>SpendCell: "{ spend, max_budget, ... }"
    SpendCell->>User: Display "$X.XX"
    alt "max_budget != null"
        SpendCell->>User: Also display "/ $Y.YY"
    end
    User->>SpendCell: Click Refresh
    SpendCell->>API: GET spend data (refetch)
    API-->>SpendCell: "{ spend, max_budget, ... }"
    SpendCell->>User: Updated "$X.XX [/ $Y.YY]"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: re-add max\_budget info on keys ov..."](https://github.com/amazeeio/amazee.ai/commit/516d59a446f9108c04c96d4cc5c1576bd8e66271) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32817208)</sub>

<!-- /greptile_comment -->