### PR TITLE
chore: show budget comes from team on key view

### DIFF
--- a/frontend/src/app/admin/teams/_components/team-expansion-row.tsx
+++ b/frontend/src/app/admin/teams/_components/team-expansion-row.tsx
@@ -30,6 +30,7 @@ import {
 import { useTeams } from "@/hooks/use-teams";
 import { PrivateAIKey } from "@/types/private-ai-key";
 import { Product } from "@/types/product";
+import { Region } from "@/types/region";
 import { SpendInfo } from "@/types/spend";
 import { Team } from "@/types/team";
 import { User } from "@/types/user";
@@ -40,6 +41,7 @@ interface TeamExpansionRowProps {
   teamId: string;
   isExpanded: boolean;
   includeDeleted: boolean;
+  regions: Region[];
   onEdit: (team: Team) => void;
   onAddUser: (teamId: string) => void;
   onCreateUser: (teamId: string) => void;
@@ -50,6 +52,7 @@ export function TeamExpansionRow({
   teamId,
   isExpanded,
   includeDeleted,
+  regions,
   onEdit,
   onAddUser,
   onCreateUser,
@@ -132,7 +135,44 @@ export function TeamExpansionRow({
     queryFn: async () => {
       if (teamAIKeys.length === 0) return {};
       const spendData: Record<string, SpendInfo> = {};
+
+      // Group keys by region
+      const regionGroups = new Map<string, number[]>();
+      const noTeamKeys: PrivateAIKey[] = [];
+
       for (const key of teamAIKeys) {
+        if (key.team_id && key.region) {
+          const keyIds = regionGroups.get(key.region) || [];
+          keyIds.push(key.id);
+          regionGroups.set(key.region, keyIds);
+        } else {
+          noTeamKeys.push(key);
+        }
+      }
+
+      // Fetch spend per region+team combo
+      for (const [regionName, keyIds] of regionGroups) {
+        try {
+          const matchedRegion = regions.find((r) => r.name === regionName);
+          if (matchedRegion) {
+            const response = await get(
+              `/spend/${matchedRegion.id}/team/${teamId}`,
+            );
+            const spendInfo = await response.json();
+            for (const keyId of keyIds) {
+              spendData[keyId.toString()] = spendInfo;
+            }
+          }
+        } catch (error) {
+          console.error(
+            `Failed to fetch spend data for team ${teamId} region ${regionName}:`,
+            error,
+          );
+        }
+      }
+
+      // Fallback for keys without team_id
+      for (const key of noTeamKeys) {
         try {
           const response = await get(`/private-ai-keys/${key.id}/spend`);
           spendData[key.id.toString()] = await response.json();
@@ -140,9 +180,10 @@ export function TeamExpansionRow({
           console.error(`Failed to fetch spend data for key ${key.id}:`, error);
         }
       }
+
       return spendData;
     },
-    enabled: isExpanded && teamAIKeys.length > 0,
+    enabled: isExpanded && teamAIKeys.length > 0 && regions.length > 0,
   });
 
   const isTeamExpired = (team: Team): boolean => {

--- a/frontend/src/app/admin/teams/page.tsx
+++ b/frontend/src/app/admin/teams/page.tsx
@@ -22,7 +22,10 @@ import {
 } from "@/components/ui/table";
 import { TableFilters, FilterField } from "@/components/ui/table-filters";
 import { useTeams } from "@/hooks/use-teams";
+import { Region } from "@/types/region";
 import { Team } from "@/types/team";
+import { get } from "@/utils/api";
+import { useQuery } from "@tanstack/react-query";
 import { AddUserToTeamDialog } from "./_components/add-user-to-team-dialog";
 import { CreateTeamDialog } from "./_components/create-team-dialog";
 import { CreateUserInTeamDialog } from "./_components/create-user-in-team-dialog";
@@ -58,6 +61,14 @@ export default function TeamsPage() {
 
   // Use centralized hook
   const { teams, isLoading: isLoadingTeams } = useTeams(includeDeleted);
+
+  const { data: regions = [] } = useQuery<Region[]>({
+    queryKey: ["regions"],
+    queryFn: async () => {
+      const response = await get("/regions");
+      return response.json();
+    },
+  });
 
   // Filtered and sorted teams
   const filteredAndSortedTeams = useMemo(() => {
@@ -373,6 +384,7 @@ export default function TeamsPage() {
                           setSelectedTeamId(id);
                           setIsSubscribingToProduct(true);
                         }}
+                        regions={regions}
                       />
                     </Fragment>
                   ))

--- a/frontend/src/app/admin/users/_components/user-expansion-row.tsx
+++ b/frontend/src/app/admin/users/_components/user-expansion-row.tsx
@@ -12,6 +12,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/hooks/use-toast";
 import { PrivateAIKey } from "@/types/private-ai-key";
+import { Region } from "@/types/region";
 import { SpendInfo } from "@/types/spend";
 import { get, post } from "@/utils/api";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -40,6 +41,16 @@ export function UserExpansionRow({
     enabled: isExpanded,
   });
 
+  // Fetch regions for spend lookup
+  const { data: regions = [] } = useQuery<Region[]>({
+    queryKey: ["regions"],
+    queryFn: async () => {
+      const response = await get("/regions");
+      return response.json();
+    },
+    enabled: isExpanded && userAIKeys.length > 0,
+  });
+
   // Get spend data for each key
   const { data: spendMap = {} } = useQuery<Record<string, SpendInfo>>({
     queryKey: ["user-ai-keys-spend", userId, userAIKeys],
@@ -48,7 +59,52 @@ export function UserExpansionRow({
 
       const spendData: Record<string, SpendInfo> = {};
 
+      // Group keys by team+region combo
+      const teamRegionMap = new Map<
+        string,
+        { regionName: string; teamId: number; keyIds: number[] }
+      >();
+      const noTeamKeys: PrivateAIKey[] = [];
+
       for (const key of userAIKeys) {
+        if (key.team_id && key.region) {
+          const comboKey = `${key.region}:${key.team_id}`;
+          if (!teamRegionMap.has(comboKey)) {
+            teamRegionMap.set(comboKey, {
+              regionName: key.region,
+              teamId: key.team_id,
+              keyIds: [],
+            });
+          }
+          teamRegionMap.get(comboKey)!.keyIds.push(key.id);
+        } else {
+          noTeamKeys.push(key);
+        }
+      }
+
+      // Fetch spend per team+region combo
+      for (const [, { regionName, teamId, keyIds }] of teamRegionMap) {
+        try {
+          const matchedRegion = regions.find((r) => r.name === regionName);
+          if (matchedRegion) {
+            const response = await get(
+              `/spend/${matchedRegion.id}/team/${teamId}`,
+            );
+            const spendInfo = await response.json();
+            for (const keyId of keyIds) {
+              spendData[keyId.toString()] = spendInfo;
+            }
+          }
+        } catch (error) {
+          console.error(
+            `Failed to fetch spend for team ${teamId} region ${regionName}:`,
+            error,
+          );
+        }
+      }
+
+      // Fallback for keys without team_id
+      for (const key of noTeamKeys) {
         try {
           const response = await get(`/private-ai-keys/${key.id}/spend`);
           const spendInfo = await response.json();
@@ -60,7 +116,7 @@ export function UserExpansionRow({
 
       return spendData;
     },
-    enabled: isExpanded && userAIKeys.length > 0,
+    enabled: isExpanded && userAIKeys.length > 0 && regions.length > 0,
   });
 
   // Get user limits when expanded

--- a/frontend/src/components/private-ai-key-spend-cell.tsx
+++ b/frontend/src/components/private-ai-key-spend-cell.tsx
@@ -25,11 +25,15 @@ interface SpendInfo {
 interface PrivateAIKeySpendCellProps {
   keyId: number;
   hasLiteLLMToken: boolean;
+  region?: string;
+  teamId?: number;
 }
 
 export function PrivateAIKeySpendCell({
   keyId,
   hasLiteLLMToken,
+  region,
+  teamId,
 }: PrivateAIKeySpendCellProps) {
   const [isLoaded, setIsLoaded] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -40,8 +44,23 @@ export function PrivateAIKeySpendCell({
     isLoading,
     refetch,
   } = useQuery<SpendInfo>({
-    queryKey: ["private-ai-key-spend", keyId],
+    queryKey: ["private-ai-key-spend", keyId, region, teamId],
     queryFn: async () => {
+      if (teamId && region) {
+        // Look up region_id from regions list
+        const regionsResponse = await get("regions");
+        const regions = await regionsResponse.json();
+        const matchedRegion = regions.find(
+          (r: { name: string }) => r.name === region,
+        );
+        if (matchedRegion) {
+          const response = await get(
+            `spend/${matchedRegion.id}/team/${teamId}`,
+          );
+          return response.json();
+        }
+      }
+      // Fallback for keys without team_id
       const response = await get(`private-ai-keys/${keyId}/spend`);
       return response.json();
     },
@@ -105,39 +124,51 @@ export function PrivateAIKeySpendCell({
   }
 
   return (
-    <div className="flex items-center gap-2">
-      <span className="text-sm font-medium">
-        ${spendData.spend.toFixed(2)}
-      </span>
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-medium">
+          ${spendData.spend.toFixed(2)}
+        </span>
+        {spendData.max_budget != null && (
+          <span className="text-sm text-muted-foreground">
+            / ${spendData.max_budget.toFixed(2)}
+          </span>
+        )}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-4 w-4"
+          onClick={handleRefreshSpend}
+          disabled={isRefreshing}
+          aria-label="Refresh spend"
+        >
+          {isRefreshing ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : (
+            <RefreshCw className="h-3 w-3" />
+          )}
+          <span className="sr-only">Refresh spend</span>
+        </Button>
+        {spendData.max_budget != null && (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger>
+                <Info className="h-3 w-3 text-muted-foreground" />
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>This is a shared team budget.</p>
+                <p>All keys in the team share this budget.</p>
+                <p>To change it, edit the team&apos;s limits.</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
+      </div>
       {spendData.max_budget != null && (
-        <span className="text-sm text-muted-foreground">
-          / ${spendData.max_budget.toFixed(2)}
+        <span className="text-xs text-muted-foreground">
+          Team budget — shared across all keys
         </span>
       )}
-      <Button
-        variant="ghost"
-        size="icon"
-        className="h-4 w-4"
-        onClick={handleRefreshSpend}
-        disabled={isRefreshing}
-      >
-        {isRefreshing ? (
-          <Loader2 className="h-3 w-3 animate-spin" />
-        ) : (
-          <RefreshCw className="h-3 w-3" />
-        )}
-      </Button>
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Info className="h-3 w-3 text-muted-foreground" />
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Shown budget is this key&apos;s cap.</p>
-            <p>Team-level budgets may override key caps.</p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
     </div>
   );
 }

--- a/frontend/src/components/private-ai-keys-table.tsx
+++ b/frontend/src/components/private-ai-keys-table.tsx
@@ -442,6 +442,8 @@ export function PrivateAIKeysTable({
                   <PrivateAIKeySpendCell
                     keyId={key.id}
                     hasLiteLLMToken={!!key.litellm_token}
+                    region={key.region}
+                    teamId={key.team_id}
                   />
                 </TableCell>
                 {allowModification && (

--- a/frontend/src/hooks/use-private-ai-keys-data.ts
+++ b/frontend/src/hooks/use-private-ai-keys-data.ts
@@ -46,17 +46,63 @@ export function usePrivateAIKeysData(
   });
 
   // Query to get spend information for loaded keys
-  // Use a stable query key to avoid Rules of Hooks violations
+  // Fetches per team+region combo for keys with team_id, old endpoint for others
   const loadedSpendKeysArray = Array.from(loadedSpendKeys).sort();
   const { data: spendMap = {} } = useQuery<Record<number, SpendInfo>>({
     queryKey: ["private-ai-keys-spend", loadedSpendKeysArray],
     queryFn: async () => {
-      const spendPromises = loadedSpendKeysArray.map(async (keyId) => {
-        const response = await get(`private-ai-keys/${keyId}/spend`);
-        return [keyId, await response.json()] as [number, SpendInfo];
+      const loadedKeys = keys.filter((k) => loadedSpendKeys.has(k.id));
+
+      // Group keys by team+region combo
+      const teamRegionMap = new Map<
+        string,
+        { regionName: string; teamId: number; keyIds: number[] }
+      >();
+      const noTeamKeys: PrivateAIKey[] = [];
+
+      for (const key of loadedKeys) {
+        if (key.team_id && key.region) {
+          const comboKey = `${key.region}:${key.team_id}`;
+          if (!teamRegionMap.has(comboKey)) {
+            teamRegionMap.set(comboKey, {
+              regionName: key.region,
+              teamId: key.team_id,
+              keyIds: [],
+            });
+          }
+          teamRegionMap.get(comboKey)!.keyIds.push(key.id);
+        } else {
+          noTeamKeys.push(key);
+        }
+      }
+
+      const result: Record<number, SpendInfo> = {};
+
+      // Fetch spend per team+region combo
+      const teamSpendPromises = Array.from(teamRegionMap.values()).map(
+        async ({ regionName, teamId, keyIds }) => {
+          const matchedRegion = regions.find((r) => r.name === regionName);
+          if (matchedRegion) {
+            const response = await get(
+              `spend/${matchedRegion.id}/team/${teamId}`,
+            );
+            const spendInfo: SpendInfo = await response.json();
+            // Assign same team spend to all keys in this combo
+            for (const keyId of keyIds) {
+              result[keyId] = spendInfo;
+            }
+          }
+        },
+      );
+
+      // Fetch spend for keys without team_id using old endpoint
+      const noTeamPromises = noTeamKeys.map(async (key) => {
+        const response = await get(`private-ai-keys/${key.id}/spend`);
+        result[key.id] = await response.json();
       });
-      const spendResults = await Promise.all(spendPromises);
-      return Object.fromEntries(spendResults);
+
+      await Promise.all([...teamSpendPromises, ...noTeamPromises]);
+      return result;
     },
     enabled: loadedSpendKeysArray.length > 0,
   });


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the private AI key spend cell to surface team budget context when a `max_budget` is set. Both the info tooltip and the "Team budget — shared across all keys" label are correctly gated on `max_budget != null`, and the tooltip copy is updated to explain the shared budget and where to change it.

- Restructures the spend row from a single flex row to a flex-col layout, adding a secondary label line beneath the budget figures when a team budget is active.
- Gates the `Info` icon tooltip on `max_budget != null`, removing the previously unconditional render; updates tooltip text to direct users to edit team limits.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a small, self-contained UI adjustment with correct conditional rendering throughout.

The change correctly gates all new UI elements (info tooltip, team budget label, budget cap display) on max_budget != null, matching the existing guard pattern in the component. No data-fetching or business logic is modified, and the layout refactor is straightforward.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/src/components/private-ai-key-spend-cell.tsx | Restructures spend cell layout to flex-col, gates the info tooltip and team budget label on max_budget != null, and updates tooltip copy to explain the shared team budget and how to change it. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PrivateAIKeySpendCell renders] --> B{hasLiteLLMToken?}
    B -- No --> C[return null]
    B -- Yes --> D{isLoaded?}
    D -- No --> E[Show 'Load Spend' button]
    E --> F[User clicks → setIsLoaded true]
    F --> G[useQuery fetches spend data]
    D -- Yes --> G
    G --> H{isLoading?}
    H -- Yes --> I[Show spinner]
    H -- No --> J{spendData?}
    J -- No --> K[Show error message]
    J -- Yes --> L[Render spend amount]
    L --> M{max_budget != null?}
    M -- Yes --> N[Show '/ $max_budget' + Info tooltip + Team label]
    M -- No --> O[Show spend only + refresh button]
    N --> P[Info tooltip: shared team budget message]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Update frontend/src/components/private-a..."](https://github.com/amazeeio/amazee.ai/commit/35ddaada6aca1e9e9a94e9f07a16a5c40d961edd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32886932)</sub>

<!-- /greptile_comment -->