### PR TITLE
chore: batch slack message if over 10k limit

### DIFF
--- a/.github/workflows/weekly-missing-models-check.yaml
+++ b/.github/workflows/weekly-missing-models-check.yaml
@@ -101,7 +101,7 @@ jobs:
           slack_post() {
             local payload="$1"
             local response
-            response=$(curl -s -X POST https://slack.com/api/chat.postMessage \
+            response=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
               -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
               -H "Content-Type: application/json" \
               -d "$payload")

--- a/.github/workflows/weekly-missing-models-check.yaml
+++ b/.github/workflows/weekly-missing-models-check.yaml
@@ -90,39 +90,82 @@ jobs:
 
       - name: Notify Slack about new missing models
         if: steps.gate.outputs.skip != 'true' && steps.compare.outputs.has_new_missing == 'true'
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            {
-              "channel": "${{ vars.SLACK_CHANNEL_ID }}",
-              "text": ":robot_face: New ${{ matrix.provider }} models are available upstream but not yet deployed to amazee.ai.",
-              "blocks": [
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ vars.SLACK_CHANNEL_ID }}
+          PROVIDER: ${{ matrix.provider }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+        run: |
+          # Helper: post to Slack and assert ok==true
+          slack_post() {
+            local payload="$1"
+            local response
+            response=$(curl -s -X POST https://slack.com/api/chat.postMessage \
+              -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "$payload")
+            if ! echo "$response" | jq -e '.ok' > /dev/null 2>&1; then
+              echo "::error::Slack API error: $response"
+              return 1
+            fi
+            echo "$response"
+          }
+
+          # Send a header message
+          header_payload=$(jq -n \
+            --arg channel "$SLACK_CHANNEL_ID" \
+            --arg provider "$PROVIDER" \
+            --arg workflow_url "$WORKFLOW_URL" \
+            --arg workflow_name "$WORKFLOW_NAME" \
+            '{
+              channel: $channel,
+              text: ":robot_face: New \($provider) models are available upstream but not yet deployed to amazee.ai.",
+              blocks: [
                 {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":robot_face: *New `${{ matrix.provider }}` models detected*\nThe following models exist upstream but are not yet deployed to one of the amazee.ai LiteLLM regions."
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: ":robot_face: *New `\($provider)` models detected*\nThe following models exist upstream but are not yet deployed to one of the amazee.ai LiteLLM regions."
                   }
                 },
                 {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ${{ steps.compare.outputs.summary_json }}
-                  }
-                },
-                {
-                  "type": "section",
-                  "fields": [
+                  type: "section",
+                  fields: [
                     {
-                      "type": "mrkdwn",
-                      "text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"
+                      type: "mrkdwn",
+                      text: "*Workflow:*\n<\($workflow_url)|\($workflow_name)>"
                     }
                   ]
                 }
               ]
-            }
+            }')
+          header_response=$(slack_post "$header_payload")
+          thread_ts=$(echo "$header_response" | jq -r '.ts')
+
+          # Send each summary chunk as a threaded reply
+          chunk_count=$(jq 'length' slack-summary-chunks.json)
+          for i in $(seq 0 $(( chunk_count - 1 ))); do
+            chunk=$(jq -r ".[$i]" slack-summary-chunks.json)
+            payload=$(jq -n \
+              --arg channel "$SLACK_CHANNEL_ID" \
+              --arg text "$chunk" \
+              --arg thread_ts "$thread_ts" \
+              '{
+                channel: $channel,
+                thread_ts: $thread_ts,
+                text: $text,
+                blocks: [
+                  {
+                    type: "section",
+                    text: {
+                      type: "mrkdwn",
+                      text: $text
+                    }
+                  }
+                ]
+              }')
+            slack_post "$payload" > /dev/null
+          done
 
 

--- a/.github/workflows/weekly-missing-models-check.yaml
+++ b/.github/workflows/weekly-missing-models-check.yaml
@@ -106,7 +106,7 @@ jobs:
               -H "Content-Type: application/json" \
               -d "$payload")
             if ! echo "$response" | jq -e '.ok' > /dev/null 2>&1; then
-              echo "::error::Slack API error: $response"
+              echo "::error::Slack API error: $response" >&2
               return 1
             fi
             echo "$response"

--- a/.github/workflows/weekly-missing-models-check.yaml
+++ b/.github/workflows/weekly-missing-models-check.yaml
@@ -140,7 +140,7 @@ jobs:
                 }
               ]
             }')
-          header_response=$(slack_post "$header_payload")
+          header_response=$(slack_post "$header_payload") || exit 1
           thread_ts=$(echo "$header_response" | jq -r '.ts')
 
           # Send each summary chunk as a threaded reply

--- a/scripts/check_missing_models.py
+++ b/scripts/check_missing_models.py
@@ -29,6 +29,9 @@ from urllib.error import HTTPError, URLError
 DEFAULT_API_URL = "https://api.amazee.ai"
 DEFAULT_PROVIDER = "aws"
 SCRIPTS_DIR = Path(__file__).resolve().parent
+# Slack Block Kit section.text.text supports up to 3000 characters.
+# Keep some headroom so chunked summaries remain safely within the field limit.
+SLACK_MAX_TEXT_LENGTH = 2900
 
 
 def _default_state_file(provider: str) -> Path:
@@ -153,20 +156,84 @@ def build_diff(
     }
 
 
+def _chunk_summary(summary: str, max_length: int = SLACK_MAX_TEXT_LENGTH) -> list[str]:
+    """Split the Slack summary into chunks that each fit within Slack's text block limit.
+
+    Splits on section boundaries (double newlines) to keep region-group sections intact.
+    """
+    if not summary:
+        return []
+    if len(summary) <= max_length:
+        return [summary]
+
+    sections = summary.split("\n\n")
+    chunks: list[str] = []
+    current_parts: list[str] = []
+    current_len = 0
+
+    for section in sections:
+        # Guard: if a single section exceeds max_length, split by lines.
+        if len(section) > max_length:
+            if current_parts:
+                chunks.append("\n\n".join(current_parts))
+                current_parts = []
+                current_len = 0
+            lines = section.split("\n")
+            line_buf: list[str] = []
+            buf_len = 0
+            for line in lines:
+                line_addition = len(line) + (1 if line_buf else 0)
+                if line_buf and buf_len + line_addition > max_length:
+                    chunks.append("\n".join(line_buf))
+                    line_buf = [line]
+                    buf_len = len(line)
+                else:
+                    line_buf.append(line)
+                    buf_len += line_addition
+            if line_buf:
+                chunks.append("\n".join(line_buf))
+            continue
+        addition = len(section) + (2 if current_parts else 0)  # +2 for "\n\n" join
+        if current_parts and current_len + addition > max_length:
+            chunks.append("\n\n".join(current_parts))
+            current_parts = [section]
+            current_len = len(section)
+        else:
+            current_parts.append(section)
+            current_len += addition
+
+    if current_parts:
+        chunks.append("\n\n".join(current_parts))
+
+    return chunks
+
+
 def write_github_outputs(diff: dict[str, Any]) -> None:
-    """Emit ``$GITHUB_OUTPUT`` lines so the surrounding workflow can branch."""
+    """Emit ``$GITHUB_OUTPUT`` lines so the surrounding workflow can branch.
+
+    Also writes chunked summaries to a JSON file for the workflow to iterate over
+    when sending multiple Slack messages.
+    """
     output_path = os.environ.get("GITHUB_OUTPUT")
     if not output_path:
         return
-    summary = diff["slack_summary"] or "No new missing models detected."
+    chunks = _chunk_summary(diff["slack_summary"])
+    if not chunks:
+        chunks = ["No new missing models detected."]
+
+    # Write chunks to a file the workflow can read with jq.
+    chunks_file = Path("slack-summary-chunks.json")
+    chunks_file.write_text(json.dumps(chunks, indent=2) + "\n", encoding="utf-8")
+
     with open(output_path, "a", encoding="utf-8") as handle:
         handle.write(
             f"has_new_missing={'true' if diff['has_new_missing'] else 'false'}\n"
         )
         handle.write(f"state_changed={'true' if diff['state_changed'] else 'false'}\n")
         handle.write(f"provider={diff.get('provider', '')}\n")
-        # JSON-encoded so newlines/quotes are safe to interpolate into a Slack payload.
-        handle.write(f"summary_json={json.dumps(summary)}\n")
+        handle.write(f"summary_chunk_count={len(chunks)}\n")
+        # Keep summary_json as the first chunk for backward compat.
+        handle.write(f"summary_json={json.dumps(chunks[0])}\n")
 
 
 def main() -> int:

--- a/scripts/check_missing_models.py
+++ b/scripts/check_missing_models.py
@@ -182,6 +182,13 @@ def _chunk_summary(summary: str, max_length: int = SLACK_MAX_TEXT_LENGTH) -> lis
             line_buf: list[str] = []
             buf_len = 0
             for line in lines:
+                while len(line) > max_length:
+                    if line_buf:
+                        chunks.append("\n".join(line_buf))
+                        line_buf = []
+                        buf_len = 0
+                    chunks.append(line[:max_length])
+                    line = line[max_length:]
                 line_addition = len(line) + (1 if line_buf else 0)
                 if line_buf and buf_len + line_addition > max_length:
                     chunks.append("\n".join(line_buf))


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refactors the weekly missing-models Slack notification to handle long summaries by splitting them into ≤2900-character chunks (within Slack's Block Kit `section.text` 3000-char limit) and delivers them as threaded replies to a header message.

- `_chunk_summary` in `check_missing_models.py` splits the summary on `\n\n` boundaries (with a line-level fallback for oversized sections) and writes the chunks to `slack-summary-chunks.json` for the workflow to consume.
- The workflow step is rewritten from the `slackapi/slack-github-action` action to a shell script that posts a header message, captures its `ts`, and iterates over each chunk as a threaded reply — with proper `jq`-based `.ok` assertion and `curl -sS` for Slack error visibility.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the common case; the chunking logic and threading are correct, but a chunk delivery failure in the loop will not cause the workflow step to exit non-zero.

The core chunking, threading, and header-abort logic are all correctly implemented. The one gap is that `slack_post "$payload" > /dev/null` on line 168 discards the function's return code — if Slack rejects a chunk (malformed block, rate-limit, etc.), the error annotation appears on stderr but the loop continues and the step exits zero, leaving a partial delivery silently marked as passing.

.github/workflows/weekly-missing-models-check.yaml — specifically the chunk delivery loop where `slack_post` return codes are not checked.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/check_missing_models.py | Adds `_chunk_summary` to split the Slack summary at 2900-char boundaries (section-first, line-level fallback), and updates `write_github_outputs` to write the chunks to `slack-summary-chunks.json`; a single line exceeding 2900 chars would still produce an oversized chunk but is extremely unlikely with model-name data. |
| .github/workflows/weekly-missing-models-check.yaml | Replaces the `slackapi/slack-github-action` step with a shell script that posts a header, captures `thread_ts`, and delivers each chunk as a threaded reply; header failures abort via `|| exit 1`, and Slack `.ok` assertions surface API errors to stderr — but chunk delivery failures (return 1 from `slack_post`) are not propagated to the step exit code. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant PY as check_missing_models.py
    participant FS as slack-summary-chunks.json
    participant WF as GitHub Actions Workflow
    participant SLACK as Slack API

    PY->>PY: build_diff() → slack_summary
    PY->>PY: "_chunk_summary(slack_summary, max=2900)"
    PY->>FS: write chunks JSON array
    PY->>WF: GITHUB_OUTPUT: has_new_missing, summary_chunk_count

    WF->>WF: jq -n → header_payload
    WF->>SLACK: POST chat.postMessage (header)
    SLACK-->>WF: "{ok: true, ts: "..."}"
    WF->>WF: "thread_ts = response.ts"

    loop for each chunk i in slack-summary-chunks.json
        WF->>WF: jq -r ".[i]" → chunk text
        WF->>WF: jq -n → payload with thread_ts
        WF->>SLACK: POST chat.postMessage (threaded reply)
        SLACK-->>WF: "{ok: true}"
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Update .github/workflows/weekly-missing-..."](https://github.com/amazeeio/amazee.ai/commit/3241687e223374790f650f06ef559318a485e44f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32985354)</sub>

<!-- /greptile_comment -->