### PR TITLE
AI-408 hard delete soft deleted teams

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: backend-test backend-test-build test-clean test-network test-postgres frontend-test frontend-test-build migration-create migration-upgrade migration-downgrade migration-stamp
+.PHONY: backend-test backend-test-build test-clean test-teardown test-network test-postgres frontend-test frontend-test-build migration-create migration-upgrade migration-downgrade migration-stamp
 
 # Default target
 all: backend-test
@@ -12,20 +12,26 @@ backend-test-build:
 	docker build -t amazee-backend-test -f Dockerfile.test .
 
 # Start PostgreSQL container for testing
-test-postgres: test-clean test-network
+test-postgres: test-network
 	docker run -d \
 		--name amazee-test-postgres \
 		--network amazeeai_default \
 		-e POSTGRES_USER=postgres \
 		-e POSTGRES_PASSWORD=postgres \
 		-e POSTGRES_DB=postgres_service \
-		-p 5432:5432 \
 		pgvector/pgvector:pg16 && \
 	sleep 5
 
+# Teardown: stop and remove test containers, network, and image
+test-teardown:
+	docker stop amazee-test-postgres 2>/dev/null || true
+	docker rm amazee-test-postgres 2>/dev/null || true
+	docker network rm amazeeai_default 2>/dev/null || true
+	docker rmi amazee-backend-test 2>/dev/null || true
+
 # Run backend tests for a specific regex
 # Usage: make backend-test-regex regex="test_pattern"
-backend-test-regex: test-clean backend-test-build test-postgres
+backend-test-regex: backend-test-build test-postgres
 	@if [ -z "$(regex)" ]; then \
 		echo "Error: regex parameter is required. Usage: make backend-test-regex regex=\"test_pattern\""; \
 		exit 1; \
@@ -45,9 +51,10 @@ backend-test-regex: test-clean backend-test-build test-postgres
 		-v $(PWD)/app:/app/app \
 		-v $(PWD)/tests:/app/tests \
 		amazee-backend-test pytest -vv -k "$(regex)"
+	$(MAKE) test-teardown
 
 # Run backend tests in a new container
-backend-test: test-clean backend-test-build test-postgres
+backend-test: backend-test-build test-postgres
 	docker run --rm \
 		--network amazeeai_default \
 		-e DATABASE_URL="postgresql://postgres:postgres@amazee-test-postgres/postgres_service" \
@@ -63,9 +70,10 @@ backend-test: test-clean backend-test-build test-postgres
 		-v $(PWD)/app:/app/app \
 		-v $(PWD)/tests:/app/tests \
 		amazee-backend-test
+	$(MAKE) test-teardown
 
 # Run backend tests with coverage report
-backend-test-cov: test-clean backend-test-build test-postgres
+backend-test-cov: backend-test-build test-postgres
 	docker run --rm \
 		--network amazeeai_default \
 		-e DATABASE_URL="postgresql://postgres:postgres@amazee-test-postgres/postgres_service" \
@@ -81,6 +89,7 @@ backend-test-cov: test-clean backend-test-build test-postgres
 		-v $(PWD)/app:/app/app \
 		-v $(PWD)/tests:/app/tests \
 		amazee-backend-test pytest -v --cov=app tests/
+	$(MAKE) test-teardown
 
 # Build the frontend test container
 frontend-test-build:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ backend-test-build:
 	docker build -t amazee-backend-test -f Dockerfile.test .
 
 # Start PostgreSQL container for testing
-test-postgres: test-clean test-network
+test-postgres: test-network
 	docker run -d \
 		--name amazee-test-postgres \
 		--network amazeeai_default \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: backend-test backend-test-build test-clean test-teardown test-network test-postgres frontend-test frontend-test-build migration-create migration-upgrade migration-downgrade migration-stamp
+.PHONY: backend-test backend-test-build test-clean test-network test-postgres frontend-test frontend-test-build migration-create migration-upgrade migration-downgrade migration-stamp
 
 # Default target
 all: backend-test
@@ -12,7 +12,7 @@ backend-test-build:
 	docker build -t amazee-backend-test -f Dockerfile.test .
 
 # Start PostgreSQL container for testing
-test-postgres: test-network
+test-postgres: test-clean test-network
 	docker run -d \
 		--name amazee-test-postgres \
 		--network amazeeai_default \
@@ -21,13 +21,6 @@ test-postgres: test-network
 		-e POSTGRES_DB=postgres_service \
 		pgvector/pgvector:pg16 && \
 	sleep 5
-
-# Teardown: stop and remove test containers, network, and image
-test-teardown:
-	docker stop amazee-test-postgres 2>/dev/null || true
-	docker rm amazee-test-postgres 2>/dev/null || true
-	docker network rm amazeeai_default 2>/dev/null || true
-	docker rmi amazee-backend-test 2>/dev/null || true
 
 # Run backend tests for a specific regex
 # Usage: make backend-test-regex regex="test_pattern"
@@ -52,7 +45,7 @@ backend-test-regex: backend-test-build test-postgres
 		-v $(PWD)/app:/app/app \
 		-v $(PWD)/tests:/app/tests \
 		amazee-backend-test pytest -vv -k "$(regex)" || status=$$?; \
-	$(MAKE) test-teardown; \
+	$(MAKE) test-clean; \
 	exit $$status
 
 # Run backend tests in a new container
@@ -73,7 +66,7 @@ backend-test: backend-test-build test-postgres
 		-v $(PWD)/app:/app/app \
 		-v $(PWD)/tests:/app/tests \
 		amazee-backend-test || status=$$?; \
-	$(MAKE) test-teardown; \
+	$(MAKE) test-clean; \
 	exit $$status
 
 # Run backend tests with coverage report
@@ -94,7 +87,7 @@ backend-test-cov: backend-test-build test-postgres
 		-v $(PWD)/app:/app/app \
 		-v $(PWD)/tests:/app/tests \
 		amazee-backend-test pytest -v --cov=app tests/ || status=$$?; \
-	$(MAKE) test-teardown; \
+	$(MAKE) test-clean; \
 	exit $$status
 
 # Build the frontend test container

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ backend-test-regex: backend-test-build test-postgres
 		echo "Error: regex parameter is required. Usage: make backend-test-regex regex=\"test_pattern\""; \
 		exit 1; \
 	fi
+	@status=0; \
 	docker run --rm \
 		--network amazeeai_default \
 		-e DATABASE_URL="postgresql://postgres:postgres@amazee-test-postgres/postgres_service" \
@@ -50,11 +51,13 @@ backend-test-regex: backend-test-build test-postgres
 		-e ENV_SUFFIX="test" \
 		-v $(PWD)/app:/app/app \
 		-v $(PWD)/tests:/app/tests \
-		amazee-backend-test pytest -vv -k "$(regex)"
-	$(MAKE) test-teardown
+		amazee-backend-test pytest -vv -k "$(regex)" || status=$$?; \
+	$(MAKE) test-teardown; \
+	exit $$status
 
 # Run backend tests in a new container
 backend-test: backend-test-build test-postgres
+	@status=0; \
 	docker run --rm \
 		--network amazeeai_default \
 		-e DATABASE_URL="postgresql://postgres:postgres@amazee-test-postgres/postgres_service" \
@@ -69,11 +72,13 @@ backend-test: backend-test-build test-postgres
 		-e ENV_SUFFIX="test" \
 		-v $(PWD)/app:/app/app \
 		-v $(PWD)/tests:/app/tests \
-		amazee-backend-test
-	$(MAKE) test-teardown
+		amazee-backend-test || status=$$?; \
+	$(MAKE) test-teardown; \
+	exit $$status
 
 # Run backend tests with coverage report
 backend-test-cov: backend-test-build test-postgres
+	@status=0; \
 	docker run --rm \
 		--network amazeeai_default \
 		-e DATABASE_URL="postgresql://postgres:postgres@amazee-test-postgres/postgres_service" \
@@ -88,8 +93,9 @@ backend-test-cov: backend-test-build test-postgres
 		-e ENV_SUFFIX="test" \
 		-v $(PWD)/app:/app/app \
 		-v $(PWD)/tests:/app/tests \
-		amazee-backend-test pytest -v --cov=app tests/
-	$(MAKE) test-teardown
+		amazee-backend-test pytest -v --cov=app tests/ || status=$$?; \
+	$(MAKE) test-teardown; \
+	exit $$status
 
 # Build the frontend test container
 frontend-test-build:

--- a/README.md
+++ b/README.md
@@ -188,7 +188,51 @@ Limit controls and precedence:
 Note: Spend enforcement in LiteLLM is evaluated on spend updates, so the blocking request is typically the first request after crossing a cap.
 
 
-## 🗄️ How to Restore from a Database Dump
+## ♻️ Team Lifecycle & Hard Delete
+
+Teams go through a three-stage lifecycle managed by background workers.
+
+### Stages
+
+| Stage | Trigger | What happens |
+|---|---|---|
+| **Active** | Team created | Normal operation |
+| **Soft-deleted** | >76 days inactive (no API activity) + 14-day grace after warning email; or manual `POST /teams/{id}/soft-delete` | `deleted_at` set; all LiteLLM keys expired (`duration=0d`); users deactivated. POOL teams are exempt from automatic soft-delete. |
+| **Hard-deleted** | `deleted_at` is ≥ 90 days ago | All data permanently removed (GDPR requirement) |
+
+### Hard-delete cascade order
+
+When `hard_delete_expired_teams()` runs (daily at 03:00 via cron), it deletes each expired team's data in this order to respect FK constraints:
+
+1. `limited_resources` (team + user rows)
+2. LiteLLM keys (remote call, best-effort)
+3. `spend_caps` (team-, user-, and key-scoped)
+4. `ai_tokens` (private AI keys) from DB
+5. `api_tokens`, `user_admin_regions` (user FK tables — no `ON DELETE CASCADE`)
+6. `audit_logs.user_id` set to `NULL` (rows preserved for audit history)
+7. `user_spend_cache` (email-keyed stale cache)
+8. `users`
+9. `team_products`, `team_regions`
+10. Audit log entry written (`action=team.hard_delete`)
+11. `teams` (cascades `team_metrics` automatically)
+
+### Restore
+
+A soft-deleted team can be restored by a system admin via `POST /teams/{id}/restore`. The restore:
+- Clears `deleted_at` and reactivates all users
+- Re-provisions the LiteLLM team and users in every active region (idempotent)
+- Un-expires all keys in LiteLLM
+
+If LiteLLM re-provisioning fails for any region, the team is still marked restored in the DB and the response includes a `"warning"` field listing the affected regions. Check the `audit_logs` table (`action=team.restore`) for the full `litellm_failed_regions` detail.
+
+### Manual trigger
+
+```bash
+# Trigger the hard-delete job manually on the backend container
+python scripts/trigger_hard_delete_job.py
+```
+
+
 
 If you have a database dump, you can restore it into your local PostgreSQL service following these steps:
 

--- a/app/api/public.py
+++ b/app/api/public.py
@@ -739,7 +739,7 @@ def _normalize_bedrock_provider_id(
 
     normalized = provider_model_id.split("/", 1)[1]
     if normalized.startswith(provider_prefix):
-        normalized = normalized[len(provider_prefix):]
+        normalized = normalized[len(provider_prefix) :]
     return normalized
 
 
@@ -778,9 +778,7 @@ async def _collect_region_bedrock_models(
         if not isinstance(item, dict):
             continue
         params = item.get("litellm_params") or {}
-        provider_model_id = (
-            params.get("model") if isinstance(params, dict) else None
-        )
+        provider_model_id = params.get("model") if isinstance(params, dict) else None
         if not isinstance(provider_model_id, str) or not provider_model_id:
             continue
 
@@ -900,8 +898,7 @@ async def list_missing_provider_models(
         raise HTTPException(
             status_code=404,
             detail=(
-                f"Unknown provider '{provider}'. "
-                f"Supported: {sorted(_KNOWN_PROVIDERS)}"
+                f"Unknown provider '{provider}'. Supported: {sorted(_KNOWN_PROVIDERS)}"
             ),
         )
 

--- a/app/api/teams.py
+++ b/app/api/teams.py
@@ -461,10 +461,16 @@ async def restore_team(team_id: int, db: Session = Depends(get_db)):
         )
 
     # Use centralized restore function
-    await restore_soft_deleted_team(db, db_team)
+    result = await restore_soft_deleted_team(db, db_team)
 
     db.refresh(db_team)
-    return {"message": "Team restored successfully"}
+    response = {"message": "Team restored successfully"}
+    if result.get("litellm_warnings"):
+        response["warning"] = (
+            f"Team restored, but LiteLLM re-provisioning failed in regions: "
+            f"{result['litellm_warnings']}. Keys may not work until retried."
+        )
+    return response
 
 
 @router.post(

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -46,6 +46,7 @@ from app.core.security import (
     get_current_user_from_auth,
     get_role_min_team_admin,
 )
+from app.core.email import normalize_email_for_lookup
 from app.core.roles import UserRole
 from app.services.litellm import LiteLLMService
 from datetime import datetime, UTC
@@ -69,14 +70,6 @@ def get_user_by_email(db: Session, email: str) -> Optional[DBUser]:
 router = APIRouter(tags=["users"])
 
 
-def _normalize_email_for_lookup(email: str) -> str:
-    parts = email.lower().rsplit("@", 1)
-    if len(parts) == 2:
-        local_part = parts[0].split("+")[0]
-        return f"{local_part}@{parts[1]}"
-    return email.lower()
-
-
 def invalidate_user_spend_cache(db: Session, email: str) -> None:
     """Delete the cached /users/spend response for *email*.
 
@@ -87,7 +80,7 @@ def invalidate_user_spend_cache(db: Session, email: str) -> None:
     This helper intentionally does not commit; callers control the transaction
     boundary so cache invalidation remains atomic with the related write.
     """
-    normalized = _normalize_email_for_lookup(email)
+    normalized = normalize_email_for_lookup(email)
     db.query(DBUserSpendCache).filter(
         DBUserSpendCache.normalized_email == normalized
     ).delete(synchronize_session=False)
@@ -105,7 +98,7 @@ def invalidate_users_spend_cache_bulk(db: Session, emails: list[str]) -> None:
     """
     if not emails:
         return
-    normalized_emails = [_normalize_email_for_lookup(e) for e in emails]
+    normalized_emails = [normalize_email_for_lookup(e) for e in emails]
     db.query(DBUserSpendCache).filter(
         DBUserSpendCache.normalized_email.in_(normalized_emails)
     ).delete(synchronize_session=False)
@@ -523,7 +516,7 @@ async def get_user_spend(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Missing or invalid email",
         )
-    normalized_email = _normalize_email_for_lookup(email)
+    normalized_email = normalize_email_for_lookup(email)
 
     cached = _get_user_spend_cache(db, normalized_email)
     if cached:

--- a/app/core/email.py
+++ b/app/core/email.py
@@ -1,0 +1,6 @@
+def normalize_email_for_lookup(email: str) -> str:
+    parts = email.lower().rsplit("@", 1)
+    if len(parts) == 2:
+        local_part = parts[0].split("+")[0]
+        return f"{local_part}@{parts[1]}"
+    return email.lower()

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -96,18 +96,17 @@ async def get_current_user_from_auth(
     if request and hasattr(request.state, "user") and request.state.user is not None:
         # If we have a dict from middleware, load the full user object
         if isinstance(request.state.user, dict):
-            user = (
-                db.query(DBUser)
-                .filter(DBUser.id == request.state.user["id"])
-                .options(joinedload(DBUser.team))
-                .first()
-            )
+            user = _get_user_with_team(db, request.state.user["id"])
             if user:
                 _check_user_team_not_suspended(user)
                 return user
         else:
-            _check_user_team_not_suspended(request.state.user)
-            return request.state.user
+            user_id = getattr(request.state.user, "id", None)
+            if user_id is not None:
+                user = _get_user_with_team(db, user_id)
+                if user:
+                    _check_user_team_not_suspended(user)
+                    return user
 
     if not access_token and not authorization:
         raise HTTPException(
@@ -138,8 +137,8 @@ async def get_current_user_from_auth(
         if db_token:
             # Update last used timestamp
             db_token.last_used_at = datetime.now(UTC)
-            db.commit()
             _check_user_team_not_suspended(db_token.owner)
+            db.commit()
             return db_token.owner
     except HTTPException:
         raise
@@ -181,6 +180,15 @@ def _check_user_team_not_suspended(user: DBUser) -> None:
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Your organization has been suspended. Please contact support.",
         )
+
+
+def _get_user_with_team(db: Session, user_id: int) -> Optional[DBUser]:
+    return (
+        db.query(DBUser)
+        .filter(DBUser.id == user_id)
+        .options(joinedload(DBUser.team))
+        .first()
+    )
 
 
 async def get_role_min_system_admin(

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -8,7 +8,7 @@ import logging
 
 from app.core.config import settings
 from app.db.database import get_db
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import func
 from app.db.models import DBUser, DBAPIToken
 from app.core.rbac import (
@@ -74,7 +74,12 @@ async def get_current_user(
         raise credentials_exception
 
     email: str = payload.get("sub")
-    user = db.query(DBUser).filter(func.lower(DBUser.email) == email.lower()).first()
+    user = (
+        db.query(DBUser)
+        .filter(func.lower(DBUser.email) == email.lower())
+        .options(joinedload(DBUser.team))
+        .first()
+    )
     if user is None:
         raise credentials_exception
     return user
@@ -92,7 +97,10 @@ async def get_current_user_from_auth(
         # If we have a dict from middleware, load the full user object
         if isinstance(request.state.user, dict):
             user = (
-                db.query(DBUser).filter(DBUser.id == request.state.user["id"]).first()
+                db.query(DBUser)
+                .filter(DBUser.id == request.state.user["id"])
+                .options(joinedload(DBUser.team))
+                .first()
             )
             if user:
                 _check_user_team_not_suspended(user)
@@ -121,7 +129,12 @@ async def get_current_user_from_auth(
 
     # First try API token validation since it's simpler
     try:
-        db_token = db.query(DBAPIToken).filter(DBAPIToken.token == token_to_try).first()
+        db_token = (
+            db.query(DBAPIToken)
+            .filter(DBAPIToken.token == token_to_try)
+            .options(joinedload(DBAPIToken.owner).joinedload(DBUser.team))
+            .first()
+        )
         if db_token:
             # Update last used timestamp
             db_token.last_used_at = datetime.now(UTC)

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -9,7 +9,7 @@ import logging
 from app.core.config import settings
 from app.db.database import get_db
 from sqlalchemy.orm import Session, joinedload
-from sqlalchemy import func
+from sqlalchemy import func, inspect as sa_inspect
 from app.db.models import DBUser, DBAPIToken
 from app.core.rbac import (
     require_system_admin,
@@ -101,7 +101,14 @@ async def get_current_user_from_auth(
                 _check_user_team_not_suspended(user)
                 return user
         else:
-            user_id = getattr(request.state.user, "id", None)
+            # The object may be detached from its original session (e.g. loaded
+            # by AuthMiddleware then committed/expired). Use SQLAlchemy inspect
+            # to read the PK from the identity map without touching the DB.
+            try:
+                identity = sa_inspect(request.state.user).identity
+                user_id = identity[0] if identity else None
+            except Exception:
+                user_id = None
             if user_id is not None:
                 user = _get_user_with_team(db, user_id)
                 if user:

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -95,8 +95,10 @@ async def get_current_user_from_auth(
                 db.query(DBUser).filter(DBUser.id == request.state.user["id"]).first()
             )
             if user:
+                _check_user_team_not_suspended(user)
                 return user
         else:
+            _check_user_team_not_suspended(request.state.user)
             return request.state.user
 
     if not access_token and not authorization:
@@ -124,7 +126,10 @@ async def get_current_user_from_auth(
             # Update last used timestamp
             db_token.last_used_at = datetime.now(UTC)
             db.commit()
+            _check_user_team_not_suspended(db_token.owner)
             return db_token.owner
+    except HTTPException:
+        raise
     except Exception:
         pass
 
@@ -135,12 +140,33 @@ async def get_current_user_from_auth(
         )
         user = await get_current_user(credentials=credentials, db=db)
         if user:
+            _check_user_team_not_suspended(user)
             return user
+    except HTTPException:
+        raise
     except Exception:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Could not validate credentials",
             headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+def _check_user_team_not_suspended(user: DBUser) -> None:
+    """Raise 403 if the user's team has been soft-deleted.
+
+    System admins are excluded from this check so they retain access to the
+    admin interface even when their own team is soft-deleted.
+    """
+    if (
+        not user.is_admin
+        and user.team_id is not None
+        and user.team is not None
+        and user.team.deleted_at is not None
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Your organization has been suspended. Please contact support.",
         )
 
 

--- a/app/core/team_service.py
+++ b/app/core/team_service.py
@@ -182,7 +182,7 @@ async def soft_delete_team(
     logger.info(f"Successfully soft-deleted team {team.id} ({team.name})")
 
 
-async def restore_soft_deleted_team(db: Session, team: DBTeam) -> None:
+async def restore_soft_deleted_team(db: Session, team: DBTeam) -> dict:
     """
     Restore a soft-deleted team with full cascade behavior.
 
@@ -197,7 +197,13 @@ async def restore_soft_deleted_team(db: Session, team: DBTeam) -> None:
         db: Database session
         team: The team to restore
 
-    Note: This function commits the database changes.
+    Returns:
+        A dict with ``litellm_warnings`` (list of region names where
+        LiteLLM re-provisioning failed).  An empty list means full success.
+
+    Note: This function commits the database changes regardless of LiteLLM
+    failures so that the team is always marked as restored in the DB.
+    Callers should surface any returned warnings to admins.
     """
     if not team.deleted_at:
         raise ValueError(f"Team {team.id} is not soft-deleted and cannot be restored")
@@ -213,8 +219,11 @@ async def restore_soft_deleted_team(db: Session, team: DBTeam) -> None:
         .all()
     )
 
+    failed_regions: list[str] = []
+
     # Re-provision LiteLLM: ensure team and user objects exist in each region
     for region in allowed_regions:
+        region_failed = False
         try:
             litellm_service = LiteLLMService(
                 api_url=region.litellm_api_url, api_key=region.litellm_api_key
@@ -234,6 +243,7 @@ async def restore_soft_deleted_team(db: Session, team: DBTeam) -> None:
                 logger.error(
                     f"Failed to re-provision LiteLLM team in region {region.name}: {str(team_error)}"
                 )
+                region_failed = True
 
             # Ensure each user exists in LiteLLM and is a member of the team (idempotent)
             for user in team_users:
@@ -254,11 +264,15 @@ async def restore_soft_deleted_team(db: Session, team: DBTeam) -> None:
                     logger.error(
                         f"Failed to re-provision LiteLLM user {user.id} in region {region.name}: {str(user_error)}"
                     )
+                    region_failed = True
         except Exception as region_error:
             logger.error(
                 f"Failed to re-provision LiteLLM team/users in region {region.name}: {str(region_error)}"
             )
-            # Don't block restoration if LiteLLM re-provisioning fails for a region
+            region_failed = True
+
+        if region_failed:
+            failed_regions.append(region.name)
 
     # Un-expire all keys for the team in LiteLLM
     try:
@@ -282,15 +296,18 @@ async def restore_soft_deleted_team(db: Session, team: DBTeam) -> None:
                             logger.error(
                                 f"Failed to un-expire key {key.id} in LiteLLM: {str(key_error)}"
                             )
+                            if region.name not in failed_regions:
+                                failed_regions.append(region.name)
             except Exception as region_error:
                 logger.error(
                     f"Failed to un-expire keys in region {region.name}: {str(region_error)}"
                 )
+                if region.name not in failed_regions:
+                    failed_regions.append(region.name)
     except Exception as restore_error:
         logger.error(
             f"Failed to un-expire keys for team {team.id}: {str(restore_error)}"
         )
-        # Don't block restoration if key un-expiration fails
 
     restored_at = datetime.now(UTC)
 
@@ -308,7 +325,7 @@ async def restore_soft_deleted_team(db: Session, team: DBTeam) -> None:
     )
     logger.info(f"Reactivated {users_reactivated} users for restored team {team.id}")
 
-    # Write audit log entry
+    # Write audit log entry (include any LiteLLM provisioning failures)
     audit_log = DBAuditLog(
         timestamp=restored_at,
         user_id=None,
@@ -316,14 +333,25 @@ async def restore_soft_deleted_team(db: Session, team: DBTeam) -> None:
         resource_type="team",
         resource_id=str(team.id),
         action="team.restore",
-        details={"team_name": team.name},
+        details={
+            "team_name": team.name,
+            "litellm_failed_regions": failed_regions,
+        },
         request_source=None,
     )
     db.add(audit_log)
 
     db.commit()
 
-    logger.info(f"Successfully restored team {team.id} ({team.name})")
+    if failed_regions:
+        logger.warning(
+            f"Team {team.id} restored but LiteLLM re-provisioning failed in regions: {failed_regions}. "
+            f"Keys may not work until re-provisioning is retried."
+        )
+    else:
+        logger.info(f"Successfully restored team {team.id} ({team.name})")
+
+    return {"litellm_warnings": failed_regions}
 
 
 async def propagate_team_budget_to_keys(

--- a/app/core/team_service.py
+++ b/app/core/team_service.py
@@ -244,6 +244,7 @@ async def restore_soft_deleted_team(db: Session, team: DBTeam) -> dict:
                     f"Failed to re-provision LiteLLM team in region {region.name}: {str(team_error)}"
                 )
                 region_failed = True
+                continue
 
             # Ensure each user exists in LiteLLM and is a member of the team (idempotent)
             for user in team_users:

--- a/app/core/team_service.py
+++ b/app/core/team_service.py
@@ -271,9 +271,11 @@ async def restore_soft_deleted_team(db: Session, team: DBTeam) -> dict:
                 f"Failed to re-provision LiteLLM team/users in region {region.name}: {str(region_error)}"
             )
             region_failed = True
-
-        if region_failed:
-            failed_regions.append(region.name)
+        finally:
+            # `continue` inside the inner try skips code after the try/except block,
+            # so use finally to ensure failed regions are always recorded.
+            if region_failed:
+                failed_regions.append(region.name)
 
     # Un-expire all keys for the team in LiteLLM
     try:

--- a/app/core/team_service.py
+++ b/app/core/team_service.py
@@ -8,7 +8,14 @@ from datetime import UTC, datetime
 from typing import Dict, List, Optional
 
 from app.core.limit_service import DEFAULT_KEY_DURATION
-from app.db.models import DBPrivateAIKey, DBRegion, DBTeam, DBUser
+from app.db.models import (
+    DBAuditLog,
+    DBPrivateAIKey,
+    DBRegion,
+    DBTeam,
+    DBTeamRegion,
+    DBUser,
+)
 from app.services.litellm import LiteLLMService
 from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
@@ -127,7 +134,20 @@ async def soft_delete_team(
         f"Deactivated {users_deactivated} users for soft-deleted team {team.id}"
     )
 
-    # Commit the deletion and user deactivation
+    # Write audit log entry (background/worker operation — no HTTP user)
+    audit_log = DBAuditLog(
+        timestamp=current_time,
+        user_id=None,
+        event_type="WORKER",
+        resource_type="team",
+        resource_id=str(team.id),
+        action="team.soft_delete",
+        details={"team_name": team.name, "deleted_at": current_time.isoformat()},
+        request_source=None,
+    )
+    db.add(audit_log)
+
+    # Commit the deletion, user deactivation, and audit log
     db.commit()
 
     # Expire all keys in LiteLLM
@@ -170,6 +190,7 @@ async def restore_soft_deleted_team(db: Session, team: DBTeam) -> None:
     - Resets team.deleted_at to null
     - Resets team.retention_warning_sent_at to null
     - Reactivates all users in the team (is_active = True)
+    - Re-provisions the LiteLLM team and its users in every allowed region
     - Un-expires all keys in LiteLLM (sets back to default duration)
 
     Args:
@@ -182,6 +203,62 @@ async def restore_soft_deleted_team(db: Session, team: DBTeam) -> None:
         raise ValueError(f"Team {team.id} is not soft-deleted and cannot be restored")
 
     logger.info(f"Restoring soft-deleted team {team.id} ({team.name})")
+
+    # Collect team users and regions up front
+    team_users = db.query(DBUser).filter(DBUser.team_id == team.id).all()
+    allowed_regions = (
+        db.query(DBRegion)
+        .join(DBTeamRegion, DBTeamRegion.region_id == DBRegion.id)
+        .filter(DBTeamRegion.team_id == team.id, DBRegion.is_active.is_(True))
+        .all()
+    )
+
+    # Re-provision LiteLLM: ensure team and user objects exist in each region
+    for region in allowed_regions:
+        try:
+            litellm_service = LiteLLMService(
+                api_url=region.litellm_api_url, api_key=region.litellm_api_key
+            )
+            lite_team_id = LiteLLMService.format_team_id(region.name, team.id)
+
+            # Ensure the LiteLLM team exists (idempotent)
+            try:
+                await litellm_service.create_team(
+                    team_id=lite_team_id,
+                    team_alias=lite_team_id,
+                )
+                logger.info(
+                    f"Re-provisioned LiteLLM team {lite_team_id} in region {region.name}"
+                )
+            except Exception as team_error:
+                logger.error(
+                    f"Failed to re-provision LiteLLM team in region {region.name}: {str(team_error)}"
+                )
+
+            # Ensure each user exists in LiteLLM and is a member of the team (idempotent)
+            for user in team_users:
+                try:
+                    await litellm_service.create_user(
+                        user_id=str(user.id),
+                        user_email=user.email,
+                        auto_create_key=False,
+                    )
+                    await litellm_service.add_team_member(
+                        team_id=lite_team_id,
+                        user_id=str(user.id),
+                    )
+                    logger.info(
+                        f"Re-provisioned LiteLLM user {user.id} in team {lite_team_id} region {region.name}"
+                    )
+                except Exception as user_error:
+                    logger.error(
+                        f"Failed to re-provision LiteLLM user {user.id} in region {region.name}: {str(user_error)}"
+                    )
+        except Exception as region_error:
+            logger.error(
+                f"Failed to re-provision LiteLLM team/users in region {region.name}: {str(region_error)}"
+            )
+            # Don't block restoration if LiteLLM re-provisioning fails for a region
 
     # Un-expire all keys for the team in LiteLLM
     try:
@@ -215,11 +292,13 @@ async def restore_soft_deleted_team(db: Session, team: DBTeam) -> None:
         )
         # Don't block restoration if key un-expiration fails
 
+    restored_at = datetime.now(UTC)
+
     # Reset deletion and warning timestamps and reactivate team
     team.deleted_at = None
     team.retention_warning_sent_at = None
     team.is_active = True
-    team.updated_at = datetime.now(UTC)
+    team.updated_at = restored_at
 
     # Reactivate all users in the team
     users_reactivated = (
@@ -228,6 +307,19 @@ async def restore_soft_deleted_team(db: Session, team: DBTeam) -> None:
         .update({"is_active": True}, synchronize_session=False)
     )
     logger.info(f"Reactivated {users_reactivated} users for restored team {team.id}")
+
+    # Write audit log entry
+    audit_log = DBAuditLog(
+        timestamp=restored_at,
+        user_id=None,
+        event_type="WORKER",
+        resource_type="team",
+        resource_id=str(team.id),
+        action="team.restore",
+        details={"team_name": team.name},
+        request_source=None,
+    )
+    db.add(audit_log)
 
     db.commit()
 

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -1529,7 +1529,7 @@ async def hard_delete_expired_teams(db: Session):
         # Calculate cutoff date (90 days ago — GDPR data retention requirement)
         cutoff_date = datetime.now(UTC) - timedelta(days=90)
 
-        # Query all teams that have been soft-deleted for 60+ days
+        # Query all teams that have been soft-deleted for 90+ days
         teams_to_delete = (
             db.query(DBTeam)
             .filter(DBTeam.deleted_at.is_not(None), DBTeam.deleted_at <= cutoff_date)
@@ -1613,10 +1613,10 @@ async def hard_delete_expired_teams(db: Session):
                     .all()
                 )
 
-                # Delete spend_caps before keys/users/team to avoid FK violations:
-                # spend_caps.key_id → ai_tokens.id (no ondelete)
-                # spend_caps.user_id → users.id (no ondelete)
-                # spend_caps.team_id → teams.id (no ondelete)
+                # 3. Delete spend_caps before keys/users/team to avoid FK violations:
+                #    spend_caps.key_id → ai_tokens.id (no ondelete)
+                #    spend_caps.user_id → users.id (no ondelete)
+                #    spend_caps.team_id → teams.id (no ondelete)
                 db.query(DBSpendCap).filter(
                     or_(
                         DBSpendCap.team_id == team.id,
@@ -1635,7 +1635,7 @@ async def hard_delete_expired_teams(db: Session):
                     f"Deleted {total_keys} keys from database for team {team.id}"
                 )
 
-                # 3. Clean up remaining FK references to users before deleting them.
+                # 4. Clean up remaining FK references to users before deleting them.
                 #    These tables have FKs to users.id with no ondelete rule, so
                 #    PostgreSQL would raise a FK violation without explicit cleanup.
 
@@ -1677,21 +1677,21 @@ async def hard_delete_expired_teams(db: Session):
                         f"Deleted spend cache entries for users of team {team.id}"
                     )
 
-                # 3. Delete users in the team
+                # 5. Delete users in the team
                 db.query(DBUser).filter(DBUser.team_id == team.id).delete()
                 logger.info(f"Deleted {len(team_user_ids)} users for team {team.id}")
 
-                # 4. Delete team product associations
+                # 6. Delete team product associations
                 db.query(DBTeamProduct).filter(
                     DBTeamProduct.team_id == team.id
                 ).delete()
                 logger.info(f"Deleted product associations for team {team.id}")
 
-                # 5. Delete team region associations
+                # 7. Delete team region associations
                 db.query(DBTeamRegion).filter(DBTeamRegion.team_id == team.id).delete()
                 logger.info(f"Deleted region associations for team {team.id}")
 
-                # 6. Write audit log before deleting the team record
+                # 8. Write audit log before deleting the team record
                 hard_delete_time = datetime.now(UTC)
                 audit_log = DBAuditLog(
                     timestamp=hard_delete_time,
@@ -1711,7 +1711,7 @@ async def hard_delete_expired_teams(db: Session):
                 )
                 db.add(audit_log)
 
-                # 7. Delete the team itself (DBTeamMetrics will be auto-deleted via cascade)
+                # 9. Delete the team itself (DBTeamMetrics will be auto-deleted via cascade)
                 db.delete(team)
 
                 # Commit after each team to avoid rolling back everything on error

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -52,6 +52,7 @@ from app.core.spend_period_service import (
     fetch_team_spend_snapshot_for_region,
     upsert_team_spend_period,
 )
+from app.core.email import normalize_email_for_lookup
 
 logger = logging.getLogger(__name__)
 
@@ -1670,8 +1671,14 @@ async def hard_delete_expired_teams(db: Session):
                 # user_spend_cache is keyed by normalized_email (no FK, string column)
                 # Clean up stale cache rows so they don't linger indefinitely.
                 if team_user_emails:
+                    normalized_team_user_emails = {
+                        normalize_email_for_lookup(email)
+                        for email in team_user_emails
+                    }
                     db.query(DBUserSpendCache).filter(
-                        DBUserSpendCache.normalized_email.in_(team_user_emails)
+                        DBUserSpendCache.normalized_email.in_(
+                            normalized_team_user_emails
+                        )
                     ).delete(synchronize_session=False)
                     logger.info(
                         f"Deleted spend cache entries for users of team {team.id}"

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -1,6 +1,6 @@
 from datetime import datetime, UTC, timedelta
 from sqlalchemy.orm import Session
-from sqlalchemy import select, func, and_
+from sqlalchemy import select, func, and_, or_, update as sa_update
 from app.db.models import (
     DBTeam,
     DBAuditLog,
@@ -14,6 +14,10 @@ from app.db.models import (
     DBTeamRegion,
     DBPoolPurchase,
     DBPeriodicPayment,
+    DBAPIToken,
+    DBUserAdminRegion,
+    DBSpendCap,
+    DBUserSpendCache,
 )
 from app.schemas.models import BudgetType
 from app.db.database import get_db
@@ -1547,6 +1551,13 @@ async def hard_delete_expired_teams(db: Session):
                     .all()
                 )
 
+                # Also capture emails now (needed for user_spend_cache cleanup)
+                team_user_emails = (
+                    db.execute(select(DBUser.email).filter(DBUser.team_id == team.id))
+                    .scalars()
+                    .all()
+                )
+
                 # 1. Delete team and user limited resources
                 db.query(DBLimitedResource).filter(
                     DBLimitedResource.owner_type == OwnerType.TEAM,
@@ -1588,6 +1599,33 @@ async def hard_delete_expired_teams(db: Session):
                         )
 
                 # Delete keys from database
+                # Collect key IDs first so we can clean up spend_caps that reference them
+                team_key_ids = (
+                    db.execute(
+                        select(DBPrivateAIKey.id).filter(
+                            or_(
+                                DBPrivateAIKey.team_id == team.id,
+                                DBPrivateAIKey.owner_id.in_(team_user_ids),
+                            )
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+
+                # Delete spend_caps before keys/users/team to avoid FK violations:
+                # spend_caps.key_id → ai_tokens.id (no ondelete)
+                # spend_caps.user_id → users.id (no ondelete)
+                # spend_caps.team_id → teams.id (no ondelete)
+                db.query(DBSpendCap).filter(
+                    or_(
+                        DBSpendCap.team_id == team.id,
+                        DBSpendCap.user_id.in_(team_user_ids),
+                        DBSpendCap.key_id.in_(team_key_ids),
+                    )
+                ).delete(synchronize_session=False)
+                logger.info(f"Deleted spend caps for team {team.id}")
+
                 total_keys = sum(len(keys) for keys in keys_by_region.values())
                 db.query(DBPrivateAIKey).filter(
                     (DBPrivateAIKey.team_id == team.id)
@@ -1596,6 +1634,48 @@ async def hard_delete_expired_teams(db: Session):
                 logger.info(
                     f"Deleted {total_keys} keys from database for team {team.id}"
                 )
+
+                # 3. Clean up remaining FK references to users before deleting them.
+                #    These tables have FKs to users.id with no ondelete rule, so
+                #    PostgreSQL would raise a FK violation without explicit cleanup.
+
+                # api_tokens.user_id → users.id (no ondelete)
+                if team_user_ids:
+                    db.query(DBAPIToken).filter(
+                        DBAPIToken.user_id.in_(team_user_ids)
+                    ).delete(synchronize_session=False)
+                    logger.info(f"Deleted API tokens for users of team {team.id}")
+
+                # user_admin_regions.user_id → users.id (no ondelete, PK)
+                if team_user_ids:
+                    db.query(DBUserAdminRegion).filter(
+                        DBUserAdminRegion.user_id.in_(team_user_ids)
+                    ).delete(synchronize_session=False)
+                    logger.info(
+                        f"Deleted admin-region rows for users of team {team.id}"
+                    )
+
+                # audit_logs.user_id → users.id (nullable, no ondelete)
+                # Preserve audit history; just null out the user reference.
+                if team_user_ids:
+                    db.execute(
+                        sa_update(DBAuditLog)
+                        .where(DBAuditLog.user_id.in_(team_user_ids))
+                        .values(user_id=None)
+                    )
+                    logger.info(
+                        f"Nulled user_id in audit logs for users of team {team.id}"
+                    )
+
+                # user_spend_cache is keyed by normalized_email (no FK, string column)
+                # Clean up stale cache rows so they don't linger indefinitely.
+                if team_user_emails:
+                    db.query(DBUserSpendCache).filter(
+                        DBUserSpendCache.normalized_email.in_(team_user_emails)
+                    ).delete(synchronize_session=False)
+                    logger.info(
+                        f"Deleted spend cache entries for users of team {team.id}"
+                    )
 
                 # 3. Delete users in the team
                 db.query(DBUser).filter(DBUser.team_id == team.id).delete()

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy import select, func, and_
 from app.db.models import (
     DBTeam,
+    DBAuditLog,
     DBProduct,
     DBTeamProduct,
     DBPrivateAIKey,
@@ -1515,14 +1516,14 @@ async def monitor_teams(db: Session):
 @hard_delete_teams_duration.time()
 async def hard_delete_expired_teams(db: Session):
     """
-    Hard deletion job for teams that have been soft-deleted for 60+ days.
+    Hard deletion job for teams that have been soft-deleted for 90+ days.
     Cascades deletion to all related resources (keys, users, limits, metrics, etc.).
     Runs less frequently than monitor_teams (daily at 3 AM).
     """
     logger.info("Starting hard delete job for expired teams")
     try:
-        # Calculate cutoff date (60 days ago)
-        cutoff_date = datetime.now(UTC) - timedelta(days=60)
+        # Calculate cutoff date (90 days ago — GDPR data retention requirement)
+        cutoff_date = datetime.now(UTC) - timedelta(days=90)
 
         # Query all teams that have been soft-deleted for 60+ days
         teams_to_delete = (
@@ -1610,7 +1611,27 @@ async def hard_delete_expired_teams(db: Session):
                 db.query(DBTeamRegion).filter(DBTeamRegion.team_id == team.id).delete()
                 logger.info(f"Deleted region associations for team {team.id}")
 
-                # 6. Delete the team itself (DBTeamMetrics will be auto-deleted via cascade)
+                # 6. Write audit log before deleting the team record
+                hard_delete_time = datetime.now(UTC)
+                audit_log = DBAuditLog(
+                    timestamp=hard_delete_time,
+                    user_id=None,
+                    event_type="WORKER",
+                    resource_type="team",
+                    resource_id=str(team.id),
+                    action="team.hard_delete",
+                    details={
+                        "team_name": team.name,
+                        "soft_deleted_at": team.deleted_at.isoformat()
+                        if team.deleted_at
+                        else None,
+                        "hard_deleted_at": hard_delete_time.isoformat(),
+                    },
+                    request_source=None,
+                )
+                db.add(audit_log)
+
+                # 7. Delete the team itself (DBTeamMetrics will be auto-deleted via cascade)
                 db.delete(team)
 
                 # Commit after each team to avoid rolling back everything on error

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime, UTC, timedelta
 from sqlalchemy.orm import Session
 from sqlalchemy import select, func, and_, or_, update as sa_update
@@ -1521,16 +1522,18 @@ async def monitor_teams(db: Session):
 @hard_delete_teams_duration.time()
 async def hard_delete_expired_teams(db: Session):
     """
-    Hard deletion job for teams that have been soft-deleted for 90+ days.
+    Hard deletion job for teams that have been soft-deleted beyond the retention period.
     Cascades deletion to all related resources (keys, users, limits, metrics, etc.).
     Runs less frequently than monitor_teams (daily at 3 AM).
     """
     logger.info("Starting hard delete job for expired teams")
     try:
-        # Calculate cutoff date (90 days ago — GDPR data retention requirement)
-        cutoff_date = datetime.now(UTC) - timedelta(days=90)
+        retention_days = max(
+            30, int(os.getenv("TEAM_HARD_DELETE_RETENTION_DAYS", "90"))
+        )
+        cutoff_date = datetime.now(UTC) - timedelta(days=retention_days)
 
-        # Query all teams that have been soft-deleted for 90+ days
+        # Query all teams that have been soft-deleted beyond the retention period
         teams_to_delete = (
             db.query(DBTeam)
             .filter(DBTeam.deleted_at.is_not(None), DBTeam.deleted_at <= cutoff_date)

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -1672,8 +1672,7 @@ async def hard_delete_expired_teams(db: Session):
                 # Clean up stale cache rows so they don't linger indefinitely.
                 if team_user_emails:
                     normalized_team_user_emails = {
-                        normalize_email_for_lookup(email)
-                        for email in team_user_emails
+                        normalize_email_for_lookup(email) for email in team_user_emails
                     }
                     db.query(DBUserSpendCache).filter(
                         DBUserSpendCache.normalized_email.in_(

--- a/app/main.py
+++ b/app/main.py
@@ -256,17 +256,14 @@ def custom_openapi():
                     del operation["parameters"]
 
             # Remove security from non-protected endpoints
-            if (
-                path_name
-                in [
-                    "/auth/login",
-                    "/auth/register",
-                    "/health",
-                    "/auth/generate-trial-access",
-                    "/public/models",
-                    "/public/models/",
-                ]
-            ):
+            if path_name in [
+                "/auth/login",
+                "/auth/register",
+                "/health",
+                "/auth/generate-trial-access",
+                "/public/models",
+                "/public/models/",
+            ]:
                 if "security" in operation:
                     del operation["security"]
 

--- a/scripts/check_missing_models.py
+++ b/scripts/check_missing_models.py
@@ -75,7 +75,9 @@ def save_state(state_file: Path, state: dict[str, Any]) -> None:
     state_file.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
 
 
-def build_diff(report: dict[str, Any], previous_state: dict[str, Any]) -> dict[str, Any]:
+def build_diff(
+    report: dict[str, Any], previous_state: dict[str, Any]
+) -> dict[str, Any]:
     """Compute per-region-group ``new_missing`` vs. ``previous_state`` plus
     the next state to persist.
 
@@ -158,7 +160,9 @@ def write_github_outputs(diff: dict[str, Any]) -> None:
         return
     summary = diff["slack_summary"] or "No new missing models detected."
     with open(output_path, "a", encoding="utf-8") as handle:
-        handle.write(f"has_new_missing={'true' if diff['has_new_missing'] else 'false'}\n")
+        handle.write(
+            f"has_new_missing={'true' if diff['has_new_missing'] else 'false'}\n"
+        )
         handle.write(f"state_changed={'true' if diff['state_changed'] else 'false'}\n")
         handle.write(f"provider={diff.get('provider', '')}\n")
         # JSON-encoded so newlines/quotes are safe to interpolate into a Slack payload.

--- a/tests/test_hard_delete.py
+++ b/tests/test_hard_delete.py
@@ -723,7 +723,7 @@ async def test_hard_delete_removes_key_spend_caps(
 
 @patch("app.core.worker.LiteLLMService")
 @pytest.mark.asyncio
-async def test_hard_delete_removes_user_spend_cache(
+async def test_hard_delete_removes_user_spend_cache_for_normalized_email(
     mock_litellm, db: Session, test_team
 ):
     """
@@ -731,7 +731,7 @@ async def test_hard_delete_removes_user_spend_cache(
     When: Running the hard delete job
     Then: The spend cache rows for those emails should be deleted
     """
-    user = DBUser(email="cache@example.com", team_id=test_team.id)
+    user = DBUser(email="Cache+tag@Example.com", team_id=test_team.id)
     db.add(user)
     db.commit()
 

--- a/tests/test_hard_delete.py
+++ b/tests/test_hard_delete.py
@@ -21,17 +21,17 @@ from tests.conftest import soft_delete_team_for_test
 
 @patch("app.core.worker.LiteLLMService")
 @pytest.mark.asyncio
-async def test_hard_delete_teams_older_than_60_days(
+async def test_hard_delete_teams_older_than_90_days(
     mock_litellm, db: Session, test_team, test_region
 ):
     """
-    Given: A team that was soft-deleted 61 days ago
+    Given: A team that was soft-deleted 91 days ago
     When: Running the hard delete job
     Then: Should permanently delete the team and all related resources
     """
-    # Soft delete the team 61 days ago
+    # Soft delete the team 91 days ago
     soft_delete_team_for_test(
-        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=61)
+        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=91)
     )
 
     # Create related resources
@@ -77,7 +77,7 @@ async def test_hard_delete_teams_older_than_60_days(
 @pytest.mark.asyncio
 async def test_hard_delete_preserves_recent_soft_deletes(db: Session, test_team):
     """
-    Given: A team that was soft-deleted 30 days ago (less than 60 days)
+    Given: A team that was soft-deleted 30 days ago (less than 90 days)
     When: Running the hard delete job
     Then: Should NOT delete the team (still within grace period)
     """
@@ -99,15 +99,15 @@ async def test_hard_delete_preserves_recent_soft_deletes(db: Session, test_team)
 
 @patch("app.core.worker.LiteLLMService")
 @pytest.mark.asyncio
-async def test_hard_delete_exactly_60_days(mock_litellm, db: Session, test_team):
+async def test_hard_delete_exactly_90_days(mock_litellm, db: Session, test_team):
     """
-    Given: A team that was soft-deleted exactly 60 days ago
+    Given: A team that was soft-deleted exactly 90 days ago
     When: Running the hard delete job
     Then: Should permanently delete the team (inclusive boundary)
     """
-    # Soft delete the team exactly 60 days ago
+    # Soft delete the team exactly 90 days ago
     soft_delete_team_for_test(
-        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=60)
+        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=90)
     )
 
     team_id = test_team.id
@@ -124,7 +124,7 @@ async def test_hard_delete_exactly_60_days(mock_litellm, db: Session, test_team)
 @pytest.mark.asyncio
 async def test_hard_delete_cascades_team_metrics(mock_litellm, db: Session, test_team):
     """
-    Given: A team with metrics that was soft-deleted 61 days ago
+    Given: A team with metrics that was soft-deleted 91 days ago
     When: Running the hard delete job
     Then: Should delete the team metrics
     """
@@ -137,9 +137,9 @@ async def test_hard_delete_cascades_team_metrics(mock_litellm, db: Session, test
     )
     db.add(metrics)
 
-    # Soft delete the team 61 days ago
+    # Soft delete the team 91 days ago
     soft_delete_team_for_test(
-        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=61)
+        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=91)
     )
 
     team_id = test_team.id
@@ -160,7 +160,7 @@ async def test_hard_delete_cascades_limited_resources(
     mock_litellm, db: Session, test_team
 ):
     """
-    Given: A team with limited resources that was soft-deleted 61 days ago
+    Given: A team with limited resources that was soft-deleted 91 days ago
     When: Running the hard delete job
     Then: Should delete all team and user limited resources
     """
@@ -195,9 +195,9 @@ async def test_hard_delete_cascades_limited_resources(
     )
     db.add(user_resource)
 
-    # Soft delete the team 61 days ago
+    # Soft delete the team 91 days ago
     soft_delete_team_for_test(
-        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=61)
+        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=91)
     )
 
     team_id = test_team.id
@@ -234,7 +234,7 @@ async def test_hard_delete_cascades_product_associations(
     mock_litellm, db: Session, test_team
 ):
     """
-    Given: A team with product associations that was soft-deleted 61 days ago
+    Given: A team with product associations that was soft-deleted 91 days ago
     When: Running the hard delete job
     Then: Should delete the team-product associations
     """
@@ -246,9 +246,9 @@ async def test_hard_delete_cascades_product_associations(
     team_product = DBTeamProduct(team_id=test_team.id, product_id=product.id)
     db.add(team_product)
 
-    # Soft delete the team 61 days ago
+    # Soft delete the team 91 days ago
     soft_delete_team_for_test(
-        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=61)
+        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=91)
     )
 
     team_id = test_team.id
@@ -275,15 +275,15 @@ async def test_hard_delete_cascades_region_associations(
     mock_litellm, db: Session, test_team, test_region
 ):
     """
-    Given: A team with region associations that was soft-deleted 61 days ago
+    Given: A team with region associations that was soft-deleted 91 days ago
     When: Running the hard delete job
     Then: Should delete the team-region associations
     """
     # test_region fixture already auto-associates active teams to public regions
 
-    # Soft delete the team 61 days ago
+    # Soft delete the team 91 days ago
     soft_delete_team_for_test(
-        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=61)
+        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=91)
     )
 
     team_id = test_team.id
@@ -306,7 +306,7 @@ async def test_hard_delete_calls_litellm_for_all_keys(
     mock_litellm, db: Session, test_team, test_region
 ):
     """
-    Given: A team with multiple keys that was soft-deleted 61 days ago
+    Given: A team with multiple keys that was soft-deleted 91 days ago
     When: Running the hard delete job
     Then: Should call LiteLLM delete for each key
     """
@@ -325,9 +325,9 @@ async def test_hard_delete_calls_litellm_for_all_keys(
     )
     db.add_all([key1, key2])
 
-    # Soft delete the team 61 days ago
+    # Soft delete the team 91 days ago
     soft_delete_team_for_test(
-        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=61)
+        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=91)
     )
 
     # Mock LiteLLM service
@@ -362,9 +362,9 @@ async def test_hard_delete_continues_on_litellm_error(
     )
     db.add(key)
 
-    # Soft delete the team 61 days ago
+    # Soft delete the team 91 days ago
     soft_delete_team_for_test(
-        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=61)
+        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=91)
     )
 
     team_id = test_team.id
@@ -415,9 +415,9 @@ async def test_hard_delete_deletes_user_owned_keys(
     )
     db.add(user_key)
 
-    # Soft delete the team 61 days ago
+    # Soft delete the team 91 days ago
     soft_delete_team_for_test(
-        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=61)
+        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=91)
     )
 
     mock_service = AsyncMock()
@@ -444,7 +444,7 @@ async def test_hard_delete_deletes_user_owned_keys(
 @pytest.mark.asyncio
 async def test_hard_delete_multiple_teams(mock_litellm, db: Session, test_region):
     """
-    Given: Multiple teams that were soft-deleted over 60 days ago
+    Given: Multiple teams that were soft-deleted over 90 days ago
     When: Running the hard delete job
     Then: Should delete all eligible teams
     """
@@ -457,10 +457,10 @@ async def test_hard_delete_multiple_teams(mock_litellm, db: Session, test_region
 
     # Soft delete teams with different timestamps
     soft_delete_team_for_test(
-        db, team1, deleted_at=datetime.now(UTC) - timedelta(days=65)
+        db, team1, deleted_at=datetime.now(UTC) - timedelta(days=95)
     )
     soft_delete_team_for_test(
-        db, team2, deleted_at=datetime.now(UTC) - timedelta(days=70)
+        db, team2, deleted_at=datetime.now(UTC) - timedelta(days=100)
     )
     soft_delete_team_for_test(
         db, team3, deleted_at=datetime.now(UTC) - timedelta(days=30)
@@ -513,9 +513,9 @@ async def test_hard_delete_rollback_on_error(mock_litellm, db: Session, test_tea
     When: An error occurs during deletion
     Then: Should rollback the transaction for that team
     """
-    # Soft delete the team 61 days ago
+    # Soft delete the team 91 days ago
     soft_delete_team_for_test(
-        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=61)
+        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=91)
     )
 
     team_id = test_team.id

--- a/tests/test_hard_delete.py
+++ b/tests/test_hard_delete.py
@@ -13,6 +13,11 @@ from app.db.models import (
     DBLimitedResource,
     DBTeamRegion,
     DBRegion,
+    DBAPIToken,
+    DBUserAdminRegion,
+    DBAuditLog,
+    DBSpendCap,
+    DBUserSpendCache,
 )
 from app.schemas.limits import ResourceType, UnitType, OwnerType, LimitType, LimitSource
 from app.core.worker import hard_delete_expired_teams
@@ -533,3 +538,219 @@ async def test_hard_delete_rollback_on_error(mock_litellm, db: Session, test_tea
     db.query(DBTeam).filter(DBTeam.id == team_id).first()
     # Team might be deleted or might not be, depending on where error occurred
     # The important thing is that the job didn't crash
+
+
+@patch("app.core.worker.LiteLLMService")
+@pytest.mark.asyncio
+async def test_hard_delete_removes_api_tokens(mock_litellm, db: Session, test_team):
+    """
+    Given: A team whose users have API tokens (portal auth tokens)
+    When: Running the hard delete job
+    Then: Those API tokens should be deleted before users are removed
+    """
+    user = DBUser(email="apitoken@example.com", team_id=test_team.id)
+    db.add(user)
+    db.commit()
+
+    api_token = DBAPIToken(name="my-token", token="tok-abc123", user_id=user.id)
+    db.add(api_token)
+
+    soft_delete_team_for_test(
+        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=91)
+    )
+
+    await hard_delete_expired_teams(db)
+
+    remaining = db.query(DBAPIToken).filter(DBAPIToken.token == "tok-abc123").first()
+    assert remaining is None
+
+
+@patch("app.core.worker.LiteLLMService")
+@pytest.mark.asyncio
+async def test_hard_delete_removes_user_admin_regions(
+    mock_litellm, db: Session, test_team, test_region
+):
+    """
+    Given: A team whose users have admin-region rows
+    When: Running the hard delete job
+    Then: Those rows should be deleted before users are removed
+    """
+    user = DBUser(email="adminregion@example.com", team_id=test_team.id)
+    db.add(user)
+    db.commit()
+
+    admin_region = DBUserAdminRegion(user_id=user.id, region_id=test_region.id)
+    db.add(admin_region)
+    user_id = user.id
+
+    soft_delete_team_for_test(
+        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=91)
+    )
+
+    await hard_delete_expired_teams(db)
+
+    remaining = (
+        db.query(DBUserAdminRegion).filter(DBUserAdminRegion.user_id == user_id).first()
+    )
+    assert remaining is None
+
+
+@patch("app.core.worker.LiteLLMService")
+@pytest.mark.asyncio
+async def test_hard_delete_nulls_audit_log_user_id(
+    mock_litellm, db: Session, test_team
+):
+    """
+    Given: A team whose users authored audit log entries
+    When: Running the hard delete job
+    Then: Those audit log rows should be preserved but user_id set to NULL
+    """
+    user = DBUser(email="auditlog@example.com", team_id=test_team.id)
+    db.add(user)
+    db.commit()
+
+    log = DBAuditLog(
+        timestamp=datetime.now(UTC),
+        user_id=user.id,
+        event_type="API",
+        resource_type="key",
+        resource_id="1",
+        action="key.create",
+        details={},
+        request_source="frontend",
+    )
+    db.add(log)
+    db.commit()
+    log_id = log.id
+
+    soft_delete_team_for_test(
+        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=91)
+    )
+
+    await hard_delete_expired_teams(db)
+
+    # Row should still exist (preserve audit history)
+    surviving_log = db.query(DBAuditLog).filter(DBAuditLog.id == log_id).first()
+    assert surviving_log is not None
+    # But user_id should now be NULL
+    assert surviving_log.user_id is None
+
+
+@patch("app.core.worker.LiteLLMService")
+@pytest.mark.asyncio
+async def test_hard_delete_removes_spend_caps(
+    mock_litellm, db: Session, test_team, test_region
+):
+    """
+    Given: A team with spend caps (team-scoped and user-scoped)
+    When: Running the hard delete job
+    Then: All spend caps associated with the team should be deleted
+    """
+    user = DBUser(email="spenccap@example.com", team_id=test_team.id)
+    db.add(user)
+    db.commit()
+
+    team_cap = DBSpendCap(
+        scope="team",
+        region_id=test_region.id,
+        team_id=test_team.id,
+        max_budget=50.0,
+    )
+    user_cap = DBSpendCap(
+        scope="team_member",
+        region_id=test_region.id,
+        team_id=test_team.id,
+        user_id=user.id,
+        max_budget=10.0,
+    )
+    db.add_all([team_cap, user_cap])
+
+    soft_delete_team_for_test(
+        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=91)
+    )
+
+    await hard_delete_expired_teams(db)
+
+    remaining = db.query(DBSpendCap).filter(DBSpendCap.team_id == test_team.id).all()
+    assert len(remaining) == 0
+
+
+@patch("app.core.worker.LiteLLMService")
+@pytest.mark.asyncio
+async def test_hard_delete_removes_key_spend_caps(
+    mock_litellm, db: Session, test_team, test_region
+):
+    """
+    Given: A team with keys that have key-scoped spend caps
+    When: Running the hard delete job
+    Then: Key spend caps should be deleted before the keys are removed
+    """
+    user = DBUser(email="keycap@example.com", team_id=test_team.id)
+    db.add(user)
+    db.commit()
+
+    key = DBPrivateAIKey(
+        name="capped-key",
+        litellm_token="tok-capped",
+        team_id=test_team.id,
+        region_id=test_region.id,
+    )
+    db.add(key)
+    db.commit()
+    key_id = key.id
+
+    key_cap = DBSpendCap(
+        scope="key",
+        region_id=test_region.id,
+        team_id=test_team.id,
+        key_id=key.id,
+        max_budget=5.0,
+    )
+    db.add(key_cap)
+
+    soft_delete_team_for_test(
+        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=91)
+    )
+
+    mock_service = AsyncMock()
+    mock_litellm.return_value = mock_service
+
+    await hard_delete_expired_teams(db)
+
+    remaining = db.query(DBSpendCap).filter(DBSpendCap.key_id == key_id).first()
+    assert remaining is None
+
+
+@patch("app.core.worker.LiteLLMService")
+@pytest.mark.asyncio
+async def test_hard_delete_removes_user_spend_cache(
+    mock_litellm, db: Session, test_team
+):
+    """
+    Given: A team whose user emails appear in the spend cache
+    When: Running the hard delete job
+    Then: The spend cache rows for those emails should be deleted
+    """
+    user = DBUser(email="cache@example.com", team_id=test_team.id)
+    db.add(user)
+    db.commit()
+
+    cache_entry = DBUserSpendCache(
+        normalized_email="cache@example.com",
+        response_data={"spend": 1.23},
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+    db.add(cache_entry)
+
+    soft_delete_team_for_test(
+        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=91)
+    )
+
+    await hard_delete_expired_teams(db)
+
+    remaining = (
+        db.query(DBUserSpendCache)
+        .filter(DBUserSpendCache.normalized_email == "cache@example.com")
+        .first()
+    )
+    assert remaining is None

--- a/tests/test_public_models_missing.py
+++ b/tests/test_public_models_missing.py
@@ -187,8 +187,9 @@ def test_missing_models_provider_lookup_is_case_insensitive(client, db):
     _make_public_region(db, "us-east-1", suffix="us")
     admin, password = _make_admin_user(db, email="case-insensitive-admin@example.com")
     token = _get_token(client, admin.email, password)
-    with patch("app.api.public.LiteLLMService") as mock_service_cls, _patch_catalog_fetch(
-        _upstream_catalog()
+    with (
+        patch("app.api.public.LiteLLMService") as mock_service_cls,
+        _patch_catalog_fetch(_upstream_catalog()),
     ):
         mock_service_cls.return_value.get_model_info = AsyncMock(
             return_value=_model_info_with_bedrock([])
@@ -218,8 +219,9 @@ def test_missing_aws_reports_gaps_per_region_group(client, db):
         ]
     )
 
-    with patch("app.api.public.LiteLLMService") as mock_service_cls, _patch_catalog_fetch(
-        _upstream_catalog()
+    with (
+        patch("app.api.public.LiteLLMService") as mock_service_cls,
+        _patch_catalog_fetch(_upstream_catalog()),
     ):
         mock_service_cls.return_value.get_model_info = AsyncMock(return_value=deployed)
         response = client.get(AWS_PATH, headers={"Authorization": f"Bearer {token}"})
@@ -249,8 +251,12 @@ def test_missing_aws_reports_gaps_per_region_group(client, db):
             assert m["model_id"] != "legacy.dont-show-me"
 
     # EU and AU have no contributing regions, so everything available is "missing".
-    assert by_group["EU"]["missing_model_count"] == by_group["EU"]["available_model_count"]
-    assert by_group["AU"]["missing_model_count"] == by_group["AU"]["available_model_count"]
+    assert (
+        by_group["EU"]["missing_model_count"] == by_group["EU"]["available_model_count"]
+    )
+    assert (
+        by_group["AU"]["missing_model_count"] == by_group["AU"]["available_model_count"]
+    )
 
 
 def test_missing_aws_ignores_non_bedrock_providers(client, db):
@@ -269,8 +275,9 @@ def test_missing_aws_ignores_non_bedrock_providers(client, db):
         ]
     )
 
-    with patch("app.api.public.LiteLLMService") as mock_service_cls, _patch_catalog_fetch(
-        _upstream_catalog()
+    with (
+        patch("app.api.public.LiteLLMService") as mock_service_cls,
+        _patch_catalog_fetch(_upstream_catalog()),
     ):
         mock_service_cls.return_value.get_model_info = AsyncMock(return_value=deployed)
         response = client.get(AWS_PATH, headers={"Authorization": f"Bearer {token}"})
@@ -288,7 +295,9 @@ def test_missing_aws_admin_includes_dedicated_regions(client, db):
     dedicated_region = _make_dedicated_region(db, "us-east-private", suffix="us-priv")
 
     public_deployed = _model_info_with_bedrock(["bedrock/us.amazon.nova-pro-v1:0"])
-    private_deployed = _model_info_with_bedrock(["bedrock/us.anthropic.claude-opus-4-7"])
+    private_deployed = _model_info_with_bedrock(
+        ["bedrock/us.anthropic.claude-opus-4-7"]
+    )
 
     def _service_factory(api_url, api_key):
         service = AsyncMock()
@@ -303,9 +312,10 @@ def test_missing_aws_admin_includes_dedicated_regions(client, db):
     admin, password = _make_admin_user(db)
     token = _get_token(client, admin.email, password)
 
-    with patch(
-        "app.api.public.LiteLLMService", side_effect=_service_factory
-    ), _patch_catalog_fetch(_upstream_catalog()):
+    with (
+        patch("app.api.public.LiteLLMService", side_effect=_service_factory),
+        _patch_catalog_fetch(_upstream_catalog()),
+    ):
         response = client.get(AWS_PATH, headers={"Authorization": f"Bearer {token}"})
 
     assert response.status_code == 200
@@ -348,9 +358,10 @@ def test_missing_aws_non_admin_excludes_dedicated_regions(client, db):
             raise AssertionError("Dedicated region must not be queried anonymously")
         return service
 
-    with patch(
-        "app.api.public.LiteLLMService", side_effect=_service_factory
-    ), _patch_catalog_fetch(_upstream_catalog()):
+    with (
+        patch("app.api.public.LiteLLMService", side_effect=_service_factory),
+        _patch_catalog_fetch(_upstream_catalog()),
+    ):
         response = client.get(AWS_PATH, headers={"Authorization": f"Bearer {token}"})
 
     assert response.status_code == 200
@@ -367,8 +378,9 @@ def test_missing_aws_handles_unavailable_region(client, db):
     admin, password = _make_admin_user(db, email="unavailable-region-admin@example.com")
     token = _get_token(client, admin.email, password)
 
-    with patch("app.api.public.LiteLLMService") as mock_service_cls, _patch_catalog_fetch(
-        _upstream_catalog()
+    with (
+        patch("app.api.public.LiteLLMService") as mock_service_cls,
+        _patch_catalog_fetch(_upstream_catalog()),
     ):
         mock_service_cls.return_value.get_model_info = AsyncMock(
             side_effect=httpx.ConnectError("boom")
@@ -378,7 +390,9 @@ def test_missing_aws_handles_unavailable_region(client, db):
     assert response.status_code == 200
     by_group = {g["region_group"]: g for g in response.json()["region_groups"]}
     assert by_group["US"]["configured_model_count"] == 0
-    assert by_group["US"]["missing_model_count"] == by_group["US"]["available_model_count"]
+    assert (
+        by_group["US"]["missing_model_count"] == by_group["US"]["available_model_count"]
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -391,8 +405,9 @@ def test_missing_aws_cache_control_is_not_publicly_cacheable(client, db):
     _make_public_region(db, "us-east-1", suffix="us")
     admin, password = _make_admin_user(db, email="cache-header-admin@example.com")
     token = _get_token(client, admin.email, password)
-    with patch("app.api.public.LiteLLMService") as mock_service_cls, _patch_catalog_fetch(
-        _upstream_catalog()
+    with (
+        patch("app.api.public.LiteLLMService") as mock_service_cls,
+        _patch_catalog_fetch(_upstream_catalog()),
     ):
         mock_service_cls.return_value.get_model_info = AsyncMock(
             return_value=_model_info_with_bedrock([])
@@ -400,4 +415,7 @@ def test_missing_aws_cache_control_is_not_publicly_cacheable(client, db):
         response = client.get(AWS_PATH, headers={"Authorization": f"Bearer {token}"})
 
     assert response.status_code == 200
-    assert response.headers["Cache-Control"] == "no-store, no-cache, must-revalidate, private"
+    assert (
+        response.headers["Cache-Control"]
+        == "no-store, no-cache, must-revalidate, private"
+    )

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,8 +1,14 @@
 import pytest
 from fastapi import HTTPException
-from app.core.security import check_sales_or_higher, get_role_min_system_admin
+from types import SimpleNamespace
+
+from app.core.security import (
+    check_sales_or_higher,
+    get_current_user_from_auth,
+    get_role_min_system_admin,
+)
 from app.core.roles import UserRole
-from app.db.models import DBUser
+from app.db.models import DBTeam, DBUser
 
 
 class TestSecurityFunctions:
@@ -52,7 +58,6 @@ class TestSecurityFunctions:
 
         assert exc_info.value.status_code == 403
         assert "Not authorized to perform this action" in str(exc_info.value.detail)
-
     @pytest.mark.asyncio
     async def test_check_sales_or_higher_team_user_denied(self):
         """
@@ -100,3 +105,40 @@ class TestSecurityFunctions:
 
         assert exc_info.value.status_code == 403
         assert "Not authorized to perform this action" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_from_auth_reloads_detached_request_user(db):
+    team = DBTeam(
+        name="Suspended Team",
+        admin_email="suspended@example.com",
+        phone="1234567890",
+        billing_address="123 Test St, Test City, 12345",
+        is_active=False,
+    )
+    db.add(team)
+    db.commit()
+    db.refresh(team)
+
+    user = DBUser(
+        email="suspended-user@example.com",
+        hashed_password="hashed",
+        is_active=True,
+        is_admin=False,
+        team_id=team.id,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    team.deleted_at = user.created_at
+    db.commit()
+
+    db.expunge(user)
+    request = SimpleNamespace(state=SimpleNamespace(user=user))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user_from_auth(db=db, request=request)
+
+    assert exc_info.value.status_code == 403
+    assert "suspended" in exc_info.value.detail.lower()

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -58,6 +58,7 @@ class TestSecurityFunctions:
 
         assert exc_info.value.status_code == 403
         assert "Not authorized to perform this action" in str(exc_info.value.detail)
+
     @pytest.mark.asyncio
     async def test_check_sales_or_higher_team_user_denied(self):
         """

--- a/tests/test_team_retention.py
+++ b/tests/test_team_retention.py
@@ -938,7 +938,10 @@ async def test_restore_soft_deleted_team_integration(
     mock_litellm_class.return_value = mock_service
 
     # Call the function
-    await restore_soft_deleted_team(db, test_team)
+    result = await restore_soft_deleted_team(db, test_team)
+
+    # Verify no LiteLLM provisioning failures
+    assert result["litellm_warnings"] == []
 
     # Verify team was restored
     db.refresh(test_team)

--- a/tests/test_team_retention.py
+++ b/tests/test_team_retention.py
@@ -1304,6 +1304,43 @@ async def test_restore_reprovisions_litellm_team_and_users(
     assert mock_service.add_team_member.call_count == 2
 
 
+@patch("app.core.team_service.LiteLLMService")
+@pytest.mark.asyncio
+async def test_restore_skips_user_reprovision_when_team_create_fails(
+    mock_litellm_class, db: Session, test_team, test_region
+):
+    user1 = DBUser(email="u1@example.com", team_id=test_team.id, is_active=False)
+    user2 = DBUser(email="u2@example.com", team_id=test_team.id, is_active=False)
+    db.add_all([user1, user2])
+    db.commit()
+
+    existing = (
+        db.query(DBTeamRegion)
+        .filter(
+            DBTeamRegion.team_id == test_team.id,
+            DBTeamRegion.region_id == test_region.id,
+        )
+        .first()
+    )
+    if not existing:
+        db.add(DBTeamRegion(team_id=test_team.id, region_id=test_region.id))
+        db.commit()
+
+    test_team.deleted_at = datetime.now(UTC)
+    db.commit()
+
+    mock_service = AsyncMock()
+    mock_service.create_team.side_effect = RuntimeError("boom")
+    mock_litellm_class.return_value = mock_service
+
+    result = await restore_soft_deleted_team(db, test_team)
+
+    assert result["litellm_warnings"] == [test_region.name]
+    mock_service.create_team.assert_called_once()
+    mock_service.create_user.assert_not_called()
+    mock_service.add_team_member.assert_not_called()
+
+
 # ── Orphan detection tests ────────────────────────────────────────────────────
 
 

--- a/tests/test_team_retention.py
+++ b/tests/test_team_retention.py
@@ -4,7 +4,9 @@ from unittest.mock import Mock, patch, AsyncMock
 from sqlalchemy.orm import Session
 
 from app.db.models import (
+    DBAuditLog,
     DBTeam,
+    DBTeamRegion,
     DBUser,
     DBPrivateAIKey,
     DBTeamProduct,
@@ -16,6 +18,7 @@ from app.core.worker import (
     _calculate_last_team_activity,
     _send_retention_warning,
     _check_team_retention_policy,
+    hard_delete_expired_teams,
 )
 from app.core.team_service import (
     soft_delete_team,
@@ -955,6 +958,11 @@ async def test_restore_soft_deleted_team_integration(
         litellm_token="token2", duration="30d"
     )
 
+    # Verify LiteLLM team and users were re-provisioned
+    mock_service.create_team.assert_called_once()
+    assert mock_service.create_user.call_count == 2
+    assert mock_service.add_team_member.call_count == 2
+
 
 @patch("app.core.team_service.LiteLLMService")
 @pytest.mark.asyncio
@@ -1148,3 +1156,179 @@ def test_get_team_keys_by_region_skips_keys_without_token(
     region_keys = keys_by_region[test_region]
     assert len(region_keys) == 1
     assert region_keys[0].name == "with-token"
+
+
+# ── Audit trail tests ──────────────────────────────────────────────────────────
+
+
+@patch("app.core.team_service.LiteLLMService")
+@pytest.mark.asyncio
+async def test_soft_delete_team_writes_audit_log(
+    mock_litellm_class, db: Session, test_team
+):
+    """
+    Given: A team
+    When: Calling soft_delete_team()
+    Then: A WORKER/team.soft_delete audit log entry is created
+    """
+    mock_litellm_class.return_value = AsyncMock()
+    test_time = datetime.now(UTC)
+
+    await soft_delete_team(db, test_team, test_time)
+
+    audit = (
+        db.query(DBAuditLog)
+        .filter(
+            DBAuditLog.resource_id == str(test_team.id),
+            DBAuditLog.action == "team.soft_delete",
+        )
+        .first()
+    )
+    assert audit is not None
+    assert audit.event_type == "WORKER"
+    assert audit.resource_type == "team"
+    assert audit.user_id is None
+    assert audit.details["team_name"] == test_team.name
+
+
+@patch("app.core.team_service.LiteLLMService")
+@pytest.mark.asyncio
+async def test_restore_soft_deleted_team_writes_audit_log(
+    mock_litellm_class, db: Session, test_team
+):
+    """
+    Given: A soft-deleted team
+    When: Calling restore_soft_deleted_team()
+    Then: A WORKER/team.restore audit log entry is created
+    """
+    mock_litellm_class.return_value = AsyncMock()
+    test_team.deleted_at = datetime.now(UTC)
+    db.commit()
+
+    await restore_soft_deleted_team(db, test_team)
+
+    audit = (
+        db.query(DBAuditLog)
+        .filter(
+            DBAuditLog.resource_id == str(test_team.id),
+            DBAuditLog.action == "team.restore",
+        )
+        .first()
+    )
+    assert audit is not None
+    assert audit.event_type == "WORKER"
+    assert audit.resource_type == "team"
+    assert audit.user_id is None
+
+
+@patch("app.core.worker.LiteLLMService")
+@pytest.mark.asyncio
+async def test_hard_delete_writes_audit_log(mock_litellm, db: Session, test_team):
+    """
+    Given: A team that was soft-deleted 91 days ago
+    When: Running the hard delete job
+    Then: A WORKER/team.hard_delete audit log entry is created (keyed by team ID string)
+    """
+    mock_litellm.return_value = AsyncMock()
+    team_id_str = str(test_team.id)
+    soft_delete_team_for_test(
+        db, test_team, deleted_at=datetime.now(UTC) - timedelta(days=91)
+    )
+
+    await hard_delete_expired_teams(db)
+
+    audit = (
+        db.query(DBAuditLog)
+        .filter(
+            DBAuditLog.resource_id == team_id_str,
+            DBAuditLog.action == "team.hard_delete",
+        )
+        .first()
+    )
+    assert audit is not None
+    assert audit.event_type == "WORKER"
+    assert audit.resource_type == "team"
+    assert audit.user_id is None
+    assert audit.details["team_name"] == test_team.name
+
+
+# ── Restore re-provisioning tests ─────────────────────────────────────────────
+
+
+@patch("app.core.team_service.LiteLLMService")
+@pytest.mark.asyncio
+async def test_restore_reprovisions_litellm_team_and_users(
+    mock_litellm_class, db: Session, test_team, test_region
+):
+    """
+    Given: A soft-deleted team with users and an associated region
+    When: Calling restore_soft_deleted_team()
+    Then: LiteLLM create_team, create_user, and add_team_member are called
+          for every user in every allowed region
+    """
+    user1 = DBUser(email="u1@example.com", team_id=test_team.id, is_active=False)
+    user2 = DBUser(email="u2@example.com", team_id=test_team.id, is_active=False)
+    db.add_all([user1, user2])
+    db.commit()
+
+    # Associate test_region with the team (the fixture may already do this)
+    existing = (
+        db.query(DBTeamRegion)
+        .filter(
+            DBTeamRegion.team_id == test_team.id,
+            DBTeamRegion.region_id == test_region.id,
+        )
+        .first()
+    )
+    if not existing:
+        db.add(DBTeamRegion(team_id=test_team.id, region_id=test_region.id))
+        db.commit()
+
+    test_team.deleted_at = datetime.now(UTC)
+    db.commit()
+
+    mock_service = AsyncMock()
+    mock_litellm_class.return_value = mock_service
+
+    await restore_soft_deleted_team(db, test_team)
+
+    # LiteLLM team must be (re-)created
+    mock_service.create_team.assert_called_once()
+    # Each user must be (re-)created and added as a member
+    assert mock_service.create_user.call_count == 2
+    assert mock_service.add_team_member.call_count == 2
+
+
+# ── Orphan detection tests ────────────────────────────────────────────────────
+
+
+def test_orphaned_user_gets_403_on_auth_me(
+    client, db, test_team, team_admin_token, test_team_admin
+):
+    """
+    Given: A regular (non-admin) user whose team has been soft-deleted
+    When: They call GET /auth/me
+    Then: They receive 403 with a suspension message (not a confusing 404)
+    """
+    # team_admin_token belongs to test_team and is not is_admin
+    soft_delete_team_for_test(db, test_team)
+
+    response = client.get(
+        "/auth/me", headers={"Authorization": f"Bearer {team_admin_token}"}
+    )
+
+    assert response.status_code == 403
+    assert "suspended" in response.json()["detail"].lower()
+
+
+def test_admin_not_blocked_by_orphan_check(client, admin_token):
+    """
+    Given: A system admin (is_admin=True) with no team
+    When: They call GET /auth/me
+    Then: They receive 200 — admins bypass the orphan check
+    """
+    response = client.get(
+        "/auth/me", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+
+    assert response.status_code == 200

--- a/tests/test_team_retention.py
+++ b/tests/test_team_retention.py
@@ -472,7 +472,9 @@ def test_get_team_denies_deleted_access_for_non_admin(
     """
     Given: A soft-deleted team in the database and a non-admin user
     When: Getting the team with include_deleted=true parameter
-    Then: Should return 404 Not Found (team appears to not exist)
+    Then: Should return 403 Forbidden — auth layer rejects suspended-team users
+          before the endpoint is even reached (not 404, because the check is
+          in get_current_user_from_auth which runs first)
     """
     # Soft delete the team
     db.query(DBTeam).filter(DBTeam.id == test_team.id).update(
@@ -486,8 +488,8 @@ def test_get_team_denies_deleted_access_for_non_admin(
     )
 
     assert (
-        response.status_code == 404
-    )  # Should be not found for non-admin (team appears to not exist)
+        response.status_code == 403
+    )  # Auth layer suspends team users before endpoint logic runs
 
 
 def test_teams_with_products_never_deleted(db: Session, test_team):


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR implements the final stage of the team lifecycle: a daily background job that hard-deletes teams whose `deleted_at` is ≥ 90 days old (raised from 60), with a full FK-safe cascade covering `spend_caps`, `api_tokens`, `user_admin_regions`, audit-log nulling, and `user_spend_cache`. It also gates all API access for users whose team is soft-deleted (403), re-provisions LiteLLM on team restore, and adds audit-log entries for all three lifecycle events.

- **Hard-delete cascade** (`worker.py`): raises threshold to 90 days; adds deletion of `spend_caps`, `api_tokens`, `user_admin_regions`, `user_spend_cache`, and audit-log user_id nulling before deleting users/team; writes a `team.hard_delete` audit entry.
- **Suspension gate** (`security.py`): `_check_user_team_not_suspended` added to every auth path; users of soft-deleted teams receive 403 instead of reaching endpoint logic.
- **Restore re-provisioning** (`team_service.py`): `restore_soft_deleted_team` now re-creates the LiteLLM team and users in each active region and returns a `litellm_warnings` dict; the endpoint surfaces failures as a `warning` field.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The hard-delete and auth-gate logic is well-structured, but an email-case mismatch in the spend-cache cleanup means PII may survive a GDPR erasure, and two auth-path edge cases in security.py could cause unexpected errors under specific conditions.

The spend-cache cleanup queries `normalized_email` (lowercase) using raw `DBUser.email` values that can be mixed-case, so user emails may remain in the cache after a hard delete. In security.py, the API-token path's joinedload is negated by an intervening commit, and the non-dict middleware branch now accesses a relationship on a potentially-detached object without any guard. These issues are concentrated in the two most critical files — the GDPR cleanup worker and the authentication layer.

app/core/worker.py (spend-cache email normalization) and app/core/security.py (API-token joinedload order, non-dict middleware branch) warrant a closer look before merging.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/core/worker.py | Hard-delete threshold raised from 60→90 days; adds cleanup of spend_caps, api_tokens, user_admin_regions, audit_log nulling, and user_spend_cache — but email case mismatch in spend_cache cleanup may leave PII after erasure. |
| app/core/security.py | Adds _check_user_team_not_suspended guard across all auth paths with joinedload for team; joinedload is wasted in the API-token path due to commit before access, and the non-dict middleware path may hit DetachedInstanceError. |
| app/core/team_service.py | restore_soft_deleted_team now re-provisions LiteLLM team/users per region and returns litellm_warnings dict; soft_delete adds audit log; logic is sound but continues user provisioning unnecessarily when team creation fails. |
| app/api/teams.py | restore_team endpoint now surfaces litellm_warnings from the service layer as a response warning field; clean and straightforward change. |
| tests/test_hard_delete.py | New tests cover api_tokens, user_admin_regions, audit log nulling, spend_caps, key spend_caps, and user_spend_cache cleanup; all use lowercase test emails so the email-case mismatch bug is not caught. |
| tests/test_team_retention.py | Updated to reflect 403 (suspended) instead of 404 for soft-deleted team access; adds audit log, re-provisioning, and orphan-detection tests; all correct. |
| Makefile | Refactors test lifecycle: separates test-teardown target, removes port-mapping from postgres container, adds teardown after each test run. |
| README.md | Adds Team Lifecycle & Hard Delete documentation section explaining the three-stage lifecycle, cascade order, restore behaviour, and manual trigger. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Cron: daily 03:00] --> B[hard_delete_expired_teams]
    B --> C{teams with deleted_at >= 90 days?}
    C -- No --> Z[Done]
    C -- Yes --> D[For each eligible team]
    D --> E[1. Delete limited_resources]
    E --> F[2. Delete LiteLLM keys per region]
    F --> G[3. Delete spend_caps]
    G --> H[4. Delete ai_tokens from DB]
    H --> I[5. Delete api_tokens + user_admin_regions]
    I --> J[6. NULL audit_logs.user_id]
    J --> K[7. Delete user_spend_cache]
    K --> L[8. Delete users]
    L --> M[9. Delete team_products + team_regions]
    M --> N[10. Write audit log team.hard_delete]
    N --> O[11. Delete team - cascades team_metrics]
    O --> P[COMMIT]
    P --> D

    subgraph Auth Gate
    Q[Incoming request] --> R[load user + team via joinedload]
    R --> S{team.deleted_at set AND not admin?}
    S -- Yes --> T[403 Suspended]
    S -- No --> U[Allow request]
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: Update README with team lifecycle ..."](https://github.com/amazeeio/amazee.ai/commit/ff68e78349eaa43a66fb4ed6c196d6eac8d30b59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33938937)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->