### PR TITLE
chore: add cli container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,6 @@ RUN apk add --no-cache \
         postgresql16-client \
         procps \
         unzip \
-    && rm -rf /var/cache/apk/* \
     && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \
     && mkdir -p /home/.ssh \
     && fix-permissions /home/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM uselagoon/python-3.12:latest@sha256:5ab457220705f7b4c072ee746b5920779a385a70175e0471b9a263c840ff1070
+# ---------- base ----------
+# Shared foundation: Python deps, app code, and scripts.
+# Both `backend` (the FastAPI service) and `cli` extend this
+# so we install requirements.txt exactly once.
+FROM uselagoon/python-3.12:latest@sha256:5ab457220705f7b4c072ee746b5920779a385a70175e0471b9a263c840ff1070 AS base
 
-RUN apk add bash --no-cache
-RUN apk add curl --no-cache
+RUN apk add --no-cache bash curl
 
 WORKDIR /app
 
@@ -11,6 +14,13 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY app app/
 COPY scripts scripts/
 
+ENV PYTHONPATH=/app
+
+# ---------- backend ----------
+# FastAPI service. This is the default target so existing
+# `docker build .` / Lagoon builds keep working unchanged.
+FROM base AS backend
+
 # Copy Lagoon environment variables
 COPY .lagoon.env .
 
@@ -18,7 +28,37 @@ COPY .lagoon.env .
 RUN mkdir -p /app/logs && \
     chown -R 1000:1000 /app/logs && \
     chmod 775 /app/logs
+
 COPY backend-start.sh .
 RUN chmod +x /app/backend-start.sh
 
 CMD ["/app/backend-start.sh"]
+
+# ---------- cli ----------
+# CLI / migration / DB-restore pod. Adds postgres client tooling
+# (matched to pgvector/pgvector:pg16 server) and the usual CLI niceties.
+FROM base AS cli
+
+ENV LAGOON=cli
+
+RUN apk add --no-cache \
+        coreutils \
+        findutils \
+        git \
+        gzip \
+        openssh-client \
+        openssh-sftp-server \
+        postgresql16-client \
+        procps \
+        unzip \
+    && rm -rf /var/cache/apk/* \
+    && ln -s /usr/lib/ssh/sftp-server /usr/local/bin/sftp-server \
+    && mkdir -p /home/.ssh \
+    && fix-permissions /home/
+
+# Idle shells get killed (matches php-cli/node-cli convention).
+# Guarded because python-3.12 base does not always ship 80-shell-timeout.sh.
+RUN echo "[ -f /lagoon/entrypoints/80-shell-timeout.sh ] && source /lagoon/entrypoints/80-shell-timeout.sh" >> /home/.bashrc
+
+CMD ["/bin/docker-sleep"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,27 +16,10 @@ COPY scripts scripts/
 
 ENV PYTHONPATH=/app
 
-# ---------- backend ----------
-# FastAPI service. This is the default target so existing
-# `docker build .` / Lagoon builds keep working unchanged.
-FROM base AS backend
-
-# Copy Lagoon environment variables
-COPY .lagoon.env .
-
-# Script to initialize the database and start the server
-RUN mkdir -p /app/logs && \
-    chown -R 1000:1000 /app/logs && \
-    chmod 775 /app/logs
-
-COPY backend-start.sh .
-RUN chmod +x /app/backend-start.sh
-
-CMD ["/app/backend-start.sh"]
-
 # ---------- cli ----------
 # CLI / migration / DB-restore pod. Adds postgres client tooling
 # (matched to pgvector/pgvector:pg16 server) and the usual CLI niceties.
+# Built explicitly via `--target cli` (or compose `target: cli`).
 FROM base AS cli
 
 ENV LAGOON=cli
@@ -61,3 +44,21 @@ RUN echo "[ -f /lagoon/entrypoints/80-shell-timeout.sh ] && source /lagoon/entry
 
 CMD ["/bin/docker-sleep"]
 
+# ---------- backend ----------
+# FastAPI service. Kept as the LAST stage so a bare `docker build .`
+# (no --target) builds the backend image, preserving pre-refactor
+# behaviour for CI scripts, IDE integrations, and ad-hoc dev builds.
+FROM base AS backend
+
+# Copy Lagoon environment variables
+COPY .lagoon.env .
+
+# Script to initialize the database and start the server
+RUN mkdir -p /app/logs && \
+    chown -R 1000:1000 /app/logs && \
+    chmod 775 /app/logs
+
+COPY backend-start.sh .
+RUN chmod +x /app/backend-start.sh
+
+CMD ["/app/backend-start.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      target: backend
     environment:
       DATABASE_URL: postgresql://postgres:postgres@postgres/postgres_service
       AMAZEEAI_JWT_SECRET: ${AMAZEEAI_JWT_SECRET}
@@ -35,6 +36,22 @@ services:
         condition: service_healthy
     labels:
       lagoon.type: python
+
+  cli:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: cli
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@postgres/postgres_service
+    volumes:
+      - ./app:/app/app
+      - ./scripts:/app/scripts
+    depends_on:
+      postgres:
+        condition: service_healthy
+    labels:
+      lagoon.type: cli
 
   frontend:
     build:


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR converts the single-stage `Dockerfile` into a three-stage multi-stage build (`base` → `backend`, `base` → `cli`) and wires up a corresponding `cli` service in `docker-compose.yml`, allowing migrations, DB restores, and other CLI work to run in an isolated container that shares the same Python environment as the backend.

- **Dockerfile**: A shared `base` stage installs Python deps once; `backend` extends it unchanged (FastAPI + start script); `cli` extends it with `postgresql16-client`, SSH/SFTP, and other shell tooling, then idles with `/bin/docker-sleep`.
- **docker-compose.yml**: `target: backend` is now explicit for the existing backend service; a new `cli` service targets the cli stage with the `./scripts` volume mounted and a `lagoon.type: cli` label.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the backend build path is functionally unchanged, and the new cli container is additive.

The backend and Lagoon builds are not broken because docker-compose.yml and Lagoon both now explicitly specify their build targets. The main issues are a misleading comment that incorrectly describes the `docker build .` default target, and a redundant `rm -rf /var/cache/apk/*` that has no effect when `--no-cache` is already in use.

The Dockerfile comment on the `backend` stage heading warrants a small correction, but no files require blocking attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Dockerfile | Refactored into a three-stage multi-stage build (base → backend, base → cli). The backend stage is functionally unchanged. The cli stage adds postgres-client tooling, SSH, and uses /bin/docker-sleep as CMD. A misleading comment incorrectly claims `docker build .` builds the backend stage (it would build cli, the last stage), and a redundant `rm -rf /var/cache/apk/*` appears after `--no-cache`. |
| docker-compose.yml | Adds explicit `target: backend` to the existing backend service and introduces a new `cli` service targeting the cli Dockerfile stage, with the appropriate volumes, depends_on, and Lagoon label. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["FROM uselagoon/python-3.12 (base)\n• apk add bash curl\n• pip install requirements.txt\n• COPY app/ scripts/\n• ENV PYTHONPATH=/app"] --> B
    A --> C
    B["backend stage\n• COPY .lagoon.env\n• mkdir /app/logs\n• COPY backend-start.sh\n• CMD /app/backend-start.sh"]
    C["cli stage\n• apk add postgresql16-client, openssh, git...\n• ln -s sftp-server\n• .bashrc shell-timeout guard\n• CMD /bin/docker-sleep"]
    B --> D["docker-compose: backend service\ntarget: backend\nlagoon.type: python"]
    C --> E["docker-compose: cli service\ntarget: cli\nlagoon.type: cli"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add cli container"](https://github.com/amazeeio/amazee.ai/commit/2e2326649c76da242b940f3b3fd216958b6b5791) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33917674)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->