### PR TITLE
CORS error: https://amazee.ai origin blocked on /public/models

### DIFF
--- a/app/api/public.py
+++ b/app/api/public.py
@@ -739,7 +739,7 @@ def _normalize_bedrock_provider_id(
 
     normalized = provider_model_id.split("/", 1)[1]
     if normalized.startswith(provider_prefix):
-        normalized = normalized[len(provider_prefix):]
+        normalized = normalized[len(provider_prefix) :]
     return normalized
 
 
@@ -778,9 +778,7 @@ async def _collect_region_bedrock_models(
         if not isinstance(item, dict):
             continue
         params = item.get("litellm_params") or {}
-        provider_model_id = (
-            params.get("model") if isinstance(params, dict) else None
-        )
+        provider_model_id = params.get("model") if isinstance(params, dict) else None
         if not isinstance(provider_model_id, str) or not provider_model_id:
             continue
 
@@ -900,8 +898,7 @@ async def list_missing_provider_models(
         raise HTTPException(
             status_code=404,
             detail=(
-                f"Unknown provider '{provider}'. "
-                f"Supported: {sorted(_KNOWN_PROVIDERS)}"
+                f"Unknown provider '{provider}'. Supported: {sorted(_KNOWN_PROVIDERS)}"
             ),
         )
 

--- a/app/main.py
+++ b/app/main.py
@@ -111,6 +111,9 @@ default_origins = [
 
 def _normalize_origin(url: str) -> str:
     parsed = urlparse(url.strip())
+    if not parsed.scheme or not parsed.netloc:
+        logger.warning("Skipping malformed origin (missing scheme/host): %r", url.strip())
+        return ""
     origin = f"{parsed.scheme}://{parsed.netloc}"
     return origin.rstrip("/")
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from contextlib import asynccontextmanager
+from urllib.parse import urlparse
 
 from app.__version__ import __version__
 from app.api import (
@@ -106,15 +107,22 @@ default_origins = [
     "http://localhost:3001",
     "http://localhost:8800",
 ]
+
+
+def _normalize_origin(url: str) -> str:
+    parsed = urlparse(url.strip())
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+    return origin.rstrip("/")
+
+
 lagoon_routes = os.getenv("LAGOON_ROUTES", "").split(",")
 frontend_routes = os.getenv("FRONTEND_ROUTE", "").split(",")
 allowed_origins = default_origins + [
-    route.strip() for route in lagoon_routes if route.strip()
+    _normalize_origin(route) for route in lagoon_routes if route.strip()
 ]
 for route in frontend_routes:
-    route = route.strip()
-    if route:
-        allowed_origins.append(route)
+    if route.strip():
+        allowed_origins.append(_normalize_origin(route))
 
 # Add HTTPS redirect middleware first
 app.add_middleware(HTTPSRedirectMiddleware)

--- a/app/main.py
+++ b/app/main.py
@@ -107,9 +107,14 @@ default_origins = [
     "http://localhost:8800",
 ]
 lagoon_routes = os.getenv("LAGOON_ROUTES", "").split(",")
+frontend_routes = os.getenv("FRONTEND_ROUTE", "").split(",")
 allowed_origins = default_origins + [
     route.strip() for route in lagoon_routes if route.strip()
 ]
+for route in frontend_routes:
+    route = route.strip()
+    if route:
+        allowed_origins.append(route)
 
 # Add HTTPS redirect middleware first
 app.add_middleware(HTTPSRedirectMiddleware)
@@ -256,17 +261,14 @@ def custom_openapi():
                     del operation["parameters"]
 
             # Remove security from non-protected endpoints
-            if (
-                path_name
-                in [
-                    "/auth/login",
-                    "/auth/register",
-                    "/health",
-                    "/auth/generate-trial-access",
-                    "/public/models",
-                    "/public/models/",
-                ]
-            ):
+            if path_name in [
+                "/auth/login",
+                "/auth/register",
+                "/health",
+                "/auth/generate-trial-access",
+                "/public/models",
+                "/public/models/",
+            ]:
                 if "security" in operation:
                     del operation["security"]
 

--- a/scripts/check_missing_models.py
+++ b/scripts/check_missing_models.py
@@ -75,7 +75,9 @@ def save_state(state_file: Path, state: dict[str, Any]) -> None:
     state_file.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
 
 
-def build_diff(report: dict[str, Any], previous_state: dict[str, Any]) -> dict[str, Any]:
+def build_diff(
+    report: dict[str, Any], previous_state: dict[str, Any]
+) -> dict[str, Any]:
     """Compute per-region-group ``new_missing`` vs. ``previous_state`` plus
     the next state to persist.
 
@@ -158,7 +160,9 @@ def write_github_outputs(diff: dict[str, Any]) -> None:
         return
     summary = diff["slack_summary"] or "No new missing models detected."
     with open(output_path, "a", encoding="utf-8") as handle:
-        handle.write(f"has_new_missing={'true' if diff['has_new_missing'] else 'false'}\n")
+        handle.write(
+            f"has_new_missing={'true' if diff['has_new_missing'] else 'false'}\n"
+        )
         handle.write(f"state_changed={'true' if diff['state_changed'] else 'false'}\n")
         handle.write(f"provider={diff.get('provider', '')}\n")
         # JSON-encoded so newlines/quotes are safe to interpolate into a Slack payload.

--- a/tests/test_public_models_missing.py
+++ b/tests/test_public_models_missing.py
@@ -187,8 +187,9 @@ def test_missing_models_provider_lookup_is_case_insensitive(client, db):
     _make_public_region(db, "us-east-1", suffix="us")
     admin, password = _make_admin_user(db, email="case-insensitive-admin@example.com")
     token = _get_token(client, admin.email, password)
-    with patch("app.api.public.LiteLLMService") as mock_service_cls, _patch_catalog_fetch(
-        _upstream_catalog()
+    with (
+        patch("app.api.public.LiteLLMService") as mock_service_cls,
+        _patch_catalog_fetch(_upstream_catalog()),
     ):
         mock_service_cls.return_value.get_model_info = AsyncMock(
             return_value=_model_info_with_bedrock([])
@@ -218,8 +219,9 @@ def test_missing_aws_reports_gaps_per_region_group(client, db):
         ]
     )
 
-    with patch("app.api.public.LiteLLMService") as mock_service_cls, _patch_catalog_fetch(
-        _upstream_catalog()
+    with (
+        patch("app.api.public.LiteLLMService") as mock_service_cls,
+        _patch_catalog_fetch(_upstream_catalog()),
     ):
         mock_service_cls.return_value.get_model_info = AsyncMock(return_value=deployed)
         response = client.get(AWS_PATH, headers={"Authorization": f"Bearer {token}"})
@@ -249,8 +251,12 @@ def test_missing_aws_reports_gaps_per_region_group(client, db):
             assert m["model_id"] != "legacy.dont-show-me"
 
     # EU and AU have no contributing regions, so everything available is "missing".
-    assert by_group["EU"]["missing_model_count"] == by_group["EU"]["available_model_count"]
-    assert by_group["AU"]["missing_model_count"] == by_group["AU"]["available_model_count"]
+    assert (
+        by_group["EU"]["missing_model_count"] == by_group["EU"]["available_model_count"]
+    )
+    assert (
+        by_group["AU"]["missing_model_count"] == by_group["AU"]["available_model_count"]
+    )
 
 
 def test_missing_aws_ignores_non_bedrock_providers(client, db):
@@ -269,8 +275,9 @@ def test_missing_aws_ignores_non_bedrock_providers(client, db):
         ]
     )
 
-    with patch("app.api.public.LiteLLMService") as mock_service_cls, _patch_catalog_fetch(
-        _upstream_catalog()
+    with (
+        patch("app.api.public.LiteLLMService") as mock_service_cls,
+        _patch_catalog_fetch(_upstream_catalog()),
     ):
         mock_service_cls.return_value.get_model_info = AsyncMock(return_value=deployed)
         response = client.get(AWS_PATH, headers={"Authorization": f"Bearer {token}"})
@@ -288,7 +295,9 @@ def test_missing_aws_admin_includes_dedicated_regions(client, db):
     dedicated_region = _make_dedicated_region(db, "us-east-private", suffix="us-priv")
 
     public_deployed = _model_info_with_bedrock(["bedrock/us.amazon.nova-pro-v1:0"])
-    private_deployed = _model_info_with_bedrock(["bedrock/us.anthropic.claude-opus-4-7"])
+    private_deployed = _model_info_with_bedrock(
+        ["bedrock/us.anthropic.claude-opus-4-7"]
+    )
 
     def _service_factory(api_url, api_key):
         service = AsyncMock()
@@ -303,9 +312,10 @@ def test_missing_aws_admin_includes_dedicated_regions(client, db):
     admin, password = _make_admin_user(db)
     token = _get_token(client, admin.email, password)
 
-    with patch(
-        "app.api.public.LiteLLMService", side_effect=_service_factory
-    ), _patch_catalog_fetch(_upstream_catalog()):
+    with (
+        patch("app.api.public.LiteLLMService", side_effect=_service_factory),
+        _patch_catalog_fetch(_upstream_catalog()),
+    ):
         response = client.get(AWS_PATH, headers={"Authorization": f"Bearer {token}"})
 
     assert response.status_code == 200
@@ -348,9 +358,10 @@ def test_missing_aws_non_admin_excludes_dedicated_regions(client, db):
             raise AssertionError("Dedicated region must not be queried anonymously")
         return service
 
-    with patch(
-        "app.api.public.LiteLLMService", side_effect=_service_factory
-    ), _patch_catalog_fetch(_upstream_catalog()):
+    with (
+        patch("app.api.public.LiteLLMService", side_effect=_service_factory),
+        _patch_catalog_fetch(_upstream_catalog()),
+    ):
         response = client.get(AWS_PATH, headers={"Authorization": f"Bearer {token}"})
 
     assert response.status_code == 200
@@ -367,8 +378,9 @@ def test_missing_aws_handles_unavailable_region(client, db):
     admin, password = _make_admin_user(db, email="unavailable-region-admin@example.com")
     token = _get_token(client, admin.email, password)
 
-    with patch("app.api.public.LiteLLMService") as mock_service_cls, _patch_catalog_fetch(
-        _upstream_catalog()
+    with (
+        patch("app.api.public.LiteLLMService") as mock_service_cls,
+        _patch_catalog_fetch(_upstream_catalog()),
     ):
         mock_service_cls.return_value.get_model_info = AsyncMock(
             side_effect=httpx.ConnectError("boom")
@@ -378,7 +390,9 @@ def test_missing_aws_handles_unavailable_region(client, db):
     assert response.status_code == 200
     by_group = {g["region_group"]: g for g in response.json()["region_groups"]}
     assert by_group["US"]["configured_model_count"] == 0
-    assert by_group["US"]["missing_model_count"] == by_group["US"]["available_model_count"]
+    assert (
+        by_group["US"]["missing_model_count"] == by_group["US"]["available_model_count"]
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -391,8 +405,9 @@ def test_missing_aws_cache_control_is_not_publicly_cacheable(client, db):
     _make_public_region(db, "us-east-1", suffix="us")
     admin, password = _make_admin_user(db, email="cache-header-admin@example.com")
     token = _get_token(client, admin.email, password)
-    with patch("app.api.public.LiteLLMService") as mock_service_cls, _patch_catalog_fetch(
-        _upstream_catalog()
+    with (
+        patch("app.api.public.LiteLLMService") as mock_service_cls,
+        _patch_catalog_fetch(_upstream_catalog()),
     ):
         mock_service_cls.return_value.get_model_info = AsyncMock(
             return_value=_model_info_with_bedrock([])
@@ -400,4 +415,7 @@ def test_missing_aws_cache_control_is_not_publicly_cacheable(client, db):
         response = client.get(AWS_PATH, headers={"Authorization": f"Bearer {token}"})
 
     assert response.status_code == 200
-    assert response.headers["Cache-Control"] == "no-store, no-cache, must-revalidate, private"
+    assert (
+        response.headers["Cache-Control"]
+        == "no-store, no-cache, must-revalidate, private"
+    )


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a CORS error that blocked requests from the `https://amazee.ai` origin on `/public/models` by normalizing route URLs to `scheme://host` form before adding them to the CORS allow-list, and by introducing a new `FRONTEND_ROUTE` env var alongside the existing `LAGOON_ROUTES` one.

- `_normalize_origin()` is added to strip any path component from Lagoon/frontend route URLs using `urlparse`, ensuring the values fed to `CORSMiddleware` are proper origins rather than full URLs with paths.
- `FRONTEND_ROUTE` (already tracked in `Settings`) is now also read in `main.py` and its normalised value appended to `allowed_origins`, filling the gap that caused the reported CORS rejection.
- All other changes across `app/api/public.py`, `scripts/check_missing_models.py`, and `tests/test_public_models_missing.py` are formatting-only (line-length, parenthesised context-managers).
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the CORS fix is correct and well-scoped; only app/main.py carries substantive logic changes.

_normalize_origin silently accepts scheme-less inputs and produces a "://" string that is appended to allowed_origins without any warning or filter guard. This doesn't break CORS at runtime (browsers never match that string) but it means misconfigured env vars will go completely unnoticed. The fix itself — stripping paths from route URLs — is the right approach and directly addresses the reported issue.

app/main.py — specifically the _normalize_origin helper and the two call sites that build allowed_origins.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/main.py | Core CORS fix: adds _normalize_origin() to strip paths from URLs, reads a new FRONTEND_ROUTE env var, and applies normalization to both lagoon and frontend routes. One edge case: scheme-less URLs produce a silent "://" entry. |
| app/api/public.py | Whitespace/formatting only — no logic changes. |
| scripts/check_missing_models.py | Formatting only — line-length fixes, no logic changes. |
| tests/test_public_models_missing.py | Test formatting only — context-manager syntax updated to parenthesised form, assertion line-length fixes. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Browser as Browser (https://amazee.ai)
    participant CORS as CORSMiddleware
    participant App as FastAPI App

    Note over CORS: allowed_origins built at startup<br/>from LAGOON_ROUTES + FRONTEND_ROUTE<br/>via _normalize_origin()

    Browser->>CORS: "OPTIONS /public/models<br/>Origin: https://amazee.ai"
    CORS->>CORS: Check Origin against allowed_origins
    alt Before fix (full URL with path in list)
        CORS-->>Browser: 403 / missing CORS headers
    else After fix (normalized to scheme://host)
        CORS->>App: Forward preflight
        App-->>CORS: 200 OK
        CORS-->>Browser: 200 + Access-Control-Allow-Origin: https://amazee.ai
    end

    Browser->>CORS: "GET /public/models<br/>Origin: https://amazee.ai"
    CORS->>App: Forward request
    App-->>CORS: 200 + JSON
    CORS-->>Browser: 200 + Access-Control-Allow-Origin: https://amazee.ai
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Normalize CORS origins via urlparse to s..."](https://github.com/amazeeio/amazee.ai/commit/74d0873eb8e3b5951704b6df8a85537bc3e7ab73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34153632)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->