### PR TITLE
refactor: Simplify origin normalization and enhance components with r…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
+- None yet.
+
+### Fixes
+
+- None yet.
+
+## 0.2.0 - 2026-05-28
+
+### Features
+
 - **Spend Snapshots**: Store spend snapshots for historical tracking (#488)
 - **Dedicated Regions**: Add script to convert dedicated regions to public (#485)
 - **Dedicated Regions Logging**: Add detailed logging for region conversion phases (#491)
@@ -27,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Key Creation Spend Cap**: Fix key creation and spend cap issues (#477)
 - **Spend Cap Deletion**: Pass `team_id` and `user_id` to `_delete_spend_cap` in clear key budget (#471)
 - **Key Deletion**: Add error handling and remove dependent spend caps on key deletion (#462)
+- **CORS Origins**: Exclude malformed origins from CORS allowed origins instead of appending empty entries (#532)
+- **Spend Loading**: Reuse cached regions data to avoid duplicate `/regions` requests when loading key spend (#532)
 
 ### Changed
 

--- a/app/main.py
+++ b/app/main.py
@@ -112,7 +112,9 @@ default_origins = [
 def _normalize_origin(url: str) -> str:
     parsed = urlparse(url.strip())
     if not parsed.scheme or not parsed.netloc:
-        logger.warning("Skipping malformed origin (missing scheme/host): %r", url.strip())
+        logger.warning(
+            "Skipping malformed origin (missing scheme/host): %r", url.strip()
+        )
         return ""
     origin = f"{parsed.scheme}://{parsed.netloc}"
     return origin.rstrip("/")
@@ -121,11 +123,15 @@ def _normalize_origin(url: str) -> str:
 lagoon_routes = os.getenv("LAGOON_ROUTES", "").split(",")
 frontend_routes = os.getenv("FRONTEND_ROUTE", "").split(",")
 allowed_origins = default_origins + [
-    _normalize_origin(route) for route in lagoon_routes if route.strip()
+    normalized
+    for route in lagoon_routes
+    if route.strip() and (normalized := _normalize_origin(route))
 ]
 for route in frontend_routes:
     if route.strip():
-        allowed_origins.append(_normalize_origin(route))
+        normalized = _normalize_origin(route)
+        if normalized:
+            allowed_origins.append(normalized)
 
 # Add HTTPS redirect middleware first
 app.add_middleware(HTTPSRedirectMiddleware)

--- a/frontend/src/app/admin/private-ai-keys/page.tsx
+++ b/frontend/src/app/admin/private-ai-keys/page.tsx
@@ -119,6 +119,7 @@ export default function PrivateAIKeysPage() {
         showOwner={true}
         teamDetails={teamDetails}
         teamMembers={teamMembers}
+        regions={regions}
       />
     </div>
   );

--- a/frontend/src/app/private-ai-keys/page.tsx
+++ b/frontend/src/app/private-ai-keys/page.tsx
@@ -179,6 +179,7 @@ export default function DashboardPage() {
         isDeleting={deleteKeyMutation.isPending}
         teamDetails={teamDetails}
         teamMembers={teamMembers}
+        regions={regions}
       />
 
       {privateAIKeys.length === 0 && (

--- a/frontend/src/app/team-admin/private-ai-keys/page.tsx
+++ b/frontend/src/app/team-admin/private-ai-keys/page.tsx
@@ -135,6 +135,7 @@ export default function TeamAIKeysPage() {
         showOwner={true}
         teamDetails={teamDetails}
         teamMembers={teamMembers}
+        regions={regions}
       />
     </div>
   );

--- a/frontend/src/components/private-ai-key-spend-cell.tsx
+++ b/frontend/src/components/private-ai-key-spend-cell.tsx
@@ -41,7 +41,11 @@ export function PrivateAIKeySpendCell({
   const [isLoaded, setIsLoaded] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
+  const matchedRegion =
+    teamId && region ? regions.find((r) => r.name === region) : undefined;
+
   // Query for spend data - only enabled when isLoaded is true
+  // For team keys, also wait until the region can be resolved from the regions list
   const {
     data: spendData,
     isLoading,
@@ -49,20 +53,17 @@ export function PrivateAIKeySpendCell({
   } = useQuery<SpendInfo>({
     queryKey: ["private-ai-key-spend", keyId, region, teamId, regions.map((r) => r.id)],
     queryFn: async () => {
-      if (teamId && region) {
-        const matchedRegion = regions.find((r) => r.name === region);
-        if (matchedRegion) {
-          const response = await get(
-            `spend/${matchedRegion.id}/team/${teamId}`,
-          );
-          return response.json();
-        }
+      if (teamId && region && matchedRegion) {
+        const response = await get(
+          `spend/${matchedRegion.id}/team/${teamId}`,
+        );
+        return response.json();
       }
       // Fallback for keys without team_id
       const response = await get(`private-ai-keys/${keyId}/spend`);
       return response.json();
     },
-    enabled: isLoaded,
+    enabled: isLoaded && (!(teamId && region) || !!matchedRegion),
   });
 
   const handleLoadSpend = () => {

--- a/frontend/src/components/private-ai-key-spend-cell.tsx
+++ b/frontend/src/components/private-ai-key-spend-cell.tsx
@@ -47,7 +47,7 @@ export function PrivateAIKeySpendCell({
     isLoading,
     refetch,
   } = useQuery<SpendInfo>({
-    queryKey: ["private-ai-key-spend", keyId, region, teamId],
+    queryKey: ["private-ai-key-spend", keyId, region, teamId, regions.map((r) => r.id)],
     queryFn: async () => {
       if (teamId && region) {
         const matchedRegion = regions.find((r) => r.name === region);

--- a/frontend/src/components/private-ai-key-spend-cell.tsx
+++ b/frontend/src/components/private-ai-key-spend-cell.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/tooltip";
 import { get } from "@/utils/api";
 import { useQuery } from "@tanstack/react-query";
+import { Region } from "@/types/region";
 
 interface SpendInfo {
   spend: number;
@@ -27,6 +28,7 @@ interface PrivateAIKeySpendCellProps {
   hasLiteLLMToken: boolean;
   region?: string;
   teamId?: number;
+  regions?: Region[];
 }
 
 export function PrivateAIKeySpendCell({
@@ -34,6 +36,7 @@ export function PrivateAIKeySpendCell({
   hasLiteLLMToken,
   region,
   teamId,
+  regions = [],
 }: PrivateAIKeySpendCellProps) {
   const [isLoaded, setIsLoaded] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -47,12 +50,7 @@ export function PrivateAIKeySpendCell({
     queryKey: ["private-ai-key-spend", keyId, region, teamId],
     queryFn: async () => {
       if (teamId && region) {
-        // Look up region_id from regions list
-        const regionsResponse = await get("regions");
-        const regions = await regionsResponse.json();
-        const matchedRegion = regions.find(
-          (r: { name: string }) => r.name === region,
-        );
+        const matchedRegion = regions.find((r) => r.name === region);
         if (matchedRegion) {
           const response = await get(
             `spend/${matchedRegion.id}/team/${teamId}`,

--- a/frontend/src/components/private-ai-keys-table.tsx
+++ b/frontend/src/components/private-ai-keys-table.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/table";
 import { TableFilters, FilterField } from "@/components/ui/table-filters";
 import { PrivateAIKey } from "@/types/private-ai-key";
+import { Region } from "@/types/region";
 import { User } from "@/types/user";
 
 type SortField = "name" | "region" | "owner" | null;
@@ -32,6 +33,7 @@ interface PrivateAIKeysTableProps {
   isDeleting?: boolean;
   teamDetails?: Record<number, { name: string }>;
   teamMembers?: User[];
+  regions?: Region[];
 }
 
 export function PrivateAIKeysTable({
@@ -43,6 +45,7 @@ export function PrivateAIKeysTable({
   isDeleting = false,
   teamDetails = {},
   teamMembers = [],
+  regions = [],
 }: PrivateAIKeysTableProps) {
   const [showPassword, setShowPassword] = useState<
     Record<number | string, boolean>
@@ -444,6 +447,7 @@ export function PrivateAIKeysTable({
                     hasLiteLLMToken={!!key.litellm_token}
                     region={key.region}
                     teamId={key.team_id}
+                    regions={regions}
                   />
                 </TableCell>
                 {allowModification && (


### PR DESCRIPTION
- Fixing issues for PR `https://github.com/amazeeio/amazee.ai/pull/532` 


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes two independent improvements: it fixes a backend bug where malformed CORS origins (those returning an empty string from `_normalize_origin`) could be silently added to `allowed_origins`, and it eliminates redundant per-row API calls by lifting the regions fetch out of `PrivateAIKeySpendCell` into the parent pages and threading it down as a prop.

- **`app/main.py`**: Both the list comprehension (via walrus operator) and the for-loop now skip any `_normalize_origin` result that is an empty string, preventing `""` from ever entering the CORS allow-list.
- **`private-ai-key-spend-cell.tsx`**: The internal `GET /regions` call inside the React Query `queryFn` is replaced by a `regions` prop, avoiding N redundant network requests (one per row per "Load Spend" click). The `regions` value is now fetched once per page via `usePrivateAIKeysData` and passed down through `PrivateAIKeysTable` to each cell.
- **Three page files**: Each gains `regions={regions}` on `<PrivateAIKeysTable>` to wire up the new prop.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after addressing the queryKey issue in the spend cell; all other changes are straightforward wiring or a genuine bug fix.

The spend cell's queryFn closes over regions but regions is absent from the queryKey. If a user clicks Load Spend before the regions query resolves, React Query will cache the result of the wrong endpoint permanently for that key — team-owned keys would show per-key spend instead of shared team spend. The Python CORS fix and the prop-threading changes are clean and correct.

frontend/src/components/private-ai-key-spend-cell.tsx — the queryKey needs to include the resolved region IDs to prevent stale spend data from being cached when regions haven't loaded yet.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/main.py | Fixes a silent bug where `_normalize_origin` returning `""` could add empty strings to `allowed_origins`; both list comprehension (walrus operator) and for-loop paths are now correct. |
| frontend/src/components/private-ai-key-spend-cell.tsx | Refactored to accept `regions` as a prop instead of fetching it per-cell; `regions` is used in the `queryFn` closure but is not included in `queryKey`, which can cause stale data to be served if the user loads spend before regions resolve. |
| frontend/src/components/private-ai-keys-table.tsx | Adds `regions` prop and threads it down to each `PrivateAIKeySpendCell`; no logic changes. |
| frontend/src/app/private-ai-keys/page.tsx | Adds `regions={regions}` prop to `PrivateAIKeysTable`; straightforward wiring change. |
| frontend/src/app/admin/private-ai-keys/page.tsx | Adds `regions={regions}` prop to `PrivateAIKeysTable`; straightforward wiring change. |
| frontend/src/app/team-admin/private-ai-keys/page.tsx | Adds `regions={regions}` prop to `PrivateAIKeysTable`; straightforward wiring change. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Page as Page (admin/user/team-admin)
    participant Hook as usePrivateAIKeysData
    participant Table as PrivateAIKeysTable
    participant Cell as PrivateAIKeySpendCell
    participant API as Backend API

    Page->>Hook: usePrivateAIKeysData(keys, ...)
    Hook->>API: GET /regions
    API-->>Hook: Region[]
    Hook-->>Page: "{ teamDetails, teamMembers, regions }"

    Page->>Table: "PrivateAIKeysTable regions={regions}"
    Table->>Cell: "PrivateAIKeySpendCell regions={regions}"

    Note over Cell: User clicks Load Spend
    alt regions loaded and teamId + region present
        Cell->>Cell: "regions.find(r => r.name === region)"
        Cell->>API: "GET /spend/{regionId}/team/{teamId}"
        API-->>Cell: SpendInfo
    else regions empty or no teamId
        Cell->>API: "GET /private-ai-keys/{keyId}/spend"
        API-->>Cell: SpendInfo
    end
    Cell-->>Table: render spend data
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: Simplify origin normalization ..."](https://github.com/amazeeio/amazee.ai/commit/f0004aa70d98ea66bc24b8583abbb298308c5f20) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34306091)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->