### PR TITLE
chore: fix load spend button

### DIFF
--- a/frontend/src/app/admin/teams/_components/team-expansion-row.tsx
+++ b/frontend/src/app/admin/teams/_components/team-expansion-row.tsx
@@ -35,6 +35,7 @@ import { SpendInfo } from "@/types/spend";
 import { Team } from "@/types/team";
 import { User } from "@/types/user";
 import { get } from "@/utils/api";
+import { mapTeamSpendToSpendInfo } from "@/utils/spend-mapping";
 import { useQuery } from "@tanstack/react-query";
 
 interface TeamExpansionRowProps {
@@ -159,12 +160,7 @@ export function TeamExpansionRow({
               `/spend/${matchedRegion.id}/team/${teamId}`,
             );
             const data = await response.json();
-            // Map TeamSpendResponse to SpendInfo
-            const spendInfo = {
-              ...data,
-              spend: data.total_spend ?? 0,
-              max_budget: data.total_budget,
-            };
+            const spendInfo = mapTeamSpendToSpendInfo(data);
             for (const keyId of keyIds) {
               spendData[keyId.toString()] = spendInfo;
             }

--- a/frontend/src/app/admin/teams/_components/team-expansion-row.tsx
+++ b/frontend/src/app/admin/teams/_components/team-expansion-row.tsx
@@ -158,7 +158,13 @@ export function TeamExpansionRow({
             const response = await get(
               `/spend/${matchedRegion.id}/team/${teamId}`,
             );
-            const spendInfo = await response.json();
+            const data = await response.json();
+            // Map TeamSpendResponse to SpendInfo
+            const spendInfo = {
+              ...data,
+              spend: data.total_spend ?? 0,
+              max_budget: data.total_budget,
+            };
             for (const keyId of keyIds) {
               spendData[keyId.toString()] = spendInfo;
             }

--- a/frontend/src/app/admin/users/_components/user-expansion-row.tsx
+++ b/frontend/src/app/admin/users/_components/user-expansion-row.tsx
@@ -15,6 +15,7 @@ import { PrivateAIKey } from "@/types/private-ai-key";
 import { Region } from "@/types/region";
 import { SpendInfo } from "@/types/spend";
 import { get, post } from "@/utils/api";
+import { mapTeamSpendToSpendInfo } from "@/utils/spend-mapping";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 interface UserExpansionRowProps {
@@ -91,12 +92,7 @@ export function UserExpansionRow({
               `/spend/${matchedRegion.id}/team/${teamId}`,
             );
             const data = await response.json();
-            // Map TeamSpendResponse to SpendInfo
-            const spendInfo = {
-              ...data,
-              spend: data.total_spend ?? 0,
-              max_budget: data.total_budget,
-            };
+            const spendInfo = mapTeamSpendToSpendInfo(data);
             for (const keyId of keyIds) {
               spendData[keyId.toString()] = spendInfo;
             }

--- a/frontend/src/app/admin/users/_components/user-expansion-row.tsx
+++ b/frontend/src/app/admin/users/_components/user-expansion-row.tsx
@@ -90,7 +90,13 @@ export function UserExpansionRow({
             const response = await get(
               `/spend/${matchedRegion.id}/team/${teamId}`,
             );
-            const spendInfo = await response.json();
+            const data = await response.json();
+            // Map TeamSpendResponse to SpendInfo
+            const spendInfo = {
+              ...data,
+              spend: data.total_spend ?? 0,
+              max_budget: data.total_budget,
+            };
             for (const keyId of keyIds) {
               spendData[keyId.toString()] = spendInfo;
             }

--- a/frontend/src/components/private-ai-key-spend-cell.tsx
+++ b/frontend/src/components/private-ai-key-spend-cell.tsx
@@ -12,16 +12,7 @@ import {
 import { get } from "@/utils/api";
 import { useQuery } from "@tanstack/react-query";
 import { Region } from "@/types/region";
-
-interface SpendInfo {
-  spend: number;
-  expires: string;
-  created_at: string;
-  updated_at: string;
-  max_budget: number | null;
-  budget_duration: string | null;
-  budget_reset_at: string | null;
-}
+import { SpendInfo } from "@/types/spend";
 
 interface PrivateAIKeySpendCellProps {
   keyId: number;

--- a/frontend/src/components/private-ai-key-spend-cell.tsx
+++ b/frontend/src/components/private-ai-key-spend-cell.tsx
@@ -57,7 +57,13 @@ export function PrivateAIKeySpendCell({
         const response = await get(
           `spend/${matchedRegion.id}/team/${teamId}`,
         );
-        return response.json();
+        const data = await response.json();
+        // Map TeamSpendResponse to SpendInfo
+        return {
+          ...data,
+          spend: data.total_spend ?? 0,
+          max_budget: data.total_budget,
+        };
       }
       // Fallback for keys without team_id
       const response = await get(`private-ai-keys/${keyId}/spend`);

--- a/frontend/src/components/private-ai-key-spend-cell.tsx
+++ b/frontend/src/components/private-ai-key-spend-cell.tsx
@@ -10,6 +10,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { get } from "@/utils/api";
+import { mapTeamSpendToSpendInfo } from "@/utils/spend-mapping";
 import { useQuery } from "@tanstack/react-query";
 import { Region } from "@/types/region";
 import { SpendInfo } from "@/types/spend";
@@ -49,12 +50,7 @@ export function PrivateAIKeySpendCell({
           `spend/${matchedRegion.id}/team/${teamId}`,
         );
         const data = await response.json();
-        // Map TeamSpendResponse to SpendInfo
-        return {
-          ...data,
-          spend: data.total_spend ?? 0,
-          max_budget: data.total_budget,
-        };
+        return mapTeamSpendToSpendInfo(data);
       }
       // Fallback for keys without team_id
       const response = await get(`private-ai-keys/${keyId}/spend`);

--- a/frontend/src/hooks/use-private-ai-keys-data.ts
+++ b/frontend/src/hooks/use-private-ai-keys-data.ts
@@ -3,6 +3,7 @@ import { Region } from "@/types/region";
 import { SpendInfo } from "@/types/spend";
 import { User } from "@/types/user";
 import { get } from "@/utils/api";
+import { mapTeamSpendToSpendInfo } from "@/utils/spend-mapping";
 import { useQuery } from "@tanstack/react-query";
 
 export function usePrivateAIKeysData(
@@ -45,11 +46,21 @@ export function usePrivateAIKeysData(
     },
   });
 
+  // Fetch regions
+  const { data: regions = [] } = useQuery<Region[]>({
+    queryKey: ["regions"],
+    queryFn: async () => {
+      const response = await get("regions");
+      const data = await response.json();
+      return data;
+    },
+  });
+
   // Query to get spend information for loaded keys
   // Fetches per team+region combo for keys with team_id, old endpoint for others
   const loadedSpendKeysArray = Array.from(loadedSpendKeys).sort();
   const { data: spendMap = {} } = useQuery<Record<number, SpendInfo>>({
-    queryKey: ["private-ai-keys-spend", loadedSpendKeysArray],
+    queryKey: ["private-ai-keys-spend", loadedSpendKeysArray, regions.map(r => r.id)],
     queryFn: async () => {
       const loadedKeys = keys.filter((k) => loadedSpendKeys.has(k.id));
 
@@ -86,7 +97,8 @@ export function usePrivateAIKeysData(
             const response = await get(
               `spend/${matchedRegion.id}/team/${teamId}`,
             );
-            const spendInfo: SpendInfo = await response.json();
+            const data = await response.json();
+            const spendInfo = mapTeamSpendToSpendInfo(data);
             // Assign same team spend to all keys in this combo
             for (const keyId of keyIds) {
               result[keyId] = spendInfo;
@@ -104,17 +116,7 @@ export function usePrivateAIKeysData(
       await Promise.all([...teamSpendPromises, ...noTeamPromises]);
       return result;
     },
-    enabled: loadedSpendKeysArray.length > 0,
-  });
-
-  // Fetch regions
-  const { data: regions = [] } = useQuery<Region[]>({
-    queryKey: ["regions"],
-    queryFn: async () => {
-      const response = await get("regions");
-      const data = await response.json();
-      return data;
-    },
+    enabled: loadedSpendKeysArray.length > 0 && regions.length > 0,
   });
 
   return {

--- a/frontend/src/types/spend.ts
+++ b/frontend/src/types/spend.ts
@@ -1,8 +1,8 @@
 export interface SpendInfo {
   spend: number;
-  expires: string;
-  created_at: string;
-  updated_at: string;
+  expires?: string;
+  created_at?: string;
+  updated_at?: string;
   max_budget: number | null;
   budget_duration: string | null;
   budget_reset_at: string | null;

--- a/frontend/src/utils/spend-mapping.ts
+++ b/frontend/src/utils/spend-mapping.ts
@@ -1,0 +1,14 @@
+import { SpendInfo } from "@/types/spend";
+
+/**
+ * Maps a team spend response (TeamSpendResponse) to the SpendInfo interface.
+ * TeamSpendResponse uses total_spend and total_budget, while SpendInfo
+ * uses spend and max_budget.
+ */
+export function mapTeamSpendToSpendInfo(data: any): SpendInfo {
+  return {
+    ...data,
+    spend: data.total_spend ?? 0,
+    max_budget: data.total_budget ?? null,
+  };
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the "Load Spend" button for team-based AI keys by mapping the team spend API response shape (`total_spend`, `total_budget`) to the `SpendInfo` interface fields (`spend`, `max_budget`) expected by the frontend, and makes `expires`, `created_at`, and `updated_at` optional in the shared type since the team endpoint does not return them.

- The mapping (`total_spend ?? 0` → `spend`, `total_budget` → `max_budget`) is applied consistently in all three call sites: `team-expansion-row.tsx`, `user-expansion-row.tsx`, and `private-ai-key-spend-cell.tsx`.
- `SpendInfo` in `@/types/spend.ts` correctly marks the three per-key-only fields as optional to accommodate both the team and per-key spend endpoints.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The core fix is correct and consistent across all three call sites; one local interface copy in `private-ai-key-spend-cell.tsx` was not updated alongside the shared type.

The mapping logic (`total_spend ?? 0`, `total_budget`) is applied identically in all three affected files and the runtime display behaviour should work correctly. The only issue is that the local `SpendInfo` interface in `private-ai-key-spend-cell.tsx` still marks `expires`, `created_at`, and `updated_at` as required non-optional strings — the exact fields that were made optional in the shared type this PR updates. In a TypeScript strict build this mismatch between the local interface and the team-endpoint return value could surface as a compile-time error.

frontend/src/components/private-ai-key-spend-cell.tsx — its local SpendInfo interface was not updated to match the shared type change.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/types/spend.ts | Makes `expires`, `created_at`, and `updated_at` optional to match the team spend endpoint's response shape — a correct, minimal change. |
| frontend/src/app/admin/teams/_components/team-expansion-row.tsx | Maps `total_spend`/`total_budget` from the team spend response to `spend`/`max_budget` before storing in `spendMap`; uses the shared `SpendInfo` import correctly. |
| frontend/src/app/admin/users/_components/user-expansion-row.tsx | Applies the same `total_spend`/`total_budget` mapping as the team row; uses the shared `SpendInfo` import correctly. |
| frontend/src/components/private-ai-key-spend-cell.tsx | Applies the correct team spend mapping, but the local `SpendInfo` interface still marks `expires`, `created_at`, and `updated_at` as required strings — inconsistent with the shared type update and with what the team endpoint actually returns. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Frontend Component
    participant API as Backend API
    UI->>API: "GET /spend/{regionId}/team/{teamId}"
    API-->>UI: "{ total_spend, total_budget, ... }"
    Note over UI: Map response:<br/>spend = total_spend ?? 0<br/>max_budget = total_budget
    UI->>UI: Render spend / budget display
    UI->>API: "GET /private-ai-keys/{keyId}/spend (fallback, no team)"
    API-->>UI: "{ spend, max_budget, expires, created_at, updated_at, ... }"
    UI->>UI: Use response directly (no mapping needed)
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `frontend/src/components/private-ai-key-spend-cell.tsx`, line 16-24 ([link](https://github.com/amazeeio/amazee.ai/blob/c9d4f25aa63a587cebdce1a9ad7b10c3e5569a02/frontend/src/components/private-ai-key-spend-cell.tsx#L16-L24)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> The local `SpendInfo` interface still declares `expires`, `created_at`, and `updated_at` as required `string` fields, while the shared type in `@/types/spend.ts` was updated in this same PR to make them optional. When the team spend path returns a response that doesn't include these fields, the object returned by `queryFn` won't satisfy the local interface, which can produce a TypeScript error in strict mode. The component could simply drop the local definition and import the updated shared type instead.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["chore: fix load spend button"](https://github.com/amazeeio/amazee.ai/commit/c9d4f25aa63a587cebdce1a9ad7b10c3e5569a02) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34553894)</sub>

<!-- /greptile_comment -->