### PR TITLE
chore: improve public display name

### DIFF
--- a/app/api/public.py
+++ b/app/api/public.py
@@ -98,8 +98,30 @@ def _apply_profit_margin(price: float | None, margin: float) -> float | None:
     return price * (1 + margin)
 
 
-def _to_display_name(model_id: str) -> str:
-    words = re.split(r"[-_]+", model_id)
+def _to_display_name(model_id: str, aliases: list[str] | None = None) -> str:
+    """Convert a model_id to a human-friendly display name.
+
+    If aliases contain a dotted version number (e.g. "claude-4.7"), use that
+    to produce "Claude 4.7" instead of "Claude 4 7".
+    """
+    # Build a mapping of hyphenated number sequences to dotted equivalents
+    # by inspecting aliases for dotted versions.
+    dot_replacements: dict[str, str] = {}
+    if aliases:
+        for alias in aliases:
+            # Find dotted number patterns like "4.7", "3.5", "1.5.2"
+            for m in re.finditer(r"\d+(?:\.\d+)+", alias):
+                dotted = m.group(0)
+                # The equivalent hyphenated form: "4.7" -> "4-7"
+                hyphenated = dotted.replace(".", "-")
+                dot_replacements[hyphenated] = dotted
+
+    # Replace hyphenated number sequences with dotted versions before splitting
+    modified_id = model_id
+    for hyphenated, dotted in sorted(dot_replacements.items(), key=lambda x: -len(x[0])):
+        modified_id = modified_id.replace(hyphenated, dotted)
+
+    words = re.split(r"[-_]+", modified_id)
     return " ".join(
         word.upper() if word.isupper() else word.capitalize() for word in words if word
     )
@@ -291,10 +313,12 @@ def _extract_model_summary(
         supports_prompt_caching=bool(model_info.get("supports_prompt_caching")),
     )
 
+    aliases = _extract_aliases(item, model_id)
+
     return PublicModelSummary(
         model_id=model_id,
-        display_name=_to_display_name(model_id),
-        aliases=_extract_aliases(item, model_id),
+        display_name=_to_display_name(model_id, aliases),
+        aliases=aliases,
         metadata_raw=model_info.get("metadata") or item.get("metadata"),
         provider=_infer_provider(item),
         type=model_type,

--- a/app/api/public.py
+++ b/app/api/public.py
@@ -116,10 +116,15 @@ def _to_display_name(model_id: str, aliases: list[str] | None = None) -> str:
                 hyphenated = dotted.replace(".", "-")
                 dot_replacements[hyphenated] = dotted
 
-    # Replace hyphenated number sequences with dotted versions before splitting
+    # Replace hyphenated number sequences with dotted versions before splitting.
+    # Use word-boundary anchors so that e.g. "3-5" does not corrupt "123-5".
     modified_id = model_id
     for hyphenated, dotted in sorted(dot_replacements.items(), key=lambda x: -len(x[0])):
-        modified_id = modified_id.replace(hyphenated, dotted)
+        modified_id = re.sub(
+            r"(?<![0-9])" + re.escape(hyphenated) + r"(?![0-9])",
+            dotted,
+            modified_id,
+        )
 
     words = re.split(r"[-_]+", modified_id)
     return " ".join(


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves the public model display name generation by using alias information to preserve dotted version numbers (e.g., producing "Claude 3.5 Sonnet" instead of "Claude 3 5 Sonnet"). Aliases are now extracted before calling `_to_display_name` and passed in so hyphenated numeric segments can be restored to their dotted equivalents.

- `_to_display_name` gains an optional `aliases` parameter; it scans aliases for dotted version patterns (e.g. `"3.5"`), builds a hyphenated→dotted mapping, and applies regex substitutions with `(?<![0-9])` / `(?![0-9])` guards before splitting on `[-_]+`.
- In `_extract_model_summary`, `_extract_aliases` is now called first so the alias list can be shared with `_to_display_name`, eliminating the previous duplicate call.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is confined to display-name formatting and correctly guards regex substitutions against corrupting non-version digit sequences.

The regex anchors correctly prevent the hyphenated-version replacement from matching mid-sequence digit runs. Aliases are extracted once and reused, and the longest-first sort order avoids partial-overlap issues between version patterns. No logic path affecting stored data or API contract is touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/public.py | Adds alias-aware dotted version reconstruction to _to_display_name; boundary guards (digit lookbehind/lookahead) correctly prevent false matches on longer numeric segments; _extract_model_summary now pre-computes aliases once. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant _extract_model_summary
    participant _extract_aliases
    participant _to_display_name

    Caller->>_extract_model_summary: item, model_id, ...
    _extract_model_summary->>_extract_aliases: item, model_id
    _extract_aliases-->>_extract_model_summary: aliases (sorted list)
    _extract_model_summary->>_to_display_name: model_id, aliases
    Note over _to_display_name: Build dot_replacements from aliases
    Note over _to_display_name: Apply regex sub with guards
    Note over _to_display_name: Split on [-_]+ and capitalize
    _to_display_name-->>_extract_model_summary: display_name
    _extract_model_summary-->>Caller: PublicModelSummary(display_name, aliases, ...)
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Update app/api/public.py"](https://github.com/amazeeio/amazee.ai/commit/ec80262363f3fa0fdab1e3782498b621eb5f2815) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34872817)</sub>

<!-- /greptile_comment -->