### PR TITLE
chore: fix load spend button

### DIFF
--- a/frontend/src/app/admin/teams/_components/team-expansion-row.tsx
+++ b/frontend/src/app/admin/teams/_components/team-expansion-row.tsx
@@ -35,6 +35,7 @@ import { SpendInfo } from "@/types/spend";
 import { Team } from "@/types/team";
 import { User } from "@/types/user";
 import { get } from "@/utils/api";
+import { mapTeamSpendToSpendInfo } from "@/utils/spend-mapping";
 import { useQuery } from "@tanstack/react-query";
 
 interface TeamExpansionRowProps {
@@ -159,12 +160,7 @@ export function TeamExpansionRow({
               `/spend/${matchedRegion.id}/team/${teamId}`,
             );
             const data = await response.json();
-            // Map TeamSpendResponse to SpendInfo
-            const spendInfo = {
-              ...data,
-              spend: data.total_spend ?? 0,
-              max_budget: data.total_budget,
-            };
+            const spendInfo = mapTeamSpendToSpendInfo(data);
             for (const keyId of keyIds) {
               spendData[keyId.toString()] = spendInfo;
             }

--- a/frontend/src/app/admin/teams/_components/team-expansion-row.tsx
+++ b/frontend/src/app/admin/teams/_components/team-expansion-row.tsx
@@ -158,7 +158,13 @@ export function TeamExpansionRow({
             const response = await get(
               `/spend/${matchedRegion.id}/team/${teamId}`,
             );
-            const spendInfo = await response.json();
+            const data = await response.json();
+            // Map TeamSpendResponse to SpendInfo
+            const spendInfo = {
+              ...data,
+              spend: data.total_spend ?? 0,
+              max_budget: data.total_budget,
+            };
             for (const keyId of keyIds) {
               spendData[keyId.toString()] = spendInfo;
             }

--- a/frontend/src/app/admin/users/_components/user-expansion-row.tsx
+++ b/frontend/src/app/admin/users/_components/user-expansion-row.tsx
@@ -15,6 +15,7 @@ import { PrivateAIKey } from "@/types/private-ai-key";
 import { Region } from "@/types/region";
 import { SpendInfo } from "@/types/spend";
 import { get, post } from "@/utils/api";
+import { mapTeamSpendToSpendInfo } from "@/utils/spend-mapping";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 interface UserExpansionRowProps {
@@ -91,12 +92,7 @@ export function UserExpansionRow({
               `/spend/${matchedRegion.id}/team/${teamId}`,
             );
             const data = await response.json();
-            // Map TeamSpendResponse to SpendInfo
-            const spendInfo = {
-              ...data,
-              spend: data.total_spend ?? 0,
-              max_budget: data.total_budget,
-            };
+            const spendInfo = mapTeamSpendToSpendInfo(data);
             for (const keyId of keyIds) {
               spendData[keyId.toString()] = spendInfo;
             }

--- a/frontend/src/app/admin/users/_components/user-expansion-row.tsx
+++ b/frontend/src/app/admin/users/_components/user-expansion-row.tsx
@@ -90,7 +90,13 @@ export function UserExpansionRow({
             const response = await get(
               `/spend/${matchedRegion.id}/team/${teamId}`,
             );
-            const spendInfo = await response.json();
+            const data = await response.json();
+            // Map TeamSpendResponse to SpendInfo
+            const spendInfo = {
+              ...data,
+              spend: data.total_spend ?? 0,
+              max_budget: data.total_budget,
+            };
             for (const keyId of keyIds) {
               spendData[keyId.toString()] = spendInfo;
             }

--- a/frontend/src/components/private-ai-key-spend-cell.tsx
+++ b/frontend/src/components/private-ai-key-spend-cell.tsx
@@ -12,16 +12,7 @@ import {
 import { get } from "@/utils/api";
 import { useQuery } from "@tanstack/react-query";
 import { Region } from "@/types/region";
-
-interface SpendInfo {
-  spend: number;
-  expires: string;
-  created_at: string;
-  updated_at: string;
-  max_budget: number | null;
-  budget_duration: string | null;
-  budget_reset_at: string | null;
-}
+import { SpendInfo } from "@/types/spend";
 
 interface PrivateAIKeySpendCellProps {
   keyId: number;

--- a/frontend/src/components/private-ai-key-spend-cell.tsx
+++ b/frontend/src/components/private-ai-key-spend-cell.tsx
@@ -57,7 +57,13 @@ export function PrivateAIKeySpendCell({
         const response = await get(
           `spend/${matchedRegion.id}/team/${teamId}`,
         );
-        return response.json();
+        const data = await response.json();
+        // Map TeamSpendResponse to SpendInfo
+        return {
+          ...data,
+          spend: data.total_spend ?? 0,
+          max_budget: data.total_budget,
+        };
       }
       // Fallback for keys without team_id
       const response = await get(`private-ai-keys/${keyId}/spend`);

--- a/frontend/src/components/private-ai-key-spend-cell.tsx
+++ b/frontend/src/components/private-ai-key-spend-cell.tsx
@@ -10,6 +10,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { get } from "@/utils/api";
+import { mapTeamSpendToSpendInfo } from "@/utils/spend-mapping";
 import { useQuery } from "@tanstack/react-query";
 import { Region } from "@/types/region";
 import { SpendInfo } from "@/types/spend";
@@ -49,12 +50,7 @@ export function PrivateAIKeySpendCell({
           `spend/${matchedRegion.id}/team/${teamId}`,
         );
         const data = await response.json();
-        // Map TeamSpendResponse to SpendInfo
-        return {
-          ...data,
-          spend: data.total_spend ?? 0,
-          max_budget: data.total_budget,
-        };
+        return mapTeamSpendToSpendInfo(data);
       }
       // Fallback for keys without team_id
       const response = await get(`private-ai-keys/${keyId}/spend`);

--- a/frontend/src/hooks/use-private-ai-keys-data.ts
+++ b/frontend/src/hooks/use-private-ai-keys-data.ts
@@ -3,6 +3,7 @@ import { Region } from "@/types/region";
 import { SpendInfo } from "@/types/spend";
 import { User } from "@/types/user";
 import { get } from "@/utils/api";
+import { mapTeamSpendToSpendInfo } from "@/utils/spend-mapping";
 import { useQuery } from "@tanstack/react-query";
 
 export function usePrivateAIKeysData(
@@ -45,11 +46,21 @@ export function usePrivateAIKeysData(
     },
   });
 
+  // Fetch regions
+  const { data: regions = [] } = useQuery<Region[]>({
+    queryKey: ["regions"],
+    queryFn: async () => {
+      const response = await get("regions");
+      const data = await response.json();
+      return data;
+    },
+  });
+
   // Query to get spend information for loaded keys
   // Fetches per team+region combo for keys with team_id, old endpoint for others
   const loadedSpendKeysArray = Array.from(loadedSpendKeys).sort();
   const { data: spendMap = {} } = useQuery<Record<number, SpendInfo>>({
-    queryKey: ["private-ai-keys-spend", loadedSpendKeysArray],
+    queryKey: ["private-ai-keys-spend", loadedSpendKeysArray, regions.map(r => r.id)],
     queryFn: async () => {
       const loadedKeys = keys.filter((k) => loadedSpendKeys.has(k.id));
 
@@ -86,7 +97,8 @@ export function usePrivateAIKeysData(
             const response = await get(
               `spend/${matchedRegion.id}/team/${teamId}`,
             );
-            const spendInfo: SpendInfo = await response.json();
+            const data = await response.json();
+            const spendInfo = mapTeamSpendToSpendInfo(data);
             // Assign same team spend to all keys in this combo
             for (const keyId of keyIds) {
               result[keyId] = spendInfo;
@@ -104,17 +116,7 @@ export function usePrivateAIKeysData(
       await Promise.all([...teamSpendPromises, ...noTeamPromises]);
       return result;
     },
-    enabled: loadedSpendKeysArray.length > 0,
-  });
-
-  // Fetch regions
-  const { data: regions = [] } = useQuery<Region[]>({
-    queryKey: ["regions"],
-    queryFn: async () => {
-      const response = await get("regions");
-      const data = await response.json();
-      return data;
-    },
+    enabled: loadedSpendKeysArray.length > 0 && regions.length > 0,
   });
 
   return {

--- a/frontend/src/types/spend.ts
+++ b/frontend/src/types/spend.ts
@@ -1,8 +1,8 @@
 export interface SpendInfo {
   spend: number;
-  expires: string;
-  created_at: string;
-  updated_at: string;
+  expires?: string;
+  created_at?: string;
+  updated_at?: string;
   max_budget: number | null;
   budget_duration: string | null;
   budget_reset_at: string | null;

--- a/frontend/src/utils/spend-mapping.ts
+++ b/frontend/src/utils/spend-mapping.ts
@@ -1,0 +1,14 @@
+import { SpendInfo } from "@/types/spend";
+
+/**
+ * Maps a team spend response (TeamSpendResponse) to the SpendInfo interface.
+ * TeamSpendResponse uses total_spend and total_budget, while SpendInfo
+ * uses spend and max_budget.
+ */
+export function mapTeamSpendToSpendInfo(data: any): SpendInfo {
+  return {
+    ...data,
+    spend: data.total_spend ?? 0,
+    max_budget: data.total_budget ?? null,
+  };
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the "Load Spend" button for keys that belong to a team by mapping the team-level spend endpoint response (`total_spend`, `total_budget`) into the `SpendInfo` shape expected by the UI, and relaxing the `SpendInfo` type to make `expires`, `created_at`, and `updated_at` optional since the team endpoint does not return them.

- The mapping is applied consistently across the three consumers: `PrivateAIKeySpendCell`, `TeamExpansionRow`, and `UserExpansionRow`.
- `private-ai-key-spend-cell.tsx` still carries a local copy of the `SpendInfo` interface that was not updated alongside the shared type in `@/types/spend.ts`, leaving `expires`/`created_at`/`updated_at` marked required there.
- All three mapping sites guard `total_spend` with `?? 0` but leave `total_budget` without a fallback, meaning `max_budget` can silently become `undefined` rather than `null` when the field is absent.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the core mapping logic is correct and spend display works as intended for team keys.

The fix is functionally correct — team spend now loads and renders properly. Two minor cleanup items remain: the stale local SpendInfo interface in private-ai-key-spend-cell.tsx that diverges from the updated shared type, and the missing ?? null fallback on total_budget in all three mapping sites.

frontend/src/components/private-ai-key-spend-cell.tsx carries an outdated local interface and the total_budget mapping without a null fallback.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/types/spend.ts | Made expires, created_at, and updated_at optional to accommodate the team spend response shape that lacks these fields. |
| frontend/src/components/private-ai-key-spend-cell.tsx | Added team-spend mapping, but the local SpendInfo interface (lines 16-24) still declares expires/created_at/updated_at as required, diverging from the updated shared type in @/types/spend.ts. |
| frontend/src/app/admin/teams/_components/team-expansion-row.tsx | Correctly maps total_spend and total_budget from TeamSpendResponse to the SpendInfo shape expected by the render layer. |
| frontend/src/app/admin/users/_components/user-expansion-row.tsx | Correctly maps total_spend and total_budget from TeamSpendResponse to SpendInfo, consistent with the team-expansion-row change. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as SpendCell / ExpansionRow
    participant API as Backend API

    alt Key has team_id + region
        UI->>API: "GET /spend/{regionId}/team/{teamId}"
        API-->>UI: "TeamSpendResponse { total_spend, total_budget, ... }"
        Note over UI: Map to SpendInfo<br/>spend = total_spend ?? 0<br/>max_budget = total_budget
    else Key without team_id (fallback)
        UI->>API: "GET /private-ai-keys/{keyId}/spend"
        API-->>UI: "SpendInfo { spend, max_budget, ... }"
    end

    UI->>UI: "Render spend & budget values"
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `frontend/src/components/private-ai-key-spend-cell.tsx`, line 16-24 ([link](https://github.com/amazeeio/amazee.ai/blob/e83e916dd52e5e188816231420fa591a82d46eab/frontend/src/components/private-ai-key-spend-cell.tsx#L16-L24)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The local `SpendInfo` interface is a stale duplicate of the shared type in `@/types/spend.ts`. The shared type was updated in this PR to make `expires`, `created_at`, and `updated_at` optional, but this local copy still declares them as required. The component should import the shared type instead, which also keeps the team-spend mapping path in sync with the rest of the codebase.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["chore: fix load spend button"](https://github.com/amazeeio/amazee.ai/commit/e83e916dd52e5e188816231420fa591a82d46eab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34935059)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->