### PR TITLE
chore: fix frontend action

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -36,6 +36,7 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "vitest.config.ts"
   ]
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -7,8 +7,10 @@ export default defineConfig({
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
     include: ["src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
-    deps: {
-      inline: ["cmdk"],
+    server: {
+      deps: {
+        inline: ["cmdk"],
+      },
     },
   },
   resolve: {


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Two configuration-only fixes to unblock the frontend CI action. The changes migrate a deprecated Vitest API and resolve a TypeScript compilation conflict introduced by the vitest config file coexisting with the Next.js TS project.

- `vitest.config.ts`: Moves `deps.inline: ["cmdk"]` from the deprecated `test.deps` location to `test.server.deps`, which is the correct placement in Vitest v1+. Behavior is equivalent.
- `tsconfig.json`: Adds `vitest.config.ts` to the `exclude` list so the Next.js TypeScript plugin (which uses `moduleResolution: "bundler"`) no longer tries to type-check the vitest config, which imports from `vitest/config` and has incompatible type expectations.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Both changes are minimal, targeted config fixes with no runtime or logic impact — safe to merge.

The two changes are isolated to build/test configuration: one migrates a deprecated Vitest option to the current API location, and the other removes a type-checking conflict between the vitest config file and the Next.js TypeScript plugin. Neither change touches application logic, data handling, or runtime behavior.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/vitest.config.ts | Moves `deps.inline` from the deprecated top-level `test.deps` to `test.server.deps`, aligning with the Vitest v1+ API. |
| frontend/tsconfig.json | Excludes `vitest.config.ts` from the Next.js TypeScript project to prevent type conflicts between `vitest/config` and the Next.js TypeScript plugin. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Frontend CI Action] --> B{TypeScript Check}
    A --> C{Vitest Tests}

    B --> D["tsconfig.json\n(include: **/*.ts)"]
    D -->|Before: included| E["vitest.config.ts\n(imports vitest/config)"]
    E -->|Type conflict with Next.js plugin| F["❌ tsc error"]

    D -->|After: excluded| G["vitest.config.ts excluded\nfrom TS project"]
    G --> H["✅ tsc passes"]

    C --> I["vitest.config.ts"]
    I -->|Before: test.deps.inline| J["Deprecated API\n(Vitest v1+)"]
    J --> K["⚠️ Warning / broken"]

    I -->|After: test.server.deps.inline| L["Current API\n(Vitest v1+)"]
    L --> M["✅ cmdk inlined correctly"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix frontend action"](https://github.com/amazeeio/amazee.ai/commit/f7d0e7c40324536e29a0f9c79e225e92920b2eb8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34973586)</sub>

<!-- /greptile_comment -->