### PR TITLE
AI-398: Pool team subscriptions

### DIFF
--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -68,7 +68,8 @@ async def get_periodic_budget_status(
         raise HTTPException(status_code=404, detail="Team not found")
     if team.budget_type not in (BudgetType.PERIODIC, BudgetType.POOL):
         raise HTTPException(
-            status_code=400, detail="Endpoint is only valid for subscription-managed teams"
+            status_code=400,
+            detail="Endpoint is only valid for subscription-managed teams",
         )
     region = db.query(DBRegion).filter(DBRegion.id == region_id).first()
     if not region:

--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -599,17 +599,19 @@ async def purchase_pool_budget(
     "/region/{region_id}/teams/{team_id}/purchase/periodic",
     response_model=PeriodicTopupResponse,
     status_code=status.HTTP_201_CREATED,
-    summary="Create PERIODIC top-up purchase",
+    summary="Create subscription-managed top-up purchase",
     description=(
-        "Create a region-scoped top-up for PERIODIC teams.\n\n"
-        "- Valid only for PERIODIC teams.\n"
+        "Create a region-scoped top-up for subscription-managed teams.\n\n"
+        "- Valid for PERIODIC and POOL teams.\n"
         "- Target region must be assigned to the team.\n"
         "- Idempotency is enforced by `stripe_payment_id` (duplicate => 409).\n"
         "- Compounding is region-scoped: `max_budget = current_spend + desired_remaining`.\n"
         "- On LiteLLM sync failure, request fails (502), payment is marked `sync_failed`, and "
         "no allocatable top-up ledger balance is retained for that failed API purchase."
     ),
-    response_description="Created PERIODIC top-up and updated the target region budget.",
+    response_description=(
+        "Created subscription-managed top-up and updated the target region budget."
+    ),
     dependencies=[Depends(get_role_min_system_admin)],
 )
 async def create_periodic_topup(

--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -66,9 +66,9 @@ async def get_periodic_budget_status(
     team = db.query(DBTeam).filter(DBTeam.id == team_id).first()
     if not team:
         raise HTTPException(status_code=404, detail="Team not found")
-    if team.budget_type != BudgetType.PERIODIC:
+    if team.budget_type not in (BudgetType.PERIODIC, BudgetType.POOL):
         raise HTTPException(
-            status_code=400, detail="Endpoint is only valid for PERIODIC teams"
+            status_code=400, detail="Endpoint is only valid for subscription-managed teams"
         )
     region = db.query(DBRegion).filter(DBRegion.id == region_id).first()
     if not region:
@@ -622,10 +622,10 @@ async def create_periodic_topup(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Team not found"
         )
-    if team.budget_type != BudgetType.PERIODIC:
+    if team.budget_type not in (BudgetType.PERIODIC, BudgetType.POOL):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Endpoint is only valid for PERIODIC teams",
+            detail="Endpoint is only valid for subscription-managed teams",
         )
     return await purchase_periodic_topup(
         region_id=region_id,

--- a/app/api/public.py
+++ b/app/api/public.py
@@ -119,7 +119,9 @@ def _to_display_name(model_id: str, aliases: list[str] | None = None) -> str:
     # Replace hyphenated number sequences with dotted versions before splitting.
     # Use word-boundary anchors so that e.g. "3-5" does not corrupt "123-5".
     modified_id = model_id
-    for hyphenated, dotted in sorted(dot_replacements.items(), key=lambda x: -len(x[0])):
+    for hyphenated, dotted in sorted(
+        dot_replacements.items(), key=lambda x: -len(x[0])
+    ):
         modified_id = re.sub(
             r"(?<![0-9])" + re.escape(hyphenated) + r"(?![0-9])",
             dotted,

--- a/app/api/subscription.py
+++ b/app/api/subscription.py
@@ -113,10 +113,10 @@ async def subscription_cycle(
     team = db.query(DBTeam).filter(DBTeam.id == request.team_id).first()
     if not team:
         raise HTTPException(status_code=404, detail=f"Team {request.team_id} not found")
-    if team.budget_type != BudgetType.PERIODIC:
+    if team.budget_type not in (BudgetType.PERIODIC, BudgetType.POOL):
         raise HTTPException(
             status_code=400,
-            detail=f"Team {request.team_id} is not a PERIODIC team",
+            detail=f"Team {request.team_id} does not support subscription cycles",
         )
 
     region = db.query(DBRegion).filter(DBRegion.id == request.region_id).first()

--- a/app/api/subscription.py
+++ b/app/api/subscription.py
@@ -116,7 +116,10 @@ async def subscription_cycle(
     if team.budget_type not in (BudgetType.PERIODIC, BudgetType.POOL):
         raise HTTPException(
             status_code=400,
-            detail=f"Team {request.team_id} does not support subscription cycles",
+            detail=(
+                f"Team {request.team_id} budget_type={team.budget_type} "
+                "does not support subscription cycles"
+            ),
         )
 
     region = db.query(DBRegion).filter(DBRegion.id == request.region_id).first()

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -74,6 +74,10 @@ FIRST_EMAIL_DAYS_LEFT = 7
 SECOND_EMAIL_DAYS_LEFT = 5
 TRIAL_OVER_DAYS = 30
 
+# Budget types that support subscription cycles (PERIODIC and POOL).
+# Used to gate cycle/ledger/drift functions that were originally PERIODIC-only.
+SUBSCRIPTION_BUDGET_TYPES = frozenset({BudgetType.PERIODIC, BudgetType.POOL})
+
 # Prometheus metrics
 team_freshness_days = Gauge(
     "team_freshness_days",
@@ -417,8 +421,12 @@ async def _run_cycle_from_stripe_event(
     if not team:
         logger.warning("No team found for customer_id=%s", customer_id)
         return
-    if team.budget_type != BudgetType.PERIODIC:
-        logger.info("Skipping invoice.paid: team %s is not PERIODIC", team.id)
+    if team.budget_type not in SUBSCRIPTION_BUDGET_TYPES:
+        logger.info(
+            "Skipping invoice.paid: team %s budget_type=%s does not support subscription cycles",
+            team.id,
+            team.budget_type,
+        )
         return
 
     # --- Resolve region ---
@@ -759,7 +767,7 @@ async def capture_periodic_team_spend_for_invoice(
             "Skipping spend period capture: no team for customer_id=%s", customer_id
         )
         return
-    if team.budget_type != BudgetType.PERIODIC:
+    if team.budget_type not in SUBSCRIPTION_BUDGET_TYPES:
         return
 
     period_start_ts = getattr(invoice_obj, "period_start", None)
@@ -835,7 +843,7 @@ async def capture_periodic_team_spend_for_period(
     period_end: datetime,
     source_event_id: str | None,
 ) -> None:
-    if team.budget_type != BudgetType.PERIODIC:
+    if team.budget_type not in SUBSCRIPTION_BUDGET_TYPES:
         return
 
     try:
@@ -879,7 +887,7 @@ async def _sync_periodic_ledger_for_invoice(
     # spend snapshot per billing period; therefore consumed_cents is eventually
     # consistent between invoices, not a live spend counter.
     team = db.query(DBTeam).filter(DBTeam.stripe_customer_id == customer_id).first()
-    if not team or team.budget_type != BudgetType.PERIODIC:
+    if not team or team.budget_type not in SUBSCRIPTION_BUDGET_TYPES:
         return
 
     period_start_ts = getattr(invoice_obj, "period_start", None)
@@ -955,7 +963,7 @@ async def _sync_periodic_ledger_for_period(
     source_payment_id: int | None,
     source_invoice_id: str | None,
 ) -> None:
-    if team.budget_type != BudgetType.PERIODIC:
+    if team.budget_type not in SUBSCRIPTION_BUDGET_TYPES:
         return
 
     try:
@@ -1006,7 +1014,7 @@ async def _sync_periodic_ledger_for_period(
 async def reconcile_periodic_team_budget_drift(
     *, db: Session, team: DBTeam, region: DBRegion
 ) -> BudgetDriftResult | None:
-    if team.budget_type != BudgetType.PERIODIC:
+    if team.budget_type not in SUBSCRIPTION_BUDGET_TYPES:
         return None
     service = LiteLLMService(
         api_url=region.litellm_api_url, api_key=region.litellm_api_key
@@ -1066,8 +1074,10 @@ async def apply_billing_cycle_for_team(
         if not team:
             logger.error(f"Team not found for team ID: {team_id}")
             return sync_errors
-        if team.budget_type != BudgetType.PERIODIC:
-            raise ValueError(f"Team {team_id} is not PERIODIC")
+        if team.budget_type not in SUBSCRIPTION_BUDGET_TYPES:
+            raise ValueError(
+                f"Team {team_id} budget_type={team.budget_type} does not support subscription cycles"
+            )
 
         region = db.query(DBRegion).filter(DBRegion.id == region_id).first()
         if not region:
@@ -1266,7 +1276,7 @@ async def apply_product_for_team(
         db.add(DBTeamProduct(team_id=team.id, product_id=product.id))
     db.commit()
 
-    if team.budget_type == BudgetType.PERIODIC:
+    if team.budget_type in SUBSCRIPTION_BUDGET_TYPES:
         period_start = start_date
         # Safety-net: Stripe cycles are 30d. The 31d budget_duration on LiteLLM
         # auto-expires budget if a webhook is missed.

--- a/scripts/restore_database.py
+++ b/scripts/restore_database.py
@@ -120,9 +120,7 @@ def get_db_config():
     # `--dbname`. The password flows through PGPASSWORD instead.
     safe_netloc = _strip_password_from_netloc(parsed)
     safe_url = urlunparse(parsed._replace(netloc=safe_netloc))
-    maintenance_url = urlunparse(
-        parsed._replace(netloc=safe_netloc, path="/postgres")
-    )
+    maintenance_url = urlunparse(parsed._replace(netloc=safe_netloc, path="/postgres"))
     return {
         "url": safe_url,
         "maintenance_url": maintenance_url,
@@ -153,7 +151,9 @@ def check_required_tools():
     """Verify all required postgres client tools are on PATH."""
     missing = [t for t in REQUIRED_TOOLS if shutil.which(t) is None]
     if missing:
-        print(f"Error: Required postgres client tool(s) not found: {', '.join(missing)}")
+        print(
+            f"Error: Required postgres client tool(s) not found: {', '.join(missing)}"
+        )
         print("  This script must run in an environment with postgres client tools")
         print("  installed (e.g. the Lagoon `cli` container).")
         sys.exit(1)
@@ -211,8 +211,10 @@ def backup_current_database(config, backup_path):
     cmd = [
         "pg_dump",
         "--format=custom",
-        "--file", backup_path,
-        "--dbname", config["url"],
+        "--file",
+        backup_path,
+        "--dbname",
+        config["url"],
     ]
     try:
         run_pg_tool(cmd, config)
@@ -222,7 +224,10 @@ def backup_current_database(config, backup_path):
             os.unlink(backup_path)
         except OSError as cleanup_err:
             # Best-effort cleanup only: preserve original pg_dump failure path.
-            print(f"  Warning: could not remove partial backup file: {cleanup_err}", file=sys.stderr)
+            print(
+                f"  Warning: could not remove partial backup file: {cleanup_err}",
+                file=sys.stderr,
+            )
         raise SystemExit(f"  pg_dump failed: {sanitize(e.stderr or e, config)}")
 
     size_mb = os.path.getsize(backup_path) / (1024 * 1024)
@@ -347,7 +352,8 @@ def apply_restore(config, dump_dir):
         # Connect to the maintenance DB so pg_restore can drop/create the
         # target. `maintenance_url` carries every libpq param from the
         # configured DATABASE_URL (sslmode, connect_timeout, etc.).
-        "--dbname", config["maintenance_url"],
+        "--dbname",
+        config["maintenance_url"],
         dump_dir,
     ]
     try:
@@ -359,7 +365,7 @@ def apply_restore(config, dump_dir):
             "restored. Recover from the safety backup with:\n"
             "    pg_restore --clean --create --if-exists --no-owner "
             "--no-privileges \\\n"
-            "      -d \"<maintenance DATABASE_URL, path=/postgres>\" "
+            '      -d "<maintenance DATABASE_URL, path=/postgres>" '
             "<safety_backup>.dump"
         )
 
@@ -371,7 +377,9 @@ def check_disk_space(path, required_mb=500):
     stat = os.statvfs(path)
     available_mb = (stat.f_bavail * stat.f_frsize) / (1024 * 1024)
     if available_mb < required_mb:
-        print(f"  Warning: Only {available_mb:.0f}MB available at {path} (recommend >= {required_mb}MB)")
+        print(
+            f"  Warning: Only {available_mb:.0f}MB available at {path} (recommend >= {required_mb}MB)"
+        )
         return False
     return True
 
@@ -405,7 +413,8 @@ def main():
         help="Directory to extract the backup into (default: system temp directory)",
     )
     parser.add_argument(
-        "--yes", "-y",
+        "--yes",
+        "-y",
         action="store_true",
         help="Skip confirmation prompt",
     )
@@ -463,7 +472,9 @@ def main():
             print("A safety backup of the current database will be created first.")
         else:
             print("No safety backup will be created (--no-backup specified).")
-        response = input("\nAre you sure you want to proceed? [yes/no]: ").strip().lower()
+        response = (
+            input("\nAre you sure you want to proceed? [yes/no]: ").strip().lower()
+        )
         if response not in ("yes", "y"):
             print("Aborted.")
             sys.exit(0)
@@ -475,7 +486,9 @@ def main():
         # Step 1: Backup current database (unless skipped)
         if not args.no_backup:
             print("\n[1/3] Backing up current database...")
-            backup_dir = args.backup_dir or os.path.dirname(os.path.abspath(args.backup_file))
+            backup_dir = args.backup_dir or os.path.dirname(
+                os.path.abspath(args.backup_file)
+            )
             os.makedirs(backup_dir, exist_ok=True)
             safety_backup_path = os.path.join(
                 backup_dir, f"{config['database']}_pre_restore.dump"
@@ -494,10 +507,14 @@ def main():
             except SystemExit as exc:
                 print(f"  {exc}", file=sys.stderr)
                 if args.yes:
-                    print("  Error: Cannot proceed without safety backup in non-interactive mode.")
+                    print(
+                        "  Error: Cannot proceed without safety backup in non-interactive mode."
+                    )
                     print("  Use --no-backup to explicitly skip the safety backup.")
                     sys.exit(1)
-                response = input("  Continue without backup? [yes/no]: ").strip().lower()
+                response = (
+                    input("  Continue without backup? [yes/no]: ").strip().lower()
+                )
                 if response not in ("yes", "y"):
                     print("Aborted.")
                     sys.exit(0)
@@ -510,7 +527,9 @@ def main():
         os.makedirs(extract_dir, exist_ok=True)
         dump_dir = extract_backup(args.backup_file, extract_dir)
         dump_contents = os.listdir(dump_dir)
-        dat_count = sum(1 for f in dump_contents if f.endswith(".dat") and f != "toc.dat")
+        dat_count = sum(
+            1 for f in dump_contents if f.endswith(".dat") and f != "toc.dat"
+        )
         print(f"  Dump directory: {dump_dir}")
         print(f"  Found: toc.dat + {dat_count} data files")
 

--- a/tests/test_periodic_budget_behavior.py
+++ b/tests/test_periodic_budget_behavior.py
@@ -1,14 +1,15 @@
 """
 Tests for PERIODIC team budget behaviour introduced by the
-"Spend API: align duration budget for PERIODIC teams with Stripe webhooks" PR.
+"Spend API: align duration budget for PERIODIC teams with Stripe webhooks" PR,
+extended to cover POOL subscription teams (AI-398).
 
 Key behaviours under test:
 1. PERIODIC teams use a fixed 31-day budget duration (not days_left_in_period)
-2. POOL teams still use days_left_in_period
+2. POOL subscription teams use 31d duration (same as PERIODIC, via billing cycle)
 3. PERIODIC teams compound max_budget = accumulated_spend + monthly_cap
 4. Compounding falls back to flat cap when get_team_info fails
 5. PERIODIC teams reset key spend to 0 on each webhook
-6. POOL teams do NOT reset key spend
+6. POOL subscription teams reset key spend to 0 on cycle (same as PERIODIC)
 7. Spend API: PERIODIC teams derive total_spend from sum of key spends
 8. Spend API: PERIODIC teams derive total_budget from max(key budgets)
 """
@@ -130,14 +131,14 @@ async def test_periodic_team_uses_31d_duration(
     assert team_call.kwargs["budget_duration"] == "31d"
 
 
-# ─── 2. POOL teams use days_left_in_period duration ───────────────────────
+# ─── 2. POOL subscription teams use 31d duration (same as PERIODIC) ──────
 
 
 @pytest.mark.asyncio
 @patch("app.core.worker.LiteLLMService")
 @patch("app.core.worker.get_team_keys_by_region")
 @patch("app.core.worker.LimitService")
-async def test_pool_team_uses_days_left_duration(
+async def test_pool_subscription_team_uses_31d_duration(
     mock_limit_service,
     mock_get_keys,
     mock_litellm_class,
@@ -145,12 +146,12 @@ async def test_pool_team_uses_days_left_duration(
     test_product,
     test_region,
 ):
-    """POOL teams must use days_left_in_period from the limit service."""
+    """POOL subscription teams go through apply_billing_cycle_for_team and
+    therefore use the same fixed 31d budget_duration as PERIODIC teams."""
     team = _make_pool_team(db, "Pool Duration Team", region=test_region)
     team.stripe_customer_id = "cus_pool_duration"
     db.commit()
 
-    # Limit service says 20 days left
     mock_limit_service.return_value.get_token_restrictions.return_value = (
         20,
         100.0,
@@ -167,7 +168,7 @@ async def test_pool_team_uses_days_left_duration(
     )
 
     team_call = mock_litellm.update_team_budget.await_args
-    assert team_call.kwargs["budget_duration"] == "20d"
+    assert team_call.kwargs["budget_duration"] == "31d"
 
 
 # ─── 3. PERIODIC teams compound max_budget ────────────────────────────────
@@ -330,14 +331,14 @@ async def test_periodic_team_resets_key_spend_to_zero(
         assert call.kwargs["spend"] == 0.0
 
 
-# ─── 6. POOL teams do NOT reset key spend ─────────────────────────────────
+# ─── 6. POOL subscription teams reset key spend to 0 on cycle ─────────────
 
 
 @pytest.mark.asyncio
 @patch("app.core.worker.LiteLLMService")
 @patch("app.core.worker.get_team_keys_by_region")
 @patch("app.core.worker.LimitService")
-async def test_pool_team_does_not_reset_key_spend(
+async def test_pool_subscription_team_resets_key_spend(
     mock_limit_service,
     mock_get_keys,
     mock_litellm_class,
@@ -345,8 +346,8 @@ async def test_pool_team_does_not_reset_key_spend(
     test_product,
     test_region,
 ):
-    """POOL teams must pass spend=None to set_key_restrictions so that
-    existing key spend counters are preserved across budget updates."""
+    """POOL subscription teams go through apply_billing_cycle_for_team and
+    therefore reset key spend to 0.0 on each cycle, just like PERIODIC teams."""
     team = _make_pool_team(db, "Pool No Reset Team", region=test_region)
     team.stripe_customer_id = "cus_pool_no_reset"
     db.commit()
@@ -369,10 +370,10 @@ async def test_pool_team_does_not_reset_key_spend(
         db, "cus_pool_no_reset", test_product.id, datetime.now(UTC)
     )
 
-    # Every key must have been called with spend=None (not reset)
+    # Every key must have been called with spend=0.0 (reset on cycle)
     assert mock_litellm.set_key_restrictions.call_count == 2
     for call in mock_litellm.set_key_restrictions.call_args_list:
-        assert call.kwargs["spend"] is None
+        assert call.kwargs["spend"] == 0.0
 
 
 # ─── 7. Spend API: PERIODIC team total_spend = sum of key spends ──────────

--- a/tests/test_periodic_payments.py
+++ b/tests/test_periodic_payments.py
@@ -600,13 +600,10 @@ def test_pool_subscription_cycle_endpoint_accepted(
     mock_apply_cycle.assert_awaited_once()
 
 
-def test_pool_subscription_cycle_endpoint_rejected_for_unsupported_type(
+def test_pool_subscription_cycle_endpoint_returns_404_for_unknown_team(
     client, db, test_region
 ):
-    """The /cycle endpoint must reject teams with budget types other than PERIODIC or POOL."""
-    # Force a team that has an unexpected type (simulate by patching the guard path)
-    # We test this via a PERIODIC team to ensure the guard error message changed.
-    # The simplest check: a non-existent team still returns 404, not 400.
+    """The /cycle endpoint returns 404 when the requested team does not exist."""
     response = client.post(
         "/billing/subscription/cycle",
         headers=_auth_headers(),

--- a/tests/test_periodic_payments.py
+++ b/tests/test_periodic_payments.py
@@ -16,7 +16,6 @@ from app.db.models import (
     DBPrivateAIKey,
     DBRegion,
     DBTeam,
-    DBPoolPurchase,
 )
 from app.schemas.models import BudgetType
 
@@ -625,9 +624,7 @@ def test_pool_subscription_cycle_endpoint_rejected_for_unsupported_type(
 @patch("app.core.worker._record_periodic_payment_direct", new_callable=AsyncMock)
 @patch("app.core.worker.apply_billing_cycle_for_team", new_callable=AsyncMock)
 @patch("app.core.worker._sync_periodic_ledger_for_period", new_callable=AsyncMock)
-@patch(
-    "app.core.worker.capture_periodic_team_spend_for_period", new_callable=AsyncMock
-)
+@patch("app.core.worker.capture_periodic_team_spend_for_period", new_callable=AsyncMock)
 async def test_pool_team_invoice_paid_not_skipped(
     mock_capture_period,
     mock_sync_ledger,
@@ -719,7 +716,11 @@ async def test_pool_team_billing_cycle_uses_31d_and_resets_spend(
     db.add(key)
     db.commit()
 
-    mock_limit_service.return_value.get_token_restrictions.return_value = (31, 30.0, 500)
+    mock_limit_service.return_value.get_token_restrictions.return_value = (
+        31,
+        30.0,
+        500,
+    )
     mock_get_keys.return_value = [key]
 
     mock_litellm = mock_litellm_class.return_value

--- a/tests/test_periodic_payments.py
+++ b/tests/test_periodic_payments.py
@@ -8,13 +8,17 @@ from app.core.worker import (
     _record_periodic_payment_direct,
     _run_cycle_from_stripe_event,
     apply_billing_cycle_for_team,
+    reconcile_periodic_team_budget_drift,
 )
 from app.db.models import (
     DBPeriodicBudgetLedgerEntry,
     DBPeriodicPayment,
     DBPrivateAIKey,
     DBRegion,
+    DBTeam,
+    DBPoolPurchase,
 )
+from app.schemas.models import BudgetType
 
 
 def _auth_headers() -> dict[str, str]:
@@ -536,3 +540,210 @@ def test_subscription_deactivate_endpoint_idempotent(client, db, test_team):
     assert response.status_code == 200
     assert response.json()["idempotent"] is True
     assert response.json()["payment_id"] == payment.id
+
+
+# ─── POOL team subscription cycle tests ──────────────────────────────────────
+
+
+def _make_pool_team(db, name="Pool Sub Team"):
+    """Create a POOL team with a stripe_customer_id."""
+    team = DBTeam(
+        name=name,
+        admin_email=f"{name.lower().replace(' ', '_')}@example.com",
+        is_active=True,
+        budget_type=BudgetType.POOL,
+        require_purchase_for_requests=True,
+        stripe_customer_id=f"cus_pool_{name.replace(' ', '_').lower()}",
+    )
+    db.add(team)
+    db.commit()
+    db.refresh(team)
+    return team
+
+
+@patch("app.api.subscription._record_periodic_payment_direct", new_callable=AsyncMock)
+@patch("app.api.subscription.apply_billing_cycle_for_team", new_callable=AsyncMock)
+@patch("app.api.subscription._sync_periodic_ledger_for_period", new_callable=AsyncMock)
+@patch(
+    "app.api.subscription.capture_periodic_team_spend_for_period",
+    new_callable=AsyncMock,
+)
+def test_pool_subscription_cycle_endpoint_accepted(
+    mock_capture,
+    mock_sync_ledger,
+    mock_apply_cycle,
+    mock_record_payment,
+    client,
+    db,
+    test_region,
+):
+    """The /cycle endpoint must accept POOL teams (previously rejected with 400)."""
+    pool_team = _make_pool_team(db, "Pool Cycle Accept")
+    mock_apply_cycle.return_value = []
+    mock_record_payment.return_value = 500
+
+    response = client.post(
+        "/billing/subscription/cycle",
+        headers=_auth_headers(),
+        json={
+            "transaction_id": "txn_pool_cycle_1",
+            "budget_cents": 3000,
+            "team_id": pool_team.id,
+            "region_id": test_region.id,
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert data["team_id"] == pool_team.id
+    assert data["budget_dollars"] == 30.0
+    mock_apply_cycle.assert_awaited_once()
+
+
+def test_pool_subscription_cycle_endpoint_rejected_for_unsupported_type(
+    client, db, test_region
+):
+    """The /cycle endpoint must reject teams with budget types other than PERIODIC or POOL."""
+    # Force a team that has an unexpected type (simulate by patching the guard path)
+    # We test this via a PERIODIC team to ensure the guard error message changed.
+    # The simplest check: a non-existent team still returns 404, not 400.
+    response = client.post(
+        "/billing/subscription/cycle",
+        headers=_auth_headers(),
+        json={
+            "transaction_id": "txn_bad_team",
+            "budget_cents": 1000,
+            "team_id": 999999,
+            "region_id": test_region.id,
+        },
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+@patch("app.core.worker._record_periodic_payment_direct", new_callable=AsyncMock)
+@patch("app.core.worker.apply_billing_cycle_for_team", new_callable=AsyncMock)
+@patch("app.core.worker._sync_periodic_ledger_for_period", new_callable=AsyncMock)
+@patch(
+    "app.core.worker.capture_periodic_team_spend_for_period", new_callable=AsyncMock
+)
+async def test_pool_team_invoice_paid_not_skipped(
+    mock_capture_period,
+    mock_sync_ledger,
+    mock_apply_cycle,
+    mock_record_payment,
+    db,
+    test_region,
+):
+    """POOL teams must NOT be skipped on invoice.paid — _run_cycle_from_stripe_event
+    must proceed through the billing cycle for POOL teams."""
+    pool_team = _make_pool_team(db, "Pool Invoice Team")
+    mock_apply_cycle.return_value = []
+    mock_record_payment.return_value = 501
+
+    event_object = SimpleNamespace(
+        id="inv_pool_1",
+        subscription="sub_pool_1",
+        amount_paid=3000,
+        period_start=1700000000,
+        period_end=1702678400,
+        parent=SimpleNamespace(
+            subscription_details=SimpleNamespace(
+                subscription="sub_pool_1",
+                metadata={"regionId": str(test_region.id)},
+            )
+        ),
+    )
+
+    await _run_cycle_from_stripe_event(
+        db=db,
+        event_id="evt_pool_invoice",
+        customer_id=pool_team.stripe_customer_id,
+        event_object=event_object,
+    )
+
+    mock_apply_cycle.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("app.core.worker.LiteLLMService")
+async def test_pool_team_drift_reconciliation_returns_result(
+    mock_litellm_class,
+    db,
+    test_region,
+):
+    """reconcile_periodic_team_budget_drift must return a BudgetDriftResult for
+    POOL teams (previously returned None)."""
+    pool_team = _make_pool_team(db, "Pool Drift Team")
+
+    mock_litellm = mock_litellm_class.return_value
+    mock_litellm.get_team_info = AsyncMock(
+        return_value={"team_info": {"spend": 10.0, "max_budget": 30.0}}
+    )
+
+    region = db.query(DBRegion).filter(DBRegion.id == test_region.id).first()
+    result = await reconcile_periodic_team_budget_drift(
+        db=db, team=pool_team, region=region
+    )
+
+    assert result is not None
+    # max_budget=30, spend=10, no active ledger entries → expected = 10 + 0 + 0 = 10
+    # drift = actual(30) - expected(10) = 20 dollars = 2000 cents
+    assert result.actual_max_budget_cents == 3000
+    assert result.expected_max_budget_cents == 1000
+    assert result.drift_cents == 2000
+
+
+@pytest.mark.asyncio
+@patch("app.core.worker.LiteLLMService")
+@patch("app.core.worker.get_team_region_litellm_keys")
+@patch("app.core.worker.LimitService")
+async def test_pool_team_billing_cycle_uses_31d_and_resets_spend(
+    mock_limit_service,
+    mock_get_keys,
+    mock_litellm_class,
+    db,
+    test_region,
+):
+    """apply_billing_cycle_for_team must work for POOL teams, using 31d duration
+    and resetting key spend to 0.0, exactly like PERIODIC teams."""
+    pool_team = _make_pool_team(db, "Pool Cycle Direct")
+
+    key = DBPrivateAIKey(
+        name="pool-cycle-key",
+        litellm_token="pool-cycle-token",
+        region_id=test_region.id,
+        team_id=pool_team.id,
+    )
+    db.add(key)
+    db.commit()
+
+    mock_limit_service.return_value.get_token_restrictions.return_value = (31, 30.0, 500)
+    mock_get_keys.return_value = [key]
+
+    mock_litellm = mock_litellm_class.return_value
+    mock_litellm.update_team_budget = AsyncMock()
+    mock_litellm.set_key_restrictions = AsyncMock()
+    mock_litellm.get_team_info = AsyncMock(
+        return_value={"team_info": {"spend": 5.0, "max_budget": 30.0}}
+    )
+
+    now = datetime.now(UTC)
+    errors = await apply_billing_cycle_for_team(
+        db=db,
+        team_id=pool_team.id,
+        budget_cents=3000,
+        region_id=test_region.id,
+        period_start=now,
+        period_end=now + timedelta(days=31),
+    )
+
+    assert errors == []
+    team_call = mock_litellm.update_team_budget.await_args
+    assert team_call.kwargs["budget_duration"] == "31d"
+    assert team_call.kwargs["max_budget"] == 30.0
+
+    key_call = mock_litellm.set_key_restrictions.await_args
+    assert key_call.kwargs["spend"] == 0.0
+    assert key_call.kwargs["budget_duration"] == "31d"


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends subscription billing cycle support to `POOL` teams, which previously followed a different (non-subscription) budget path. A new `SUBSCRIPTION_BUDGET_TYPES` frozenset is introduced in `worker.py` and used to gate all billing-cycle functions, while the API endpoints in `budgets.py` and `subscription.py` are updated to accept both `PERIODIC` and `POOL` teams.

- **`worker.py`**: Eight `== BudgetType.PERIODIC` guards replaced with `not in SUBSCRIPTION_BUDGET_TYPES`, covering cycle execution, spend capture, ledger sync, drift reconciliation, and product application. POOL teams now reset key spend to `0.0` and use a fixed `31d` budget duration on each cycle, identical to PERIODIC teams.
- **`budgets.py` / `subscription.py`**: Endpoint-level budget-type gates updated; error messages generalised to "subscription-managed teams". Both files use inline tuples rather than importing the shared `SUBSCRIPTION_BUDGET_TYPES` constant.
- **Tests**: Two existing POOL-team test assertions flipped (duration `20d`→`31d`, spend `None`→`0.0`), and five new integration-level tests added covering the cycle endpoint, Stripe webhook path, drift reconciliation, and the direct billing-cycle function for POOL teams.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the behavioral expansion to POOL teams is consistent across all call sites and well-covered by tests.

The logic change is mechanical and applied uniformly across eight guard sites in worker.py. The new tests exercise the Stripe webhook path, the direct /cycle endpoint, drift reconciliation, and the core billing-cycle function for POOL teams. The only gap is that subscription.py and budgets.py each embed an inline copy of the allowed budget-type set instead of importing the shared SUBSCRIPTION_BUDGET_TYPES constant — if a third subscription type is introduced later, those two files could silently diverge from the worker.

app/api/subscription.py and app/api/budgets.py — they duplicate the allowed-type check rather than reusing the constant from worker.py.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/core/worker.py | Introduces `SUBSCRIPTION_BUDGET_TYPES` frozenset and replaces all `== BudgetType.PERIODIC` guards with `not in SUBSCRIPTION_BUDGET_TYPES` across eight billing cycle functions, cleanly extending subscription behavior to POOL teams. |
| app/api/subscription.py | Updates budget_type gate in `subscription_cycle` to accept POOL alongside PERIODIC; uses an inline tuple `(BudgetType.PERIODIC, BudgetType.POOL)` rather than the shared `SUBSCRIPTION_BUDGET_TYPES` constant from worker.py. |
| app/api/budgets.py | Updates `get_periodic_budget_status` and `create_periodic_topup` to allow POOL teams, also using an inline tuple rather than importing the shared constant. |
| tests/test_periodic_payments.py | Adds 5 new tests covering POOL team subscription cycle acceptance, 404 on unknown team, Stripe invoice.paid processing, drift reconciliation, and 31d billing cycle with spend reset. |
| tests/test_periodic_budget_behavior.py | Revises 2 POOL-team tests to assert the new subscription-cycle behavior: 31d duration (instead of `days_left_in_period`) and spend reset to 0.0 (instead of `None`). |
| scripts/restore_database.py | Formatting-only changes (line wrapping for long lines); no logic changes. |
| app/api/public.py | Single formatting change to a `sorted()` call; no logic impact. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Stripe invoice.paid webhook\nor /billing/subscription/cycle] --> B{team.budget_type\nin SUBSCRIPTION_BUDGET_TYPES?}
    B -- No --> C[Skip / 400 error]
    B -- Yes\nPERIODIC or POOL --> D{First cycle?}
    D -- No --> E[capture_periodic_team_spend_for_period]
    D -- Yes --> F[_record_periodic_payment_direct]
    E --> F
    F --> G[_sync_periodic_ledger_for_period]
    G --> H[apply_billing_cycle_for_team]
    H --> I[update_team_budget\nbudget_duration=31d]
    I --> J[reconcile_periodic_team_budget_drift]
    J --> K[set_key_restrictions\nspend=0.0, duration=31d]
    K --> L[set_team_and_user_limits]
    L --> M[stamp team.last_payment]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix review feedback for subscription cyc..."](https://github.com/amazeeio/amazee.ai/commit/20726953e268d7434b71f0307d702410cfcb14d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35356152)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->