### PR TITLE
refactor(api): update auth for cycle and deactivate subscription endpoints to use RBAC

### DIFF
--- a/app/api/subscription.py
+++ b/app/api/subscription.py
@@ -2,10 +2,8 @@ import logging
 from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session
 
-from app.core.config import settings
 from app.core.security import get_role_min_system_admin
 from app.core.team_service import get_team_region_litellm_keys
 from app.core.worker import (
@@ -33,15 +31,6 @@ from app.services.litellm import LiteLLMService
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
-_security = HTTPBearer()
-
-
-def _verify_moad_api_key(
-    credentials: HTTPAuthorizationCredentials = Depends(_security),
-):
-    if credentials.credentials != settings.MOAD_API_KEY:
-        raise HTTPException(status_code=401, detail="Invalid API key")
-    return credentials.credentials
 
 
 def _write_audit_log(
@@ -237,11 +226,14 @@ async def subscription_cycle(
         raise HTTPException(status_code=500, detail=f"Subscription cycle failed: {exc}")
 
 
-@router.post("/deactivate", response_model=SubscriptionDeactivateResponse)
+@router.post(
+    "/deactivate",
+    response_model=SubscriptionDeactivateResponse,
+    dependencies=[Depends(get_role_min_system_admin)],
+)
 async def subscription_deactivate(
     request: SubscriptionDeactivateRequest,
     db: Session = Depends(get_db),
-    _: str = Depends(_verify_moad_api_key),
 ):
     logger.info("subscription.deactivate called: %s", request.model_dump())
 

--- a/app/api/subscription.py
+++ b/app/api/subscription.py
@@ -1,11 +1,12 @@
 import logging
 from datetime import UTC, datetime, timedelta
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
+from app.core.security import get_role_min_system_admin
 from app.core.team_service import get_team_region_litellm_keys
 from app.core.worker import (
     _record_periodic_payment_direct,
@@ -32,16 +33,14 @@ from app.services.litellm import LiteLLMService
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
-security = HTTPBearer()
+_security = HTTPBearer()
 
 
 def _verify_moad_api_key(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    credentials: HTTPAuthorizationCredentials = Depends(_security),
 ):
     if credentials.credentials != settings.MOAD_API_KEY:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key"
-        )
+        raise HTTPException(status_code=401, detail="Invalid API key")
     return credentials.credentials
 
 
@@ -73,11 +72,14 @@ def _write_audit_log(
             logger.warning("Failed to rollback audit log transaction: %s", rollback_exc)
 
 
-@router.post("/cycle", response_model=SubscriptionCycleResponse)
+@router.post(
+    "/cycle",
+    response_model=SubscriptionCycleResponse,
+    dependencies=[Depends(get_role_min_system_admin)],
+)
 async def subscription_cycle(
     request: SubscriptionCycleRequest,
     db: Session = Depends(get_db),
-    _: str = Depends(_verify_moad_api_key),
 ):
     logger.info("subscription.cycle called: %s", request.model_dump())
 

--- a/tests/test_periodic_payments.py
+++ b/tests/test_periodic_payments.py
@@ -20,10 +20,6 @@ from app.db.models import (
 from app.schemas.models import BudgetType
 
 
-def _auth_headers() -> dict[str, str]:
-    return {"Authorization": "Bearer changeme"}
-
-
 @pytest.mark.asyncio
 async def test_record_periodic_payment_direct_subscription(db, test_team):
     record_id = await _record_periodic_payment_direct(
@@ -204,6 +200,7 @@ def test_subscription_cycle_endpoint_first_cycle(
     mock_apply_cycle,
     mock_record_payment,
     client,
+    admin_token,
     test_team,
     test_region,
 ):
@@ -212,7 +209,7 @@ def test_subscription_cycle_endpoint_first_cycle(
 
     response = client.post(
         "/billing/subscription/cycle",
-        headers=_auth_headers(),
+        headers={"Authorization": f"Bearer {admin_token}"},
         json={
             "transaction_id": "txn_cycle_first",
             "budget_cents": 10000,
@@ -248,6 +245,7 @@ def test_subscription_cycle_endpoint_existing_cycle_runs_snapshot_and_ledger(
     mock_apply_cycle,
     mock_record_payment,
     client,
+    admin_token,
     db,
     test_team,
     test_region,
@@ -272,7 +270,7 @@ def test_subscription_cycle_endpoint_existing_cycle_runs_snapshot_and_ledger(
 
     response = client.post(
         "/billing/subscription/cycle",
-        headers=_auth_headers(),
+        headers={"Authorization": f"Bearer {admin_token}"},
         json={
             "transaction_id": "txn_cycle_repeat",
             "budget_cents": 10000,
@@ -301,6 +299,7 @@ def test_subscription_cycle_endpoint_first_cycle_is_region_scoped(
     mock_apply_cycle,
     mock_record_payment,
     client,
+    admin_token,
     db,
     test_team,
     test_region,
@@ -343,7 +342,7 @@ def test_subscription_cycle_endpoint_first_cycle_is_region_scoped(
 
     response = client.post(
         "/billing/subscription/cycle",
-        headers=_auth_headers(),
+        headers={"Authorization": f"Bearer {admin_token}"},
         json={
             "transaction_id": "txn_cycle_region_scope",
             "budget_cents": 10000,
@@ -433,7 +432,7 @@ async def test_webhook_cycle_first_cycle_is_region_scoped(
     mock_apply_cycle.assert_awaited_once()
 
 
-def test_subscription_cycle_endpoint_idempotent(client, db, test_team):
+def test_subscription_cycle_endpoint_idempotent(client, admin_token, db, test_team):
     payment = DBPeriodicPayment(
         team_id=test_team.id,
         stripe_payment_id="txn_cycle_done",
@@ -449,7 +448,7 @@ def test_subscription_cycle_endpoint_idempotent(client, db, test_team):
 
     response = client.post(
         "/billing/subscription/cycle",
-        headers=_auth_headers(),
+        headers={"Authorization": f"Bearer {admin_token}"},
         json={
             "transaction_id": "txn_cycle_done",
             "budget_cents": 10000,
@@ -469,6 +468,7 @@ def test_subscription_deactivate_endpoint_success(
     mock_litellm_class,
     mock_record_payment,
     client,
+    admin_token,
     db,
     test_team,
     test_region,
@@ -490,7 +490,7 @@ def test_subscription_deactivate_endpoint_success(
 
     response = client.post(
         "/billing/subscription/deactivate",
-        headers=_auth_headers(),
+        headers={"Authorization": f"Bearer {admin_token}"},
         json={
             "transaction_id": "txn_deactivate_1",
             "team_id": test_team.id,
@@ -512,7 +512,7 @@ def test_subscription_deactivate_endpoint_success(
     assert mock_litellm.set_key_restrictions.await_args.kwargs["budget_amount"] == 0.0
 
 
-def test_subscription_deactivate_endpoint_idempotent(client, db, test_team):
+def test_subscription_deactivate_endpoint_idempotent(client, admin_token, db, test_team):
     payment = DBPeriodicPayment(
         team_id=test_team.id,
         stripe_payment_id="txn_deactivate_done",
@@ -528,7 +528,7 @@ def test_subscription_deactivate_endpoint_idempotent(client, db, test_team):
 
     response = client.post(
         "/billing/subscription/deactivate",
-        headers=_auth_headers(),
+        headers={"Authorization": f"Bearer {admin_token}"},
         json={
             "transaction_id": "txn_deactivate_done",
             "team_id": test_team.id,
@@ -573,6 +573,7 @@ def test_pool_subscription_cycle_endpoint_accepted(
     mock_apply_cycle,
     mock_record_payment,
     client,
+    admin_token,
     db,
     test_region,
 ):
@@ -583,7 +584,7 @@ def test_pool_subscription_cycle_endpoint_accepted(
 
     response = client.post(
         "/billing/subscription/cycle",
-        headers=_auth_headers(),
+        headers={"Authorization": f"Bearer {admin_token}"},
         json={
             "transaction_id": "txn_pool_cycle_1",
             "budget_cents": 3000,
@@ -601,12 +602,12 @@ def test_pool_subscription_cycle_endpoint_accepted(
 
 
 def test_pool_subscription_cycle_endpoint_returns_404_for_unknown_team(
-    client, db, test_region
+    client, admin_token, db, test_region
 ):
     """The /cycle endpoint returns 404 when the requested team does not exist."""
     response = client.post(
         "/billing/subscription/cycle",
-        headers=_auth_headers(),
+        headers={"Authorization": f"Bearer {admin_token}"},
         json={
             "transaction_id": "txn_bad_team",
             "budget_cents": 1000,


### PR DESCRIPTION
Updates authentication for the subscription `cycle` and `deactivate` endpoints, shifting both from a shared MOAD API key to role-based access control (system admin) via existing security dependencies.

## Changes

- Restrict `POST /billing/subscription/cycle` to system admins via `Depends(get_role_min_system_admin)`
- Restrict `POST /billing/subscription/deactivate` to system admins via `Depends(get_role_min_system_admin)`, replacing the previous MOAD API key dependency
- Remove the now-unused `_verify_moad_api_key` helper, `_security` HTTPBearer instance, and related imports (`HTTPAuthorizationCredentials`, `HTTPBearer`, `settings`)
- Update all affected tests in `tests/test_periodic_payments.py` to authenticate via the `admin_token` fixture instead of the hardcoded MOAD bearer key

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the MOAD API key auth guard on `POST /billing/subscription/cycle` and `POST /billing/subscription/deactivate` with the existing `get_role_min_system_admin` RBAC dependency, and updates all affected tests to authenticate via the `admin_token` fixture.

- The `_verify_moad_api_key` helper, the module-level `HTTPBearer` instance, and related imports (`HTTPAuthorizationCredentials`, `HTTPBearer`, `settings`) are cleanly removed from `subscription.py`.
- All eight endpoint tests in `test_periodic_payments.py` are migrated from the hardcoded `_auth_headers()` helper (Bearer `changeme`) to the properly issued `admin_token` JWT fixture; no tests are added for the rejection (401/403) paths.
- `MOAD_API_KEY` is now unused by any application code but remains declared in `app/core/config.py`, `docker-compose.yml`, and `README.md`.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the RBAC wiring is straightforward and the happy-path tests all pass with real JWT tokens.

The auth replacement itself is clean — `get_role_min_system_admin` is a well-established dependency used across the codebase and the removal of the old key-check helper leaves no dangling references in app code. The main gaps are the absence of rejection-path tests for the new guard and the audit log losing the opportunity to record the acting user's identity, both of which are non-blocking quality concerns rather than present defects.

Both changed files are straightforward; `app/api/subscription.py` is worth a second look only for the `user_id=None` audit log field now that a real authenticated user is always present.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/api/subscription.py | Replaces MOAD API key guard with `get_role_min_system_admin` on both `/cycle` and `/deactivate` endpoints; removes `_verify_moad_api_key`, `HTTPBearer`, and settings import cleanly. `_write_audit_log` still records `user_id=None` despite a real authenticated user now being present. |
| tests/test_periodic_payments.py | All happy-path tests migrated from the hardcoded `_auth_headers()` helper to the `admin_token` fixture; no tests added for the 401/403 rejection paths introduced by the new RBAC dependency. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as External Caller
    participant EP as /billing/subscription/cycle | deactivate
    participant RBAC as get_role_min_system_admin
    participant Auth as get_current_user_from_auth
    participant DB as Database

    Note over Caller,DB: New RBAC flow (this PR)
    Caller->>EP: POST with Bearer JWT
    EP->>RBAC: Depends(get_role_min_system_admin)
    RBAC->>Auth: get_current_user_from_auth
    Auth->>DB: Lookup JWT / API token
    DB-->>Auth: DBUser
    Auth-->>RBAC: current_user
    RBAC->>RBAC: require_system_admin().check_access(user)
    alt "user.is_admin == True"
        RBAC-->>EP: OK
        EP->>DB: Execute billing logic
        EP-->>Caller: 200 Response
    else not system admin
        RBAC-->>Caller: 403 Forbidden
    else no/invalid token
        Auth-->>Caller: 401 Unauthorized
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/api/subscription.py`, line 36-53 ([link](https://github.com/amazeeio/amazee.ai/blob/703074c5b94f509d9f0da3f8cb10b1c49a7e1ecd/app/api/subscription.py#L36-L53)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Audit log `user_id` stays `None` after RBAC migration**

   `_write_audit_log` always records `user_id=None`. Now that a real authenticated system-admin performs these operations, the caller identity is available in the dependency chain but is not threaded through to the audit record. This means the audit trail for billing cycle and deactivation events cannot answer "who triggered this?"

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(api): update /deactivate endpoint to..."](https://github.com/amazeeio/amazee.ai/commit/703074c5b94f509d9f0da3f8cb10b1c49a7e1ecd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35407100)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->