### PR TITLE
chore: output null manufacturer, update list for mistral, deepseek, etc.

### DIFF
--- a/app/api/public.py
+++ b/app/api/public.py
@@ -177,26 +177,47 @@ def _extract_release_date(model_id: str, model_info: dict[str, Any]) -> str | No
     return None
 
 
-def _infer_manufacturer(model_id: str, item: dict[str, Any]) -> PublicModelManufacturer:
+_MANUFACTURER_RULES: list[dict[str, str | None]] = [
+    {"keyword": "claude", "name": "Anthropic", "website": "https://www.anthropic.com"},
+    {"keyword": "gemini", "name": "Google", "website": "https://deepmind.google/models"},
+    {"keyword": "gemma", "name": "Google", "website": "https://deepmind.google/models"},
+    {"keyword": "gpt", "name": "OpenAI", "website": "https://openai.com"},
+    {"keyword": "mistral", "name": "Mistral AI", "website": "https://mistral.ai"},
+    {"keyword": "pixtral", "name": "Mistral AI", "website": "https://mistral.ai"},
+    {"keyword": "mixtral", "name": "Mistral AI", "website": "https://mistral.ai"},
+    {"keyword": "ministral", "name": "Mistral AI", "website": "https://mistral.ai"},
+    {"keyword": "devstral", "name": "Mistral AI", "website": "https://mistral.ai"},
+    {"keyword": "magistral", "name": "Mistral AI", "website": "https://mistral.ai"},
+    {"keyword": "deepseek", "name": "DeepSeek", "website": "https://www.deepseek.com"},
+    {"keyword": "llama", "name": "Meta", "website": "https://ai.meta.com/llama"},
+    {"keyword": "kimi", "name": "Moonshot", "website": "https://www.moonshot.cn"},
+    {"keyword": "qwen", "name": "Alibaba", "website": "https://www.alibabacloud.com/en/solutions/generative-ai/qwen"},
+    {"keyword": "titan", "name": "Amazon", "website": "https://aws.amazon.com/bedrock/titan"},
+    # Provider-based fallbacks (must be last — match on provider string only)
+    {"keyword": "openai", "name": "OpenAI", "website": "https://openai.com"},
+    {"keyword": "anthropic", "name": "Anthropic", "website": "https://www.anthropic.com"},
+    {"keyword": "google", "name": "Google", "website": "https://deepmind.google/models"},
+    {"keyword": "meta", "name": "Meta", "website": "https://ai.meta.com/llama"},
+]
+
+
+def _infer_manufacturer(model_id: str, item: dict[str, Any]) -> PublicModelManufacturer | None:
     model_info = item.get("model_info", {})
     provider = str(model_info.get("litellm_provider") or "").lower()
     normalized_model_id = model_id.lower()
 
-    if normalized_model_id.startswith("gpt-") or "openai" in provider:
-        name = "OpenAI"
-        website = "https://openai.com"
-    elif normalized_model_id.startswith("claude-") or "anthropic" in provider:
-        name = "Anthropic"
-        website = "https://www.anthropic.com"
-    elif normalized_model_id.startswith("gemini-") or "google" in provider:
-        name = "Google"
-        website = "https://deepmind.google/models"
-    elif normalized_model_id.startswith("llama-") or "meta" in provider:
-        name = "Meta"
-        website = "https://ai.meta.com/llama"
-    else:
-        name = "Unknown"
-        website = None
+    name: str | None = None
+    website: str | None = None
+
+    for rule in _MANUFACTURER_RULES:
+        keyword = str(rule["keyword"])
+        if keyword in normalized_model_id or keyword in provider:
+            name = rule["name"]
+            website = rule["website"]
+            break
+
+    if name is None:
+        return None
 
     version = (
         model_info.get("version")

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -239,7 +239,7 @@ class PublicModelSummary(BaseModel):
     context_length: Optional[int] = None
     max_output_tokens: Optional[int] = None
     description: str
-    manufacturer: PublicModelManufacturer
+    manufacturer: Optional[PublicModelManufacturer] = None
     capabilities: PublicModelCapabilities
     pricing: PublicModelPricing
 

--- a/tests/test_infer_manufacturer.py
+++ b/tests/test_infer_manufacturer.py
@@ -1,0 +1,88 @@
+"""Unit tests for _infer_manufacturer covering keyword and provider-based matching."""
+
+import pytest
+
+from app.api.public import _infer_manufacturer
+
+
+def _item(litellm_provider: str = "") -> dict:
+    return {"model_info": {"litellm_provider": litellm_provider}}
+
+
+class TestKeywordMatch:
+    """Models whose IDs contain a known keyword."""
+
+    @pytest.mark.parametrize(
+        "model_id,expected_name",
+        [
+            ("gpt-4o", "OpenAI"),
+            ("claude-3-5-sonnet-20241022", "Anthropic"),
+            ("gemini-1.5-pro", "Google"),
+            ("gemma-2-27b", "Google"),
+            ("llama-3.1-70b", "Meta"),
+            ("mistral-large-latest", "Mistral AI"),
+            ("pixtral-12b-2409", "Mistral AI"),
+            ("mixtral-8x7b", "Mistral AI"),
+            ("ministral-8b", "Mistral AI"),
+            ("devstral-small", "Mistral AI"),
+            ("magistral-medium", "Mistral AI"),
+            ("deepseek-v3", "DeepSeek"),
+            ("kimi-k2", "Moonshot"),
+            ("qwen-2.5-72b", "Alibaba"),
+            ("titan-text-express", "Amazon"),
+        ],
+    )
+    def test_keyword_in_model_id(self, model_id: str, expected_name: str):
+        result = _infer_manufacturer(model_id, _item())
+        assert result is not None
+        assert result.name == expected_name
+
+
+class TestProviderFallback:
+    """Models whose IDs lack a keyword but provider string matches."""
+
+    @pytest.mark.parametrize(
+        "model_id,provider,expected_name",
+        [
+            ("o1", "openai", "OpenAI"),
+            ("o3-mini", "openai", "OpenAI"),
+            ("o4-mini", "openai", "OpenAI"),
+            ("dall-e-3", "openai", "OpenAI"),
+            ("text-embedding-3-large", "openai", "OpenAI"),
+            ("some-custom-model", "anthropic", "Anthropic"),
+            ("palm-2", "google_ai_studio", "Google"),
+            ("custom-llm", "meta", "Meta"),
+        ],
+    )
+    def test_provider_based_match(
+        self, model_id: str, provider: str, expected_name: str
+    ):
+        result = _infer_manufacturer(model_id, _item(provider))
+        assert result is not None
+        assert result.name == expected_name
+
+
+class TestUnknownReturnsNone:
+    """Models with no matching keyword or provider return None."""
+
+    @pytest.mark.parametrize(
+        "model_id,provider",
+        [
+            ("my-custom-model", ""),
+            ("some-finetune", "custom_provider"),
+            ("random-model", "bedrock_converse"),
+        ],
+    )
+    def test_returns_none(self, model_id: str, provider: str):
+        result = _infer_manufacturer(model_id, _item(provider))
+        assert result is None
+
+
+class TestKeywordPriority:
+    """Keyword in model ID takes priority over provider fallback."""
+
+    def test_model_keyword_wins_over_provider(self):
+        # Model ID says "deepseek" but provider says "openai"
+        result = _infer_manufacturer("deepseek-v3", _item("openai"))
+        assert result is not None
+        assert result.name == "DeepSeek"


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refactors `_infer_manufacturer` from a series of hardcoded `if/elif` branches into a table-driven `_MANUFACTURER_RULES` list, broadening coverage to Mistral AI variants, DeepSeek, Moonshot (Kimi), Alibaba (Qwen), and Amazon (Titan), while replacing the old `"Unknown"` fallback with an explicit `None` return. The `manufacturer` field on `PublicModelSummary` is made `Optional` to match.

- `_MANUFACTURER_RULES` is ordered so that model-ID keyword checks fire first, with provider-string-based fallbacks for OpenAI, Anthropic, Google, and Meta placed last, fixing the gap where o-series and other non-prefixed OpenAI models returned `"Unknown"`.
- `PublicModelManufacturer | None` is now the return type and the schema field is `Optional[PublicModelManufacturer] = None`, meaning unknown/custom models surface `null` to API consumers.
- A dedicated `tests/test_infer_manufacturer.py` covers keyword matching, provider fallbacks, unknown-model `None`, and keyword-priority ordering.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the logic change is well-contained, the new rule table correctly restores provider-based fallbacks for o-series and non-prefixed models, and the test suite covers keyword matching, provider fallbacks, None returns, and priority ordering.

The manufacturer inference logic is fully self-contained and only affects a display/attribution field in the public models response. The schema change to Optional is handled correctly in both the schema and the call site. The only minor gap is that the API documentation still describes manufacturer as a non-null object, which could mislead API consumers into skipping a null-guard.

docs/Public_Models_API.md — the manufacturer field type should be updated to object | null.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/public.py | Replaces hardcoded if/elif manufacturer detection with ordered _MANUFACTURER_RULES list; returns None instead of "Unknown" for unrecognised models; provider-based fallbacks correctly placed last in the rule table. |
| app/schemas/models.py | Makes PublicModelSummary.manufacturer Optional[PublicModelManufacturer] = None to align with the updated return type of _infer_manufacturer. |
| tests/test_infer_manufacturer.py | New test file covering keyword matches, provider-based fallbacks, None returns for unknown models, and priority ordering; all test cases are accurate and well-scoped. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["_infer_manufacturer(model_id, item)"] --> B["Normalise: lower-case model_id + provider"]
    B --> C["Iterate _MANUFACTURER_RULES in order"]
    C --> D{"keyword in model_id\nOR keyword in provider?"}
    D -- Yes --> E["Set name + website, break"]
    D -- No --> F{"More rules?"}
    F -- Yes --> C
    F -- No --> G["name is None"]
    G --> H["return None"]
    E --> I["Build PublicModelManufacturer\n(name, website, version, release_date, attribution)"]
    I --> J["return PublicModelManufacturer"]

    subgraph Rule Order
        R1["claude / gemini / gemma / gpt\n(model-ID keyword checks)"]
        R2["mistral / pixtral / mixtral / ministral\ndevstral / magistral\n(Mistral family)"]
        R3["deepseek / llama / kimi / qwen / titan\n(other vendors)"]
        R4["openai / anthropic / google / meta\n(provider-string fallbacks — last)"]
        R1 --> R2 --> R3 --> R4
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: output null manufacturer, update ..."](https://github.com/amazeeio/amazee.ai/commit/9e48a114c12a173b69f0abf84a9299685d26dc6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35572580)</sub>

<!-- /greptile_comment -->