### PR TITLE
AI API: fix issues from e2e testing

### DIFF
--- a/app/api/subscription.py
+++ b/app/api/subscription.py
@@ -4,6 +4,8 @@ from datetime import UTC, datetime, timedelta
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
+from app.core.config import settings
+from app.core.periodic_budget_ledger_service import compute_active_topup_remaining
 from app.core.security import get_role_min_system_admin
 from app.core.team_service import get_team_region_litellm_keys
 from app.core.worker import (
@@ -276,22 +278,53 @@ async def subscription_deactivate(
         )
 
     try:
+        active_subscription_period = (
+            db.query(DBPeriodicBudgetLedgerEntry)
+            .filter(
+                DBPeriodicBudgetLedgerEntry.team_id == team.id,
+                DBPeriodicBudgetLedgerEntry.region_id == region.id,
+                DBPeriodicBudgetLedgerEntry.entry_type == "subscription",
+                DBPeriodicBudgetLedgerEntry.is_active.is_(True),
+                DBPeriodicBudgetLedgerEntry.effective_period_start.isnot(None),
+                DBPeriodicBudgetLedgerEntry.effective_period_end.isnot(None),
+            )
+            .order_by(
+                DBPeriodicBudgetLedgerEntry.effective_period_end.desc(),
+                DBPeriodicBudgetLedgerEntry.id.desc(),
+            )
+            .first()
+        )
+        if active_subscription_period:
+            await capture_periodic_team_spend_for_period(
+                db=db,
+                team=team,
+                region=region,
+                period_start=active_subscription_period.effective_period_start,
+                period_end=active_subscription_period.effective_period_end,
+                source_event_id=request.transaction_id,
+            )
+
         litellm_service = LiteLLMService(
             api_url=region.litellm_api_url,
             api_key=region.litellm_api_key,
         )
         lite_team_id = LiteLLMService.format_team_id(region.name, team.id)
+        topup_remaining_dollars = (
+            compute_active_topup_remaining(db, team_id=team.id, region_id=region.id)
+            / 100.0
+        )
+        topup_budget_duration = f"{settings.PERIODIC_TOPUP_EXPIRY_DAYS}d"
 
         try:
             await litellm_service.update_team_budget(
                 team_id=lite_team_id,
-                max_budget=0.0,
-                # Safety-net 31d: auto-expires if webhook is missed.
-                budget_duration="31d",
+                max_budget=topup_remaining_dollars,
+                budget_duration=topup_budget_duration,
+                spend=0.0,
             )
         except Exception as exc:
             logger.error(
-                "Failed to zero out LiteLLM team budget for team %s: %s",
+                "Failed to update LiteLLM deactivation budget for team %s: %s",
                 team.id,
                 exc,
             )
@@ -301,16 +334,15 @@ async def subscription_deactivate(
             try:
                 await litellm_service.set_key_restrictions(
                     litellm_token=key.litellm_token,
-                    # Safety-net 31d: auto-expires if webhook is missed.
-                    duration="31d",
-                    budget_duration="31d",
-                    budget_amount=0.0,
+                    duration=topup_budget_duration,
+                    budget_duration=topup_budget_duration,
+                    budget_amount=topup_remaining_dollars,
                     rpm_limit=None,
-                    spend=None,
+                    spend=0.0,
                 )
             except Exception as exc:
                 logger.error(
-                    "Failed to zero out LiteLLM key budget for key %s: %s",
+                    "Failed to update LiteLLM deactivation key budget for key %s: %s",
                     key.id,
                     exc,
                 )

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -1132,6 +1132,7 @@ async def apply_billing_cycle_for_team(
                     team_id=lite_team_id,
                     max_budget=team_max_budget,
                     budget_duration=budget_duration,
+                    spend=0.0,
                 )
                 logger.info(
                     "Updated team %s budget to %s (duration=%s) in region %s",

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -1104,11 +1104,14 @@ async def apply_billing_cycle_for_team(
 
         team_max_budget = per_region_budget
         current_team_spend = 0.0
+        current_team_max_budget: float | None = None
         if keys:
             try:
                 team_info_resp = await litellm_service.get_team_info(lite_team_id)
                 team_info = team_info_resp.get("team_info", team_info_resp)
                 current_team_spend = float(team_info.get("spend", 0.0) or 0.0)
+                if team_info.get("max_budget") is not None:
+                    current_team_max_budget = float(team_info.get("max_budget") or 0.0)
                 topup_remaining_cents = compute_active_topup_remaining(
                     db, team_id=team.id, region_id=region.id
                 )
@@ -1131,10 +1134,17 @@ async def apply_billing_cycle_for_team(
 
         if not sync_errors:
             try:
-                team_max_budget_cents = int(round(team_max_budget * 100))
+                overage_baseline_budget = (
+                    current_team_max_budget
+                    if current_team_max_budget is not None
+                    else team_max_budget
+                )
+                overage_baseline_budget_cents = int(
+                    round(overage_baseline_budget * 100)
+                )
                 current_team_spend_cents = int(round(current_team_spend * 100))
                 carryover_spend_cents = max(
-                    0, current_team_spend_cents - team_max_budget_cents
+                    0, current_team_spend_cents - overage_baseline_budget_cents
                 )
                 carryover_spend = carryover_spend_cents / 100.0
                 await litellm_service.update_team_budget(

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -1103,9 +1103,12 @@ async def apply_billing_cycle_for_team(
         lite_team_id = LiteLLMService.format_team_id(region.name, team.id)
 
         team_max_budget = per_region_budget
+        current_team_spend = 0.0
         if keys:
             try:
-                await litellm_service.get_team_info(lite_team_id)
+                team_info_resp = await litellm_service.get_team_info(lite_team_id)
+                team_info = team_info_resp.get("team_info", team_info_resp)
+                current_team_spend = float(team_info.get("spend", 0.0) or 0.0)
                 topup_remaining_cents = compute_active_topup_remaining(
                     db, team_id=team.id, region_id=region.id
                 )
@@ -1128,17 +1131,24 @@ async def apply_billing_cycle_for_team(
 
         if not sync_errors:
             try:
+                team_max_budget_cents = int(round(team_max_budget * 100))
+                current_team_spend_cents = int(round(current_team_spend * 100))
+                carryover_spend_cents = max(
+                    0, current_team_spend_cents - team_max_budget_cents
+                )
+                carryover_spend = carryover_spend_cents / 100.0
                 await litellm_service.update_team_budget(
                     team_id=lite_team_id,
                     max_budget=team_max_budget,
                     budget_duration=budget_duration,
-                    spend=0.0,
+                    spend=carryover_spend,
                 )
                 logger.info(
-                    "Updated team %s budget to %s (duration=%s) in region %s",
+                    "Updated team %s budget to %s (duration=%s, carryover_spend=%s) in region %s",
                     team.id,
                     team_max_budget,
                     budget_duration,
+                    carryover_spend,
                     region.name,
                 )
                 if keys:

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -570,6 +570,7 @@ class LiteLLMService:
         team_id: str,
         max_budget: Optional[float],
         budget_duration: Optional[str] = None,
+        spend: Optional[float] = None,
         model_aliases: Optional[dict[str, str]] = None,
     ):
         """Update the budget for a LiteLLM team.
@@ -587,6 +588,8 @@ class LiteLLMService:
             request_data["max_budget"] = max_budget
             if budget_duration:
                 request_data["budget_duration"] = budget_duration
+            if spend is not None:
+                request_data["spend"] = spend
             if model_aliases is not None:
                 request_data["model_aliases"] = model_aliases
 

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -578,6 +578,8 @@ class LiteLLMService:
         Args:
             max_budget: Budget limit. None removes the team-level budget gate.
                         0.0 blocks all requests. Positive float sets explicit limit.
+            spend: When provided, overrides the team's spend counter
+                   (e.g. 0.0 to reset spend at billing cycle start).
         """
         try:
             request_data = {

--- a/tests/test_litellm_service.py
+++ b/tests/test_litellm_service.py
@@ -714,6 +714,7 @@ def test_update_team_budget_includes_model_aliases(
             team_id="team-1",
             max_budget=10.0,
             budget_duration="1mo",
+            spend=0.0,
             model_aliases={"gpt-4": "azure/gpt-4-turbo-2024-04-09"},
         )
     )
@@ -725,6 +726,7 @@ def test_update_team_budget_includes_model_aliases(
             "team_id": "team-1",
             "max_budget": 10.0,
             "budget_duration": "1mo",
+            "spend": 0.0,
             "model_aliases": {"gpt-4": "azure/gpt-4-turbo-2024-04-09"},
         },
     )

--- a/tests/test_periodic_payments.py
+++ b/tests/test_periodic_payments.py
@@ -189,6 +189,68 @@ async def test_apply_billing_cycle_for_team_carries_over_spend_overage(
 
 
 @pytest.mark.asyncio
+@patch("app.core.worker.compute_active_topup_remaining", return_value=0)
+@patch("app.core.worker.LiteLLMService")
+@patch("app.core.worker.LimitService")
+async def test_apply_billing_cycle_for_team_carries_over_against_current_litellm_budget(
+    mock_limit_service,
+    mock_litellm_class,
+    _mock_topup,
+    db,
+    test_team,
+    test_region,
+):
+    key = DBPrivateAIKey(
+        name="carryover-key-budget-change",
+        litellm_token="carryover-token-budget-change",
+        region_id=test_region.id,
+        team_id=test_team.id,
+    )
+    db.add(key)
+    payment = DBPeriodicPayment(
+        team_id=test_team.id,
+        stripe_payment_id="pay_sync_carryover_budget_change",
+        amount_cents=200,
+        currency="usd",
+        payment_type="subscription",
+        status="completed",
+        sync_status="pending",
+        payment_date=datetime.now(UTC),
+    )
+    db.add(payment)
+    db.commit()
+
+    mock_limit_service.return_value.get_token_restrictions.return_value = (
+        31,
+        999.0,
+        1000,
+    )
+    mock_litellm = mock_litellm_class.return_value
+    mock_litellm.get_team_info = AsyncMock(
+        return_value={"team_info": {"spend": 1.4, "max_budget": 1.0}}
+    )
+    mock_litellm.update_team_budget = AsyncMock()
+    mock_litellm.set_key_restrictions = AsyncMock()
+
+    errors = await apply_billing_cycle_for_team(
+        db=db,
+        team_id=test_team.id,
+        budget_cents=200,
+        region_id=test_region.id,
+        period_start=datetime.now(UTC),
+        period_end=datetime.now(UTC) + timedelta(days=31),
+        source_payment_id=payment.id,
+    )
+
+    assert errors == []
+    mock_litellm.update_team_budget.assert_awaited_once()
+    # Incoming cycle budget becomes $2.0, but carryover is computed from current
+    # LiteLLM budget ($1.0), so overage remains $0.4.
+    assert mock_litellm.update_team_budget.await_args.kwargs["max_budget"] == 2.0
+    assert mock_litellm.update_team_budget.await_args.kwargs["spend"] == 0.4
+
+
+@pytest.mark.asyncio
 @patch("app.core.worker.LiteLLMService")
 @patch("app.core.worker.LimitService")
 async def test_apply_billing_cycle_for_team_updates_sync_status_failure(

--- a/tests/test_periodic_payments.py
+++ b/tests/test_periodic_payments.py
@@ -123,6 +123,7 @@ async def test_apply_billing_cycle_for_team_updates_sync_status_success(
     mock_litellm.update_team_budget.assert_awaited_once()
     assert mock_litellm.update_team_budget.await_args.kwargs["budget_duration"] == "31d"
     assert mock_litellm.update_team_budget.await_args.kwargs["max_budget"] == 100.0
+    assert mock_litellm.update_team_budget.await_args.kwargs["spend"] == 0.0
     mock_litellm.set_key_restrictions.assert_awaited_once()
     assert mock_litellm.set_key_restrictions.await_args.kwargs["budget_amount"] == 100.0
     assert mock_litellm.set_key_restrictions.await_args.kwargs["spend"] == 0.0
@@ -512,7 +513,9 @@ def test_subscription_deactivate_endpoint_success(
     assert mock_litellm.set_key_restrictions.await_args.kwargs["budget_amount"] == 0.0
 
 
-def test_subscription_deactivate_endpoint_idempotent(client, admin_token, db, test_team):
+def test_subscription_deactivate_endpoint_idempotent(
+    client, admin_token, db, test_team
+):
     payment = DBPeriodicPayment(
         team_id=test_team.id,
         stripe_payment_id="txn_deactivate_done",

--- a/tests/test_periodic_payments.py
+++ b/tests/test_periodic_payments.py
@@ -131,6 +131,64 @@ async def test_apply_billing_cycle_for_team_updates_sync_status_success(
 
 
 @pytest.mark.asyncio
+@patch("app.core.worker.compute_active_topup_remaining", return_value=0)
+@patch("app.core.worker.LiteLLMService")
+@patch("app.core.worker.LimitService")
+async def test_apply_billing_cycle_for_team_carries_over_spend_overage(
+    mock_limit_service,
+    mock_litellm_class,
+    _mock_topup,
+    db,
+    test_team,
+    test_region,
+):
+    key = DBPrivateAIKey(
+        name="carryover-key",
+        litellm_token="carryover-token",
+        region_id=test_region.id,
+        team_id=test_team.id,
+    )
+    db.add(key)
+    payment = DBPeriodicPayment(
+        team_id=test_team.id,
+        stripe_payment_id="pay_sync_carryover",
+        amount_cents=100,
+        currency="usd",
+        payment_type="subscription",
+        status="completed",
+        sync_status="pending",
+        payment_date=datetime.now(UTC),
+    )
+    db.add(payment)
+    db.commit()
+
+    mock_limit_service.return_value.get_token_restrictions.return_value = (
+        31,
+        999.0,
+        1000,
+    )
+    mock_litellm = mock_litellm_class.return_value
+    mock_litellm.get_team_info = AsyncMock(return_value={"team_info": {"spend": 1.4}})
+    mock_litellm.update_team_budget = AsyncMock()
+    mock_litellm.set_key_restrictions = AsyncMock()
+
+    errors = await apply_billing_cycle_for_team(
+        db=db,
+        team_id=test_team.id,
+        budget_cents=100,
+        region_id=test_region.id,
+        period_start=datetime.now(UTC),
+        period_end=datetime.now(UTC) + timedelta(days=31),
+        source_payment_id=payment.id,
+    )
+
+    assert errors == []
+    mock_litellm.update_team_budget.assert_awaited_once()
+    assert mock_litellm.update_team_budget.await_args.kwargs["max_budget"] == 1.0
+    assert mock_litellm.update_team_budget.await_args.kwargs["spend"] == 0.4
+
+
+@pytest.mark.asyncio
 @patch("app.core.worker.LiteLLMService")
 @patch("app.core.worker.LimitService")
 async def test_apply_billing_cycle_for_team_updates_sync_status_failure(

--- a/tests/test_periodic_payments.py
+++ b/tests/test_periodic_payments.py
@@ -509,8 +509,153 @@ def test_subscription_deactivate_endpoint_success(
     }
     mock_litellm.update_team_budget.assert_awaited_once()
     assert mock_litellm.update_team_budget.await_args.kwargs["max_budget"] == 0.0
+    assert (
+        mock_litellm.update_team_budget.await_args.kwargs["budget_duration"] == "365d"
+    )
+    assert mock_litellm.update_team_budget.await_args.kwargs["spend"] == 0.0
     mock_litellm.set_key_restrictions.assert_awaited_once()
     assert mock_litellm.set_key_restrictions.await_args.kwargs["budget_amount"] == 0.0
+    assert (
+        mock_litellm.set_key_restrictions.await_args.kwargs["budget_duration"] == "365d"
+    )
+    assert mock_litellm.set_key_restrictions.await_args.kwargs["spend"] == 0.0
+
+
+@patch("app.api.subscription._record_periodic_payment_direct", new_callable=AsyncMock)
+@patch("app.api.subscription.LiteLLMService")
+def test_subscription_deactivate_preserves_active_topup_budget(
+    mock_litellm_class,
+    mock_record_payment,
+    client,
+    admin_token,
+    db,
+    test_team,
+    test_region,
+):
+    db.add(
+        DBPrivateAIKey(
+            name="deactivate-key-topup",
+            litellm_token="deactivate-token-topup",
+            region_id=test_region.id,
+            team_id=test_team.id,
+        )
+    )
+    db.add(
+        DBPeriodicBudgetLedgerEntry(
+            team_id=test_team.id,
+            region_id=test_region.id,
+            entry_type="topup",
+            source_payment_id=None,
+            source_invoice_id=None,
+            stripe_payment_id="pi_topup_active_1",
+            amount_cents=500,
+            consumed_cents=100,
+            purchased_at=datetime.now(UTC) - timedelta(days=1),
+            effective_period_start=None,
+            effective_period_end=None,
+            expires_at=datetime.now(UTC) + timedelta(days=30),
+            rolled_over_from_id=None,
+            is_active=True,
+        )
+    )
+    db.commit()
+
+    mock_record_payment.return_value = 654
+    mock_litellm = mock_litellm_class.return_value
+    mock_litellm.update_team_budget = AsyncMock()
+    mock_litellm.set_key_restrictions = AsyncMock()
+
+    response = client.post(
+        "/billing/subscription/deactivate",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "transaction_id": "txn_deactivate_with_topup",
+            "team_id": test_team.id,
+            "region_id": test_region.id,
+            "reason": "cancelled",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["payment_id"] == 654
+    mock_litellm.update_team_budget.assert_awaited_once()
+    assert mock_litellm.update_team_budget.await_args.kwargs["max_budget"] == 4.0
+    assert (
+        mock_litellm.update_team_budget.await_args.kwargs["budget_duration"] == "365d"
+    )
+    assert mock_litellm.update_team_budget.await_args.kwargs["spend"] == 0.0
+    mock_litellm.set_key_restrictions.assert_awaited_once()
+    assert mock_litellm.set_key_restrictions.await_args.kwargs["budget_amount"] == 4.0
+    assert (
+        mock_litellm.set_key_restrictions.await_args.kwargs["budget_duration"] == "365d"
+    )
+    assert mock_litellm.set_key_restrictions.await_args.kwargs["spend"] == 0.0
+
+
+@patch(
+    "app.api.subscription.capture_periodic_team_spend_for_period",
+    new_callable=AsyncMock,
+)
+@patch("app.api.subscription._record_periodic_payment_direct", new_callable=AsyncMock)
+@patch("app.api.subscription.LiteLLMService")
+def test_subscription_deactivate_captures_snapshot_before_reset(
+    mock_litellm_class,
+    mock_record_payment,
+    mock_capture_snapshot,
+    client,
+    admin_token,
+    db,
+    test_team,
+    test_region,
+):
+    period_start = datetime.now(UTC) - timedelta(days=5)
+    period_end = datetime.now(UTC) + timedelta(days=26)
+    db.add(
+        DBPeriodicBudgetLedgerEntry(
+            team_id=test_team.id,
+            region_id=test_region.id,
+            entry_type="subscription",
+            source_payment_id=None,
+            source_invoice_id="in_active_sub_1",
+            stripe_payment_id=None,
+            amount_cents=1000,
+            consumed_cents=250,
+            purchased_at=period_start,
+            effective_period_start=period_start,
+            effective_period_end=period_end,
+            expires_at=period_end,
+            rolled_over_from_id=None,
+            is_active=True,
+        )
+    )
+    db.commit()
+
+    mock_record_payment.return_value = 777
+    mock_litellm = mock_litellm_class.return_value
+    mock_litellm.update_team_budget = AsyncMock()
+    mock_litellm.set_key_restrictions = AsyncMock()
+
+    response = client.post(
+        "/billing/subscription/deactivate",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "transaction_id": "txn_deactivate_capture_snapshot",
+            "team_id": test_team.id,
+            "region_id": test_region.id,
+            "reason": "cancelled",
+        },
+    )
+
+    assert response.status_code == 200
+    mock_capture_snapshot.assert_awaited_once()
+    assert mock_capture_snapshot.await_args.kwargs["team"].id == test_team.id
+    assert mock_capture_snapshot.await_args.kwargs["region"].id == test_region.id
+    assert mock_capture_snapshot.await_args.kwargs["period_start"] == period_start
+    assert mock_capture_snapshot.await_args.kwargs["period_end"] == period_end
+    assert (
+        mock_capture_snapshot.await_args.kwargs["source_event_id"]
+        == "txn_deactivate_capture_snapshot"
+    )
 
 
 def test_subscription_deactivate_endpoint_idempotent(


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes several issues discovered during e2e testing of the AI API billing flows. It introduces spend carryover logic when applying a new billing cycle, adds spend-snapshot capture before subscription deactivation, and preserves remaining topup credits when a subscription is cancelled.

- **`worker.py`**: `apply_billing_cycle_for_team` now reads the team's current LiteLLM spend and max-budget, computes the overage against the previous period's ceiling, and passes that as `carryover_spend` when resetting the team budget.
- **`subscription.py`**: Deactivation now calls `capture_periodic_team_spend_for_period` before updating LiteLLM, and sets the team's new budget to the remaining topup balance so topup credits survive cancellation.
- **`litellm.py`**: `update_team_budget` gains an optional `spend` parameter forwarded to LiteLLM's `/team/update` endpoint.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The production logic for carryover computation and topup-preserving deactivation is correct and backed by thorough new tests; a test-quality issue in one existing test is the only noteworthy concern.

The carryover math is correct across both code paths (with and without a stored LiteLLM max_budget), and the capture-before-reset ordering on deactivation is sound. The one fragile spot is the modified test which passes its new spend==0.0 assertion only because MagicMock.__float__ defaults to 1.0 by coincidence rather than explicit setup.

tests/test_periodic_payments.py — the pre-existing billing-cycle success test needs an explicit get_team_info mock now that the carryover path reads from it.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/core/worker.py | Adds carryover-spend computation using current LiteLLM team info; logic is correct and well-tested, though key-level spend is intentionally not carried over while team-level is. |
| app/api/subscription.py | Deactivation now captures spend snapshot and preserves topup budget; capture failure is silently swallowed inside the callee so it won't block deactivation. |
| app/services/litellm.py | Minimal, clean addition of optional spend parameter to update_team_budget; properly guarded with if spend is not None. |
| tests/test_periodic_payments.py | New tests for carryover and deactivation scenarios are thorough, but the modified existing test relies on MagicMock default __float__ behaviour to satisfy the new spend==0.0 assertion. |
| tests/test_litellm_service.py | Straightforward update asserting that spend is forwarded in the request body. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Stripe
    participant SubAPI as subscription.py
    participant Worker as worker.py
    participant LiteLLM
    participant DB

    Note over SubAPI,DB: Billing cycle
    Worker->>LiteLLM: get_team_info(lite_team_id)
    LiteLLM-->>Worker: "{spend, max_budget}"
    Worker->>DB: compute_active_topup_remaining()
    DB-->>Worker: topup_remaining_cents
    Note over Worker: carryover = max(0, spend - old_max_budget)
    Worker->>LiteLLM: "update_team_budget(max_budget=new+topup, spend=carryover)"
    Worker->>LiteLLM: "set_key_restrictions(spend=0.0) per key"

    Note over SubAPI,DB: Subscription deactivation
    Stripe->>SubAPI: POST /billing/subscription/deactivate
    SubAPI->>DB: query active subscription ledger period
    SubAPI->>Worker: capture_periodic_team_spend_for_period()
    Worker->>LiteLLM: fetch_team_spend_snapshot_for_region()
    Worker->>DB: upsert_team_spend_period()
    SubAPI->>DB: compute_active_topup_remaining()
    DB-->>SubAPI: topup_remaining_cents
    SubAPI->>LiteLLM: "update_team_budget(max_budget=topup_remaining, spend=0.0)"
    SubAPI->>LiteLLM: "set_key_restrictions(budget=topup_remaining, spend=0.0)"
    SubAPI->>DB: _record_periodic_payment_direct()
    SubAPI-->>Stripe: 200 OK
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/core/worker.py`, line 1190-1214 ([link](https://github.com/amazeeio/amazee.ai/blob/8780888298bc261b8d4210df55a19588f134a009/app/core/worker.py#L1190-L1214)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Key-level spend not carrying over**

   The team budget is reset with `spend=carryover_spend` to reflect overage from the previous cycle, but every key is unconditionally reset with `spend=0.0`. If LiteLLM enforces team-level and key-level budgets independently, a key will believe it has its full `effective_key_budget` available even though the team has already "pre-spent" `carryover_spend` against its new ceiling. In practice the team limit acts as the hard cap so no over-spend occurs, but it does mean key-level spend counters won't mirror the team-level carryover for reporting/diagnostics. If this asymmetry is intentional it would be worth a brief comment.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(worker): implement carryover budget..."](https://github.com/amazeeio/amazee.ai/commit/8780888298bc261b8d4210df55a19588f134a009) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35814021)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->