### PR TITLE
fix: slack notification

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -9,8 +9,9 @@ COPY requirements-test.txt .
 # Install Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt -r requirements-test.txt
 
-# Copy application code and tests
+# Copy application code, scripts, and tests
 COPY app/ app/
+COPY scripts/ scripts/
 COPY tests/ tests/
 
 # Set environment variables for testing

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ backend-test-regex: backend-test-build test-postgres
 		-e TESTING="1" \
 		-e ENV_SUFFIX="test" \
 		-v $(PWD)/app:/app/app \
+		-v $(PWD)/scripts:/app/scripts \
 		-v $(PWD)/tests:/app/tests \
 		amazee-backend-test pytest -vv -k "$(regex)" || status=$$?; \
 	$(MAKE) test-clean; \
@@ -71,6 +72,7 @@ backend-test: backend-test-build test-postgres
 		-e TESTING="1" \
 		-e ENV_SUFFIX="test" \
 		-v $(PWD)/app:/app/app \
+		-v $(PWD)/scripts:/app/scripts \
 		-v $(PWD)/tests:/app/tests \
 		amazee-backend-test || status=$$?; \
 	$(MAKE) test-clean; \
@@ -92,6 +94,7 @@ backend-test-cov: backend-test-build test-postgres
 		-e TESTING="1" \
 		-e ENV_SUFFIX="test" \
 		-v $(PWD)/app:/app/app \
+		-v $(PWD)/scripts:/app/scripts \
 		-v $(PWD)/tests:/app/tests \
 		amazee-backend-test pytest -v --cov=app tests/ || status=$$?; \
 	$(MAKE) test-clean; \

--- a/app/api/public.py
+++ b/app/api/public.py
@@ -819,14 +819,19 @@ def _normalize_bedrock_provider_id(
 
 async def _collect_region_bedrock_models(
     region: DBRegion,
-) -> tuple[str, dict[str, set[str]]]:
-    """Return ``(region_name, {region_group: {normalized_model_id, ...}})``.
+) -> tuple[str, dict[str, set[str]], dict[str, set[str]]]:
+    """Return ``(region_name, {group: {normalized_id, ...}}, {group: {all_matchable_ids, ...}})``.
+
+    The first dict contains only the canonical normalized model IDs (used for
+    counting deployed models).  The second dict adds aliases extracted from
+    LiteLLM model metadata (used for matching against upstream catalog IDs).
 
     Failures are logged and produce empty sets so a single broken region can't
     take down the whole report.  We deliberately do NOT short-circuit when a
     region returns zero models — that's a legitimate state.
     """
     configured: dict[str, set[str]] = {group: set() for group in _AWS_REGION_GROUPS}
+    matchable: dict[str, set[str]] = {group: set() for group in _AWS_REGION_GROUPS}
 
     service = LiteLLMService(
         api_url=region.litellm_api_url,
@@ -846,7 +851,7 @@ async def _collect_region_bedrock_models(
             region.name,
             exc,
         )
-        return region.name, configured
+        return region.name, configured, matchable
 
     for item in model_info.get("data", []) or []:
         if not isinstance(item, dict):
@@ -870,8 +875,19 @@ async def _collect_region_bedrock_models(
             # double-count and hide real gaps.
             if provider_model_id.startswith(f"bedrock/{details['provider_prefix']}"):
                 configured[group].add(normalized)
+                matchable[group].add(normalized)
+                # Also add all aliases (lowercased) so that models deployed
+                # under a short name (e.g. "qwen3-32b") are matched against
+                # their full upstream Bedrock model ID
+                # (e.g. "qwen.qwen3-32b-v1:0") which appears in the aliases.
+                model_info = item.get("model_info")
+                model_info_dict = model_info if isinstance(model_info, dict) else {}
+                model_name = item.get("model_name") or model_info_dict.get("key") or ""
+                if model_name:
+                    for alias in _extract_aliases(item, model_name):
+                        matchable[group].add(alias)
 
-    return region.name, configured
+    return region.name, configured, matchable
 
 
 async def _build_aws_missing_report(
@@ -897,6 +913,9 @@ async def _build_aws_missing_report(
     configured_by_group: dict[str, set[str]] = {
         group: set() for group in _AWS_REGION_GROUPS
     }
+    matchable_by_group: dict[str, set[str]] = {
+        group: set() for group in _AWS_REGION_GROUPS
+    }
     contributing_regions_by_group: dict[str, set[str]] = {
         group: set() for group in _AWS_REGION_GROUPS
     }
@@ -905,17 +924,25 @@ async def _build_aws_missing_report(
         per_region = await asyncio.gather(
             *(_collect_region_bedrock_models(region) for region in regions)
         )
-        for region_name, region_configured in per_region:
+        for region_name, region_configured, region_matchable in per_region:
             for group, ids in region_configured.items():
                 if ids:
                     configured_by_group[group].update(ids)
+                    matchable_by_group[group].update(region_matchable[group])
                     contributing_regions_by_group[group].add(region_name)
 
     region_groups: list[ProviderRegionMissingModels] = []
     for group, details in _AWS_REGION_GROUPS.items():
         available = available_by_group[group]
         configured_ids = configured_by_group[group]
-        missing_ids = sorted(set(available) - configured_ids)
+        matchable_ids = matchable_by_group[group]
+        # Compare case-insensitively: aliases in matchable_ids are lowercased
+        # by _extract_aliases/_normalize_alias, so lowercase the upstream keys
+        # when computing the set difference.
+        matchable_lower = {mid.lower() for mid in matchable_ids}
+        missing_ids = sorted(
+            mid for mid in available if mid.lower() not in matchable_lower
+        )
         missing_models = [
             BedrockMissingModel(**available[model_id]) for model_id in missing_ids
         ]

--- a/scripts/check_missing_models.py
+++ b/scripts/check_missing_models.py
@@ -62,6 +62,39 @@ def fetch_report(
         raise RuntimeError(f"Failed to reach {url}: {exc}") from exc
 
 
+def fetch_model_card_urls(models_url: str, timeout: int = 60) -> dict[str, str]:
+    """Fetch the upstream Bedrock catalog and return a modelId -> modelCardUrl map.
+
+    Returns an empty dict on failure so that the Slack output gracefully
+    degrades to plain text (no hyperlinks).
+    """
+    if not models_url:
+        return {}
+    request = urllib.request.Request(models_url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            catalog = json.load(response)
+    except (HTTPError, URLError, ValueError):
+        return {}
+
+    if not isinstance(catalog, list):
+        return {}
+
+    urls: dict[str, str] = {}
+    for model in catalog:
+        if not isinstance(model, dict):
+            continue
+        model_id = model.get("modelId")
+        model_card = model.get("modelCard")
+        model_card_url = (
+            model_card.get("modelCardUrl") if isinstance(model_card, dict) else None
+        )
+        if isinstance(model_id, str) and isinstance(model_card_url, str) and model_card_url.strip():
+            urls[model_id] = model_card_url
+
+    return urls
+
+
 def load_state(state_file: Path) -> dict[str, Any]:
     if not state_file.exists():
         return {"region_groups": {}}
@@ -79,14 +112,21 @@ def save_state(state_file: Path, state: dict[str, Any]) -> None:
 
 
 def build_diff(
-    report: dict[str, Any], previous_state: dict[str, Any]
+    report: dict[str, Any],
+    previous_state: dict[str, Any],
+    model_card_urls: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Compute per-region-group ``new_missing`` vs. ``previous_state`` plus
     the next state to persist.
 
     A model counts as "new" only when it appears in the current report and
     *did not* appear in the previous state for the same region group.
+
+    ``model_card_urls`` is an optional mapping of model_id -> documentation URL
+    used to enrich the Slack summary with hyperlinks.
     """
+    if model_card_urls is None:
+        model_card_urls = {}
     summary_sections: list[str] = []
     has_new = False
 
@@ -112,9 +152,16 @@ def build_diff(
                 f"*{group}* ({entry['upstream_region']}) — {len(new_missing)} new missing model(s)"
             ]
             for model in new_missing:
-                section_lines.append(
-                    f"• `{model['model_id']}` ({model['provider_name']} / {model['model_name']})"
-                )
+                model_card_url = model_card_urls.get(model["model_id"])
+                if model_card_url:
+                    safe_name = model['model_name'].replace("&", "&amp;").replace(">", "&gt;").replace("|", "&#124;")
+                    section_lines.append(
+                        f"• `{model['model_id']}` ({model['provider_name']} / <{model_card_url}|{safe_name}>)"
+                    )
+                else:
+                    section_lines.append(
+                        f"• `{model['model_id']}` ({model['provider_name']} / {model['model_name']})"
+                    )
             summary_sections.append("\n".join(section_lines))
 
         diff_groups.append(
@@ -292,8 +339,12 @@ def main() -> int:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
 
+    # Fetch model card URLs from the upstream catalog for Slack hyperlinks.
+    # This is best-effort; failures degrade gracefully to plain text.
+    model_card_urls = fetch_model_card_urls(report.get("models_url", ""))
+
     previous_state = load_state(state_file)
-    diff = build_diff(report, previous_state)
+    diff = build_diff(report, previous_state, model_card_urls)
     save_state(state_file, diff["next_state"])
 
     report_file.write_text(json.dumps(diff, indent=2) + "\n", encoding="utf-8")

--- a/tests/test_public_models_missing.py
+++ b/tests/test_public_models_missing.py
@@ -1,7 +1,9 @@
 """Tests for the /models/missing/{provider} endpoint family."""
 
+import json
 from datetime import datetime, UTC
 from unittest.mock import AsyncMock, patch
+from urllib.error import URLError
 
 import httpx
 
@@ -419,3 +421,234 @@ def test_missing_aws_cache_control_is_not_publicly_cacheable(client, db):
         response.headers["Cache-Control"]
         == "no-store, no-cache, must-revalidate, private"
     )
+
+
+# ---------------------------------------------------------------------------
+# Alias-based matching
+# ---------------------------------------------------------------------------
+
+
+def _upstream_catalog_with_qwen():
+    """Upstream catalog containing a model that is deployed under a short alias."""
+    return [
+        {
+            "modelId": "qwen.qwen3-32b-v1:0",
+            "modelName": "Qwen3 32B (dense)",
+            "providerName": "Qwen",
+            "regions": ["us-east-1", "eu-central-1"],
+            "modelLifecycle": {"status": "ACTIVE"},
+            "modelCard": {
+                "modelCardUrl": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-32b.html"
+            },
+        },
+        {
+            "modelId": "anthropic.claude-opus-4-7",
+            "modelName": "Claude Opus 4.7",
+            "providerName": "Anthropic",
+            "regions": ["us-east-1"],
+            "modelLifecycle": {"status": "ACTIVE"},
+        },
+    ]
+
+
+def _model_info_with_aliases(provider_id, model_name, model_key):
+    """Build a fake LiteLLM model_info payload with model_info fields that produce aliases."""
+    return {
+        "data": [
+            {
+                "model_name": model_name,
+                "litellm_params": {"model": provider_id},
+                "model_info": {
+                    "litellm_provider": "bedrock",
+                    "key": model_key,
+                    "model": model_key,
+                },
+            }
+        ]
+    }
+
+
+def test_missing_aws_alias_match_excludes_model(client, db):
+    """A model deployed under a short name whose aliases contain the upstream ID is not missing."""
+    _clear_bedrock_catalog_cache()
+    _make_public_region(db, "us-east-1", suffix="alias-us")
+    admin, password = _make_admin_user(db, email="alias-admin@example.com")
+    token = _get_token(client, admin.email, password)
+
+    # Model deployed as "bedrock/us.qwen3-32b" with model_info containing
+    # the full upstream ID "qwen.qwen3-32b-v1:0" which _extract_aliases picks up.
+    deployed = _model_info_with_aliases(
+        provider_id="bedrock/us.qwen3-32b",
+        model_name="qwen3-32b",
+        model_key="qwen.qwen3-32b-v1:0",
+    )
+
+    with (
+        patch("app.api.public.LiteLLMService") as mock_service_cls,
+        _patch_catalog_fetch(_upstream_catalog_with_qwen()),
+    ):
+        mock_service_cls.return_value.get_model_info = AsyncMock(return_value=deployed)
+        response = client.get(AWS_PATH, headers={"Authorization": f"Bearer {token}"})
+
+    assert response.status_code == 200
+    by_group = {g["region_group"]: g for g in response.json()["region_groups"]}
+    us = by_group["US"]
+    missing_ids = {m["model_id"] for m in us["missing_models"]}
+    # qwen.qwen3-32b-v1:0 should NOT be missing because the alias matches.
+    assert "qwen.qwen3-32b-v1:0" not in missing_ids
+    # anthropic.claude-opus-4-7 IS missing since it's not deployed.
+    assert "anthropic.claude-opus-4-7" in missing_ids
+
+
+# ---------------------------------------------------------------------------
+# Script-level tests (check_missing_models.py)
+# ---------------------------------------------------------------------------
+
+
+def test_build_diff_uses_model_card_urls_for_slack_hyperlinks():
+    """build_diff enriches Slack output with hyperlinks from model_card_urls lookup."""
+    import runpy
+    from pathlib import Path
+
+    _module = runpy.run_path(
+        str(Path(__file__).resolve().parent.parent / "scripts" / "check_missing_models.py")
+    )
+    build_diff = _module["build_diff"]
+
+    report = {
+        "provider": "aws",
+        "generated_at": "2025-01-01T00:00:00Z",
+        "models_url": "https://example.com/models.json",
+        "is_authenticated": True,
+        "region_groups": [
+            {
+                "region_group": "US",
+                "upstream_region": "us-east-1",
+                "regions": ["us-east-1"],
+                "available_model_count": 2,
+                "configured_model_count": 0,
+                "missing_model_count": 2,
+                "missing_models": [
+                    {
+                        "model_id": "qwen.qwen3-32b-v1:0",
+                        "model_name": "Qwen3 32B (dense)",
+                        "provider_name": "Qwen",
+                    },
+                    {
+                        "model_id": "anthropic.claude-opus-4-7",
+                        "model_name": "Claude Opus 4.7",
+                        "provider_name": "Anthropic",
+                    },
+                ],
+            }
+        ],
+    }
+
+    model_card_urls = {
+        "qwen.qwen3-32b-v1:0": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-32b.html",
+    }
+
+    diff = build_diff(report, {"region_groups": {}}, model_card_urls)
+    summary = diff["slack_summary"]
+
+    # Qwen should have a Slack hyperlink
+    assert "<https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-32b.html|Qwen3 32B (dense)>" in summary
+    # Claude should be plain text (no URL available)
+    assert "(Anthropic / Claude Opus 4.7)" in summary
+
+
+def test_build_diff_works_without_model_card_urls():
+    """build_diff falls back to plain text when no model_card_urls provided."""
+    import runpy
+    from pathlib import Path
+
+    _module = runpy.run_path(
+        str(Path(__file__).resolve().parent.parent / "scripts" / "check_missing_models.py")
+    )
+    build_diff = _module["build_diff"]
+
+    report = {
+        "provider": "aws",
+        "generated_at": "2025-01-01T00:00:00Z",
+        "models_url": "https://example.com/models.json",
+        "is_authenticated": True,
+        "region_groups": [
+            {
+                "region_group": "US",
+                "upstream_region": "us-east-1",
+                "regions": ["us-east-1"],
+                "available_model_count": 1,
+                "configured_model_count": 0,
+                "missing_model_count": 1,
+                "missing_models": [
+                    {
+                        "model_id": "qwen.qwen3-32b-v1:0",
+                        "model_name": "Qwen3 32B (dense)",
+                        "provider_name": "Qwen",
+                    },
+                ],
+            }
+        ],
+    }
+
+    # No model_card_urls passed
+    diff = build_diff(report, {"region_groups": {}})
+    summary = diff["slack_summary"]
+    assert "(Qwen / Qwen3 32B (dense))" in summary
+    # No hyperlinks
+    assert "<http" not in summary
+
+
+def test_fetch_model_card_urls_parses_catalog():
+    """fetch_model_card_urls extracts modelCardUrl from the upstream catalog."""
+    import runpy
+    from pathlib import Path
+    from unittest.mock import patch as mock_patch
+    from io import BytesIO
+
+    _module = runpy.run_path(
+        str(Path(__file__).resolve().parent.parent / "scripts" / "check_missing_models.py")
+    )
+    fetch_model_card_urls = _module["fetch_model_card_urls"]
+
+    catalog = json.dumps([
+        {
+            "modelId": "qwen.qwen3-32b-v1:0",
+            "modelCard": {
+                "modelCardUrl": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-32b.html"
+            },
+        },
+        {
+            "modelId": "anthropic.claude-opus-4-7",
+            "modelCard": None,
+        },
+        {
+            "modelId": "meta.llama3-1-70b-instruct-v1:0",
+        },
+    ]).encode()
+
+    with mock_patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__ = lambda s: BytesIO(catalog)
+        mock_urlopen.return_value.__exit__ = lambda s, *a: None
+        urls = fetch_model_card_urls("https://example.com/models.json")
+
+    assert urls == {
+        "qwen.qwen3-32b-v1:0": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-32b.html",
+    }
+
+
+def test_fetch_model_card_urls_returns_empty_on_failure():
+    """fetch_model_card_urls returns {} on network errors."""
+    import runpy
+    from pathlib import Path
+    from unittest.mock import patch as mock_patch
+
+    _module = runpy.run_path(
+        str(Path(__file__).resolve().parent.parent / "scripts" / "check_missing_models.py")
+    )
+    fetch_model_card_urls = _module["fetch_model_card_urls"]
+
+    with mock_patch("urllib.request.urlopen", side_effect=URLError("boom")):
+        urls = fetch_model_card_urls("https://example.com/models.json")
+
+    assert urls == {}


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the Slack notification for missing AWS Bedrock models by enriching it with hyperlinks to model card documentation pages and improving alias-based model matching so that models deployed under short names (e.g. `qwen3-32b`) are correctly matched against their full upstream IDs (e.g. `qwen.qwen3-32b-v1:0`).

- `_collect_region_bedrock_models` now returns a third value (`matchable`) that extends the canonical ID set with LiteLLM aliases, and `_build_aws_missing_report` uses this for the set-difference computation instead of the raw configured IDs.
- `scripts/check_missing_models.py` gains a `fetch_model_card_urls` helper that pulls the upstream Bedrock catalog to build a `modelId → modelCardUrl` map, and `build_diff` uses this to emit Slack `<url|text>` hyperlinks with HTML-entity-escaped display names.
- New unit tests cover alias matching, hyperlink rendering, and graceful degradation when the catalog fetch fails.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the alias-expansion logic is well-guarded and the new Slack enrichment degrades gracefully when the catalog fetch fails.

Both the alias-matching change in public.py and the hyperlink enrichment in the script handle failure paths explicitly (empty sets on region errors, empty dict on catalog fetch errors). The only findings are a variable-name shadow and an unescaped provider_name field, neither of which causes incorrect runtime behaviour today.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/api/public.py | Extends `_collect_region_bedrock_models` to return a `matchable` dict with LiteLLM aliases; `_build_aws_missing_report` uses it for missing-model computation. Local variable `model_info` inside the loop shadows the outer API-response variable of the same name. |
| scripts/check_missing_models.py | Adds `fetch_model_card_urls` for best-effort catalog fetch and enriches `build_diff` with Slack hyperlinks; `model_name` is properly escaped but `provider_name` is left unescaped in both the hyperlinked and plain-text branches. |
| tests/test_public_models_missing.py | Adds integration test for alias-based matching and unit tests for the new script helpers; coverage looks complete for the happy path and network-failure degradation. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Script as check_missing_models.py
    participant API as /models/missing/aws
    participant LiteLLM as LiteLLM Service
    participant Catalog as Bedrock Catalog

    Script->>API: GET /models/missing/aws
    API->>Catalog: _fetch_bedrock_catalog()
    Catalog-->>API: upstream model list
    API->>LiteLLM: get_model_info() (per region)
    LiteLLM-->>API: deployed models + aliases
    Note over API: _collect_region_bedrock_models()<br/>builds configured{} + matchable{}<br/>(canonical IDs + aliases)
    Note over API: _build_aws_missing_report()<br/>diff: available minus matchable_lower
    API-->>Script: ProviderMissingModelsReport (missing_models)

    Script->>Catalog: fetch_model_card_urls(models_url)
    Catalog-->>Script: modelId to modelCardUrl map
    Note over Script: build_diff()<br/>new_missing vs previous_state<br/>enriches Slack lines with url|safe_name
    Script->>Script: save_state()
    Script-->>Slack: slack_summary with hyperlinks
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/api/public.py`, line 951-960 ([link](https://github.com/amazeeio/amazee.ai/blob/a135445c1f3ea2d4a93861811701251c6d98d07d/app/api/public.py#L951-L960)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Metric divergence between `configured_model_count` and `missing_model_count` after alias expansion. `configured_model_count` counts only canonical normalized IDs, while `missing_model_count` is derived from the alias-expanded `matchable_ids`. Once any aliases cover additional upstream IDs, `available_model_count - configured_model_count` will be greater than `missing_model_count`. Consumers who compute coverage as `available - configured` will see it disagree with the explicit missing count. Adding a comment (or a separate `matchable_model_count` field) would help callers understand the distinction.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix: slack notification"](https://github.com/amazeeio/amazee.ai/commit/11630e8eb28e523ea2382e1aed920870ee04f8dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36289400)</sub>

<!-- /greptile_comment -->