### PR TITLE
feat(budgets): add handling for duplicate stripe_payment_id errors an…

### DIFF
--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -61,8 +61,11 @@ def _is_duplicate_stripe_payment_integrity_error(exc: IntegrityError) -> bool:
     constraint_name = (
         getattr(getattr(orig, "diag", None), "constraint_name", "") or ""
     ).lower()
+    if constraint_name:
+        return "stripe_payment_id" in constraint_name
+
     message = str(orig).lower()
-    return "stripe_payment_id" in constraint_name or "stripe_payment_id" in message
+    return "stripe_payment_id" in message
 
 
 # PERIODIC teams use a fixed 31d rolling window so LiteLLM never self-resets

--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -49,6 +49,22 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["budgets"])
 MONTHLY_BUDGET_DURATION = "1mo"
+
+
+def _is_duplicate_stripe_payment_integrity_error(exc: IntegrityError) -> bool:
+    """Return True only for unique stripe_payment_id conflicts."""
+    orig = getattr(exc, "orig", None)
+    pgcode = getattr(orig, "pgcode", None)
+    if pgcode != "23505":
+        return False
+
+    constraint_name = (
+        getattr(getattr(orig, "diag", None), "constraint_name", "") or ""
+    ).lower()
+    message = str(orig).lower()
+    return "stripe_payment_id" in constraint_name or "stripe_payment_id" in message
+
+
 # PERIODIC teams use a fixed 31d rolling window so LiteLLM never self-resets
 # on a calendar boundary. Spend is reset manually on each Stripe webhook renewal.
 PERIODIC_BUDGET_DURATION = "31d"
@@ -495,11 +511,25 @@ async def purchase_periodic_topup(
                 detail="A purchase with this stripe_payment_id already exists",
             )
         db.flush()
-    except IntegrityError:
+    except IntegrityError as exc:
         db.rollback()
+        if _is_duplicate_stripe_payment_integrity_error(exc):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="A purchase with this stripe_payment_id already exists",
+            )
+
+        logger.exception(
+            "IntegrityError while recording periodic top-up",
+            extra={
+                "team_id": team.id,
+                "region_id": region_id,
+                "stripe_payment_id": purchase.stripe_payment_id,
+            },
+        )
         raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="A purchase with this stripe_payment_id already exists",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to record periodic top-up purchase",
         )
 
     service = LiteLLMService(

--- a/app/migrations/versions/20260609_161500_d9a1b2c3e4f5_repair_periodic_payments_id_sequence.py
+++ b/app/migrations/versions/20260609_161500_d9a1b2c3e4f5_repair_periodic_payments_id_sequence.py
@@ -34,7 +34,8 @@ def upgrade() -> None:
     op.execute("ALTER SEQUENCE periodic_payments_id_seq OWNED BY periodic_payments.id")
     op.execute(
         "SELECT setval('periodic_payments_id_seq', "
-        "COALESCE((SELECT MAX(id) FROM periodic_payments), 0), true)"
+        "COALESCE((SELECT MAX(id) FROM periodic_payments), 1), "
+        "EXISTS (SELECT 1 FROM periodic_payments))"
     )
 
 

--- a/app/migrations/versions/20260609_161500_d9a1b2c3e4f5_repair_periodic_payments_id_sequence.py
+++ b/app/migrations/versions/20260609_161500_d9a1b2c3e4f5_repair_periodic_payments_id_sequence.py
@@ -1,0 +1,49 @@
+"""repair periodic_payments id sequence/default drift
+
+Revision ID: d9a1b2c3e4f5
+Revises: 8b7c6d5e4f3a
+Create Date: 2026-06-09 16:15:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "d9a1b2c3e4f5"
+down_revision = "8b7c6d5e4f3a"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(bind, table_name: str) -> bool:
+    return sa.inspect(bind).has_table(table_name)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    if not _table_exists(bind, "periodic_payments"):
+        return
+
+    op.execute("CREATE SEQUENCE IF NOT EXISTS periodic_payments_id_seq START WITH 1")
+    op.execute(
+        "ALTER TABLE periodic_payments "
+        "ALTER COLUMN id SET DEFAULT nextval('periodic_payments_id_seq')"
+    )
+    op.execute("ALTER SEQUENCE periodic_payments_id_seq OWNED BY periodic_payments.id")
+    op.execute(
+        "SELECT setval('periodic_payments_id_seq', "
+        "COALESCE((SELECT MAX(id) FROM periodic_payments), 0), true)"
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    if not _table_exists(bind, "periodic_payments"):
+        return
+
+    op.execute("ALTER TABLE periodic_payments ALTER COLUMN id DROP DEFAULT")
+    op.execute("DROP SEQUENCE IF EXISTS periodic_payments_id_seq")

--- a/scripts/check_missing_models.py
+++ b/scripts/check_missing_models.py
@@ -89,7 +89,11 @@ def fetch_model_card_urls(models_url: str, timeout: int = 60) -> dict[str, str]:
         model_card_url = (
             model_card.get("modelCardUrl") if isinstance(model_card, dict) else None
         )
-        if isinstance(model_id, str) and isinstance(model_card_url, str) and model_card_url.strip():
+        if (
+            isinstance(model_id, str)
+            and isinstance(model_card_url, str)
+            and model_card_url.strip()
+        ):
             urls[model_id] = model_card_url
 
     return urls
@@ -154,7 +158,12 @@ def build_diff(
             for model in new_missing:
                 model_card_url = model_card_urls.get(model["model_id"])
                 if model_card_url:
-                    safe_name = model['model_name'].replace("&", "&amp;").replace(">", "&gt;").replace("|", "&#124;")
+                    safe_name = (
+                        model["model_name"]
+                        .replace("&", "&amp;")
+                        .replace(">", "&gt;")
+                        .replace("|", "&#124;")
+                    )
                     section_lines.append(
                         f"• `{model['model_id']}` ({model['provider_name']} / <{model_card_url}|{safe_name}>)"
                     )

--- a/tests/test_pool_purchases.py
+++ b/tests/test_pool_purchases.py
@@ -339,7 +339,10 @@ def test_create_periodic_topup_duplicate_payment_integrity_error_returns_409(
         )
 
     assert response.status_code == 409
-    assert response.json()["detail"] == "A purchase with this stripe_payment_id already exists"
+    assert (
+        response.json()["detail"]
+        == "A purchase with this stripe_payment_id already exists"
+    )
 
 
 def test_create_periodic_topup_non_stripe_integrity_error_returns_500(
@@ -353,6 +356,9 @@ def test_create_periodic_topup_non_stripe_integrity_error_returns_500(
 
         class diag:  # noqa: N801
             constraint_name = "ix_periodic_payments_team_id"
+
+        def __str__(self):
+            return "duplicate key detail includes stripe_payment_id value"
 
     with patch(
         "app.api.budgets.add_topup_entry",

--- a/tests/test_pool_purchases.py
+++ b/tests/test_pool_purchases.py
@@ -11,6 +11,7 @@ from app.db.models import DBTeamRegion
 from app.schemas.limits import LimitSource, LimitType, OwnerType, ResourceType, UnitType
 from datetime import datetime, UTC, timedelta
 import pytest
+from sqlalchemy.exc import IntegrityError
 from unittest.mock import patch, AsyncMock
 from app.api.budgets import (
     sync_pool_team_budgets,
@@ -308,6 +309,68 @@ def test_create_periodic_topup_duplicate_payment_id(
     )
     assert response.status_code == 409
     assert "already exists" in response.json()["detail"]
+
+
+def test_create_periodic_topup_duplicate_payment_integrity_error_returns_409(
+    client, admin_token, db, test_team, test_region
+):
+    test_team.budget_type = "periodic"
+    db.commit()
+
+    class _OrigUniqueError(Exception):
+        pgcode = "23505"
+
+        class diag:  # noqa: N801
+            constraint_name = "ix_periodic_payments_stripe_payment_id"
+
+    with patch(
+        "app.api.budgets.add_topup_entry",
+        side_effect=IntegrityError("", {}, _OrigUniqueError()),
+    ):
+        response = client.post(
+            f"/budgets/region/{test_region.id}/teams/{test_team.id}/purchase/periodic",
+            json={
+                "amount_cents": 5000,
+                "currency": "usd",
+                "purchased_at": "2026-03-13T10:00:00Z",
+                "stripe_payment_id": f"cs_periodic_{int(time.time() * 1000000)}",
+            },
+            headers={"Authorization": "Bearer " + admin_token},
+        )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "A purchase with this stripe_payment_id already exists"
+
+
+def test_create_periodic_topup_non_stripe_integrity_error_returns_500(
+    client, admin_token, db, test_team, test_region
+):
+    test_team.budget_type = "periodic"
+    db.commit()
+
+    class _OrigIntegrityError(Exception):
+        pgcode = "23505"
+
+        class diag:  # noqa: N801
+            constraint_name = "ix_periodic_payments_team_id"
+
+    with patch(
+        "app.api.budgets.add_topup_entry",
+        side_effect=IntegrityError("", {}, _OrigIntegrityError()),
+    ):
+        response = client.post(
+            f"/budgets/region/{test_region.id}/teams/{test_team.id}/purchase/periodic",
+            json={
+                "amount_cents": 5000,
+                "currency": "usd",
+                "purchased_at": "2026-03-13T10:00:00Z",
+                "stripe_payment_id": f"cs_periodic_{int(time.time() * 1000000)}",
+            },
+            headers={"Authorization": "Bearer " + admin_token},
+        )
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Failed to record periodic top-up purchase"
 
 
 def test_create_periodic_topup_marks_sync_failed_on_litellm_error(

--- a/tests/test_public_models_missing.py
+++ b/tests/test_public_models_missing.py
@@ -511,7 +511,11 @@ def test_build_diff_uses_model_card_urls_for_slack_hyperlinks():
     from pathlib import Path
 
     _module = runpy.run_path(
-        str(Path(__file__).resolve().parent.parent / "scripts" / "check_missing_models.py")
+        str(
+            Path(__file__).resolve().parent.parent
+            / "scripts"
+            / "check_missing_models.py"
+        )
     )
     build_diff = _module["build_diff"]
 
@@ -552,7 +556,10 @@ def test_build_diff_uses_model_card_urls_for_slack_hyperlinks():
     summary = diff["slack_summary"]
 
     # Qwen should have a Slack hyperlink
-    assert "<https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-32b.html|Qwen3 32B (dense)>" in summary
+    assert (
+        "<https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-32b.html|Qwen3 32B (dense)>"
+        in summary
+    )
     # Claude should be plain text (no URL available)
     assert "(Anthropic / Claude Opus 4.7)" in summary
 
@@ -563,7 +570,11 @@ def test_build_diff_works_without_model_card_urls():
     from pathlib import Path
 
     _module = runpy.run_path(
-        str(Path(__file__).resolve().parent.parent / "scripts" / "check_missing_models.py")
+        str(
+            Path(__file__).resolve().parent.parent
+            / "scripts"
+            / "check_missing_models.py"
+        )
     )
     build_diff = _module["build_diff"]
 
@@ -607,25 +618,31 @@ def test_fetch_model_card_urls_parses_catalog():
     from io import BytesIO
 
     _module = runpy.run_path(
-        str(Path(__file__).resolve().parent.parent / "scripts" / "check_missing_models.py")
+        str(
+            Path(__file__).resolve().parent.parent
+            / "scripts"
+            / "check_missing_models.py"
+        )
     )
     fetch_model_card_urls = _module["fetch_model_card_urls"]
 
-    catalog = json.dumps([
-        {
-            "modelId": "qwen.qwen3-32b-v1:0",
-            "modelCard": {
-                "modelCardUrl": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-32b.html"
+    catalog = json.dumps(
+        [
+            {
+                "modelId": "qwen.qwen3-32b-v1:0",
+                "modelCard": {
+                    "modelCardUrl": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-32b.html"
+                },
             },
-        },
-        {
-            "modelId": "anthropic.claude-opus-4-7",
-            "modelCard": None,
-        },
-        {
-            "modelId": "meta.llama3-1-70b-instruct-v1:0",
-        },
-    ]).encode()
+            {
+                "modelId": "anthropic.claude-opus-4-7",
+                "modelCard": None,
+            },
+            {
+                "modelId": "meta.llama3-1-70b-instruct-v1:0",
+            },
+        ]
+    ).encode()
 
     with mock_patch("urllib.request.urlopen") as mock_urlopen:
         mock_urlopen.return_value.__enter__ = lambda s: BytesIO(catalog)
@@ -644,7 +661,11 @@ def test_fetch_model_card_urls_returns_empty_on_failure():
     from unittest.mock import patch as mock_patch
 
     _module = runpy.run_path(
-        str(Path(__file__).resolve().parent.parent / "scripts" / "check_missing_models.py")
+        str(
+            Path(__file__).resolve().parent.parent
+            / "scripts"
+            / "check_missing_models.py"
+        )
     )
     fetch_model_card_urls = _module["fetch_model_card_urls"]
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves `IntegrityError` handling in the periodic top-up purchase endpoint by distinguishing between duplicate-`stripe_payment_id` violations (PostgreSQL error code 23505, constraint name contains \"stripe_payment_id\") and unrelated integrity errors such as primary-key sequence drift. Previously all `IntegrityError`s were silently swallowed and returned as 409 Conflict; now only the Stripe duplicate case returns 409 while others return 500 with structured logging. A companion migration repairs the `periodic_payments.id` sequence that was causing the false 409s.

- **`app/api/budgets.py`**: Adds `_is_duplicate_stripe_payment_integrity_error()` helper and updates the `except IntegrityError` handler to differentiate 409 vs 500 responses, with proper logging for unexpected errors.
- **Migration `d9a1b2c3e4f5`**: Creates `periodic_payments_id_seq` if absent, attaches it as the column default, and seeds it from `MAX(id)` to repair sequence/default drift.
- **`tests/test_pool_purchases.py`**: Adds two new unit tests covering both the 409 (stripe duplicate via mocked `IntegrityError`) and 500 (non-stripe constraint violation) paths.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the error-handling fix is well-scoped and the migration is properly guarded and idempotent.

The core logic change is correct and well-tested. The only concerns are a slightly over-permissive message-string fallback in the duplicate-detection helper and a minor migration cosmetic around setval(0). Neither affects correctness in the normal production path.

The `_is_duplicate_stripe_payment_integrity_error` helper in `app/api/budgets.py` and the `setval` call in the migration are worth a second look, but neither blocks the change.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/budgets.py | Adds `_is_duplicate_stripe_payment_integrity_error` helper and refines the except-IntegrityError block; logic is sound with a minor concern about the message-string fallback being slightly over-permissive. |
| app/migrations/versions/20260609_161500_d9a1b2c3e4f5_repair_periodic_payments_id_sequence.py | Repairs `periodic_payments` id sequence drift; guarded by dialect/table checks, uses IF NOT EXISTS, and seeds correctly from MAX(id). Down-revision correctly chains to 8b7c6d5e4f3a. |
| tests/test_pool_purchases.py | Two new tests cover the 409 (stripe_payment_id constraint) and 500 (other unique constraint) paths by mocking `add_topup_entry` with realistic fake psycopg2 diagnostics objects. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[POST /purchase/periodic] --> B{existing_topup in ledger?}
    B -- Yes --> C[HTTP 409 Conflict\nduplicate stripe_payment_id]
    B -- No --> D[try block:\nadd DBPeriodicPayment + flush]
    D --> E[add_topup_entry]
    E --> F{entry returned?}
    F -- None\nexisting found --> G[HTTP 409 Conflict\nduplicate stripe_payment_id]
    F -- entry --> H[db.flush]
    H --> I[LiteLLM budget sync]
    D -- IntegrityError --> J[db.rollback]
    E -- IntegrityError --> J
    H -- IntegrityError --> J
    J --> K{_is_duplicate_stripe_payment\n_integrity_error?}
    K -- True\npgcode=23505 + constraint\ncontains stripe_payment_id --> L[HTTP 409 Conflict]
    K -- False\nother IntegrityError --> M[logger.exception + HTTP 500]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test: cover periodic topup IntegrityErro..."](https://github.com/amazeeio/amazee.ai/commit/a89886d1dddb61ca088e7ef67663bd37cc17c2bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36449552)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->