### PR TITLE
feat(budgets): prevent requests from zero budget POOL teams/keys

### DIFF
--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -509,10 +509,20 @@ async def purchase_periodic_topup(
         api_url=region.litellm_api_url, api_key=region.litellm_api_key
     )
     lite_team_id = LiteLLMService.format_team_id(region.name, team.id)
+    previous_team_max_budget: float | None = None
+    previous_team_budget_duration: str | None = None
+    team_budget_updated = False
     try:
         team_info_resp = await service.get_team_info(lite_team_id)
         team_info = team_info_resp.get("team_info", team_info_resp)
         current_spend = float(team_info.get("spend", 0.0) or 0.0)
+        previous_max_budget_raw = team_info.get("max_budget")
+        previous_team_max_budget = (
+            float(previous_max_budget_raw)
+            if previous_max_budget_raw is not None
+            else None
+        )
+        previous_team_budget_duration = team_info.get("budget_duration")
 
         sub_remaining_cents = 0
         now_topup = datetime.now(UTC)
@@ -544,6 +554,7 @@ async def purchase_periodic_topup(
             max_budget=new_total_budget,
             budget_duration=PERIODIC_BUDGET_DURATION,
         )
+        team_budget_updated = True
         if team.requires_pool_purchase_gate:
             key_sync_errors = await _sync_pool_key_effective_budgets(
                 db,
@@ -557,6 +568,21 @@ async def purchase_periodic_topup(
         payment_record.error_log = None
         db.commit()
     except Exception as exc:
+        if team_budget_updated:
+            try:
+                await service.update_team_budget(
+                    team_id=lite_team_id,
+                    max_budget=previous_team_max_budget,
+                    budget_duration=previous_team_budget_duration,
+                    clear_budget_duration=previous_team_budget_duration is None,
+                )
+            except Exception as rollback_exc:
+                logger.error(
+                    "Failed to roll back LiteLLM team budget after top-up sync failure for team_id=%s region_id=%s: %s",
+                    team.id,
+                    region_id,
+                    str(rollback_exc),
+                )
         # Top-up purchase failed to reach LiteLLM; do not keep allocatable
         # balance in the periodic ledger for this failed API purchase.
         if topup_entry is not None:
@@ -702,6 +728,13 @@ async def sync_pool_team_budgets(db: Session) -> dict:
         if not expired_region_ids:
             continue
 
+        expired_regions = {
+            region.id: region
+            for region in db.query(DBRegion)
+            .filter(DBRegion.id.in_(expired_region_ids))
+            .all()
+        }
+
         if all_regions_expired:
             # All regions expired, propagate $0 budget to team and all keys
             team_had_any_update = False
@@ -715,7 +748,7 @@ async def sync_pool_team_budgets(db: Session) -> dict:
                     update_key_limits=False,
                     apply_to_keys=False,
                 )
-                region = db.query(DBRegion).filter(DBRegion.id == rid).first()
+                region = expired_regions.get(rid)
                 if region is not None:
                     errors.extend(
                         await _sync_pool_key_effective_budgets(
@@ -746,7 +779,7 @@ async def sync_pool_team_budgets(db: Session) -> dict:
                     update_key_limits=False,
                     apply_to_keys=False,
                 )
-                region = db.query(DBRegion).filter(DBRegion.id == rid).first()
+                region = expired_regions.get(rid)
                 if region is not None:
                     errors.extend(
                         await _sync_pool_key_effective_budgets(

--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -237,6 +237,7 @@ async def _sync_pool_key_effective_budgets(
                         budget_duration=MONTHLY_BUDGET_DURATION,
                         max_budget=0.0,
                         clear_max_budget=False,
+                        blocked=True,
                     )
                 else:
                     configured_cap = cap_map.get(key.id)
@@ -249,6 +250,7 @@ async def _sync_pool_key_effective_budgets(
                             max_budget=None,
                             clear_max_budget=True,
                             clear_budget_duration=True,
+                            blocked=False,
                         )
                     else:
                         await service.update_key_budget(
@@ -256,6 +258,7 @@ async def _sync_pool_key_effective_budgets(
                             budget_duration=MONTHLY_BUDGET_DURATION,
                             max_budget=configured_cap,
                             clear_max_budget=False,
+                            blocked=False,
                         )
             return None
         except Exception as exc:
@@ -541,6 +544,15 @@ async def purchase_periodic_topup(
             max_budget=new_total_budget,
             budget_duration=PERIODIC_BUDGET_DURATION,
         )
+        if team.requires_pool_purchase_gate:
+            key_sync_errors = await _sync_pool_key_effective_budgets(
+                db,
+                team_id=team.id,
+                region=region,
+                purchased_total=desired_remaining,
+            )
+            if key_sync_errors:
+                raise RuntimeError("; ".join(key_sync_errors))
         payment_record.sync_status = "success"
         payment_record.error_log = None
         db.commit()
@@ -703,6 +715,16 @@ async def sync_pool_team_budgets(db: Session) -> dict:
                     update_key_limits=False,
                     apply_to_keys=False,
                 )
+                region = db.query(DBRegion).filter(DBRegion.id == rid).first()
+                if region is not None:
+                    errors.extend(
+                        await _sync_pool_key_effective_budgets(
+                            db,
+                            team_id=team.id,
+                            region=region,
+                            purchased_total=0.0,
+                        )
+                    )
                 errors.extend(result["errors"])
                 if result["teams_updated"] > 0:
                     team_had_any_update = True
@@ -724,6 +746,16 @@ async def sync_pool_team_budgets(db: Session) -> dict:
                     update_key_limits=False,
                     apply_to_keys=False,
                 )
+                region = db.query(DBRegion).filter(DBRegion.id == rid).first()
+                if region is not None:
+                    errors.extend(
+                        await _sync_pool_key_effective_budgets(
+                            db,
+                            team_id=team.id,
+                            region=region,
+                            purchased_total=0.0,
+                        )
+                    )
                 errors.extend(result["errors"])
                 if result["teams_updated"] > 0:
                     team_had_any_update = True

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -513,6 +513,13 @@ async def create_llm_token(
             max_budget=max_max_spend,
             rpm_limit=max_rpm_limit,
             apply_limits=not is_pool_team,
+            blocked=(
+                True
+                if is_pool_team
+                and pool_purchased_total is not None
+                and pool_purchased_total <= 0
+                else None
+            ),
         )
         if (
             is_pool_team
@@ -524,6 +531,7 @@ async def create_llm_token(
                 budget_duration=f"{settings.POOL_PURCHASE_EXPIRY_DAYS}d",
                 max_budget=0.0,
                 clear_max_budget=False,
+                blocked=True,
             )
 
         # Create response object

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -531,7 +531,6 @@ async def create_llm_token(
                 budget_duration=f"{settings.POOL_PURCHASE_EXPIRY_DAYS}d",
                 max_budget=0.0,
                 clear_max_budget=False,
-                blocked=True,
             )
 
         # Create response object

--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -543,7 +543,7 @@ async def _enforce_pool_no_purchase_key_lock(
 ) -> bool:
     """
     For prepaid-pool teams with no purchased budget in a region, hard-lock
-    keys by setting max_budget=0 in LiteLLM to avoid the team budget zero-edge.
+    keys in LiteLLM to avoid the team budget zero-edge.
     """
     if team is None or not team.requires_pool_purchase_gate:
         return False
@@ -573,6 +573,7 @@ async def _enforce_pool_no_purchase_key_lock(
                     budget_duration=MONTHLY_BUDGET_DURATION,
                     max_budget=0.0,
                     clear_max_budget=False,
+                    blocked=True,
                 )
             return None
         except Exception as exc:

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -108,6 +108,7 @@ class LiteLLMService:
         max_budget: Optional[float] = DEFAULT_MAX_SPEND,
         rpm_limit: Optional[int] = DEFAULT_RPM_PER_KEY,
         apply_limits: bool = True,
+        blocked: Optional[bool] = None,
     ) -> str:
         """Create a new API key for LiteLLM"""
         try:
@@ -143,6 +144,8 @@ class LiteLLMService:
             request_data["key_alias"] = clean_alias
             request_data["metadata"] = metadata
             request_data["team_id"] = team_id
+            if blocked is not None:
+                request_data["blocked"] = blocked
 
             request_data["duration"] = "365d"  # Sets the key expiry date
             if settings.ENABLE_LIMITS and apply_limits:
@@ -297,6 +300,7 @@ class LiteLLMService:
         max_budget: Optional[float] = None,
         clear_max_budget: bool = False,
         clear_budget_duration: bool = False,
+        blocked: Optional[bool] = None,
     ) -> None:
         """Update budget fields for a LiteLLM key.
 
@@ -312,6 +316,8 @@ class LiteLLMService:
                 request_data["budget_duration"] = budget_duration
             if clear_max_budget or max_budget is not None:
                 request_data["max_budget"] = max_budget
+            if blocked is not None:
+                request_data["blocked"] = blocked
 
             async with httpx.AsyncClient() as client:
                 response = await client.post(

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -578,6 +578,7 @@ class LiteLLMService:
         budget_duration: Optional[str] = None,
         spend: Optional[float] = None,
         model_aliases: Optional[dict[str, str]] = None,
+        clear_budget_duration: bool = False,
     ):
         """Update the budget for a LiteLLM team.
 
@@ -594,7 +595,7 @@ class LiteLLMService:
             # Always include max_budget, even when None, so LiteLLM receives
             # JSON null when the intent is to clear the team-level budget gate.
             request_data["max_budget"] = max_budget
-            if budget_duration:
+            if clear_budget_duration or budget_duration is not None:
                 request_data["budget_duration"] = budget_duration
             if spend is not None:
                 request_data["spend"] = spend

--- a/scripts/check_missing_models.py
+++ b/scripts/check_missing_models.py
@@ -89,7 +89,11 @@ def fetch_model_card_urls(models_url: str, timeout: int = 60) -> dict[str, str]:
         model_card_url = (
             model_card.get("modelCardUrl") if isinstance(model_card, dict) else None
         )
-        if isinstance(model_id, str) and isinstance(model_card_url, str) and model_card_url.strip():
+        if (
+            isinstance(model_id, str)
+            and isinstance(model_card_url, str)
+            and model_card_url.strip()
+        ):
             urls[model_id] = model_card_url
 
     return urls
@@ -154,7 +158,12 @@ def build_diff(
             for model in new_missing:
                 model_card_url = model_card_urls.get(model["model_id"])
                 if model_card_url:
-                    safe_name = model['model_name'].replace("&", "&amp;").replace(">", "&gt;").replace("|", "&#124;")
+                    safe_name = (
+                        model["model_name"]
+                        .replace("&", "&amp;")
+                        .replace(">", "&gt;")
+                        .replace("|", "&#124;")
+                    )
                     section_lines.append(
                         f"• `{model['model_id']}` ({model['provider_name']} / <{model_card_url}|{safe_name}>)"
                     )

--- a/tests/test_litellm_service.py
+++ b/tests/test_litellm_service.py
@@ -783,6 +783,35 @@ def test_update_team_budget_includes_model_aliases(
     )
 
 
+@patch("httpx.AsyncClient")
+def test_update_team_budget_clear_budget_duration_sends_null(
+    mock_client_class, test_region, mock_httpx_post_client
+):
+    mock_client_class.return_value = mock_httpx_post_client
+    service = LiteLLMService(
+        api_url=test_region.litellm_api_url, api_key=test_region.litellm_api_key
+    )
+
+    asyncio.run(
+        service.update_team_budget(
+            team_id="team-1",
+            max_budget=None,
+            budget_duration=None,
+            clear_budget_duration=True,
+        )
+    )
+
+    mock_httpx_post_client.post.assert_called_once_with(
+        f"{test_region.litellm_api_url}/team/update",
+        headers={"Authorization": f"Bearer {test_region.litellm_api_key}"},
+        json={
+            "team_id": "team-1",
+            "max_budget": None,
+            "budget_duration": None,
+        },
+    )
+
+
 def test_get_team_model_aliases_reads_team_info(test_region):
     service = LiteLLMService(
         api_url=test_region.litellm_api_url, api_key=test_region.litellm_api_key

--- a/tests/test_litellm_service.py
+++ b/tests/test_litellm_service.py
@@ -102,6 +102,30 @@ def test_create_key_with_email_fallback(
     assert call_args.kwargs["json"]["key_alias"] == "test_at_example.com_-_key-123"
 
 
+@patch("httpx.AsyncClient")
+def test_create_key_can_create_blocked_key(
+    mock_client_class, test_region, mock_httpx_post_client
+):
+    mock_client_class.return_value = mock_httpx_post_client
+
+    service = LiteLLMService(
+        api_url=test_region.litellm_api_url, api_key=test_region.litellm_api_key
+    )
+
+    asyncio.run(
+        service.create_key(
+            email="test@example.com",
+            name="Test Key",
+            user_id=123,
+            team_id="team-456",
+            blocked=True,
+        )
+    )
+
+    call_args = mock_httpx_post_client.post.call_args
+    assert call_args.kwargs["json"]["blocked"] is True
+
+
 @patch("app.core.config.settings.ENABLE_LIMITS", True)
 def test_create_key_with_limits_requires_non_none_values(test_region):
     """Test create_key validates required per-key limits when apply_limits is True."""
@@ -450,6 +474,33 @@ def test_update_key_budget_clear_budget_fields_send_nulls(
             "key": "test-token",
             "budget_duration": None,
             "max_budget": None,
+        },
+    )
+
+
+@patch("httpx.AsyncClient")
+def test_update_key_budget_can_toggle_blocked(
+    mock_client_class, test_region, mock_httpx_post_client
+):
+    mock_client_class.return_value = mock_httpx_post_client
+
+    service = LiteLLMService(
+        api_url=test_region.litellm_api_url, api_key=test_region.litellm_api_key
+    )
+
+    asyncio.run(
+        service.update_key_budget(
+            litellm_token="test-token",
+            blocked=False,
+        )
+    )
+
+    mock_httpx_post_client.post.assert_called_once_with(
+        f"{test_region.litellm_api_url}/key/update",
+        headers={"Authorization": f"Bearer {test_region.litellm_api_key}"},
+        json={
+            "key": "test-token",
+            "blocked": False,
         },
     )
 

--- a/tests/test_pool_purchases.py
+++ b/tests/test_pool_purchases.py
@@ -3,6 +3,7 @@ import time
 from app.db.models import (
     DBLimitedResource,
     DBPoolPurchase,
+    DBPrivateAIKey,
     DBSpendCap,
     DBPeriodicPayment,
 )
@@ -568,6 +569,66 @@ def test_pool_purchase_restores_team_budget_when_key_sync_fails(
         .first()
     )
     assert purchase is not None
+
+
+def test_pool_purchase_rolls_back_team_budget_when_key_sync_fails(
+    client, admin_token, db, test_team, test_region
+):
+    test_team.budget_type = "pool"
+    db.add(
+        DBPrivateAIKey(
+            litellm_token="sk-key-sync-fails",
+            team_id=test_team.id,
+            region_id=test_region.id,
+            name="blocked pool key",
+        )
+    )
+    db.commit()
+
+    with patch("app.api.budgets.LiteLLMService") as mock_litellm:
+        mock_litellm.format_team_id.side_effect = lambda region_name, team_id: (
+            f"{region_name.replace(' ', '_')}_{team_id}"
+        )
+        mock_instance = mock_litellm.return_value
+        mock_instance.get_team_info = AsyncMock(
+            return_value={
+                "team_info": {
+                    "max_budget": 0.0,
+                    "budget_duration": None,
+                    "spend": 0.0,
+                }
+            }
+        )
+        mock_instance.update_team_budget = AsyncMock()
+        mock_instance.update_key_budget = AsyncMock(
+            side_effect=RuntimeError("key sync failed")
+        )
+
+        response = client.post(
+            f"/budgets/region/{test_region.id}/teams/{test_team.id}/purchase",
+            json={
+                "amount_cents": 5000,
+                "currency": "usd",
+                "purchased_at": "2026-03-13T10:00:00Z",
+                "stripe_payment_id": f"pi_key_sync_rollback_{int(time.time() * 1000000)}",
+            },
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+    assert response.status_code == 502
+    assert mock_instance.update_team_budget.await_count == 2
+    first_call, rollback_call = mock_instance.update_team_budget.await_args_list
+    assert first_call.kwargs == {
+        "team_id": f"{test_region.name}_{test_team.id}",
+        "max_budget": 50.0,
+        "budget_duration": "31d",
+    }
+    assert rollback_call.kwargs == {
+        "team_id": f"{test_region.name}_{test_team.id}",
+        "max_budget": 0.0,
+        "budget_duration": None,
+        "clear_budget_duration": True,
+    }
 
 
 def test_pool_purchase_preserves_operator_manual_cap_below_purchased_total(

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -1464,7 +1464,7 @@ def test_create_llm_token_for_pool_team_skips_per_key_limits(
         if str(call.args[0]).endswith("/key/update")
     ]
     assert len(key_update_calls) == 1
-    assert key_update_calls[0].kwargs["json"]["blocked"] is True
+    assert "blocked" not in key_update_calls[0].kwargs["json"]
 
 
 @patch("httpx.AsyncClient")

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch, Mock, AsyncMock
 from app.db.models import (
     DBPrivateAIKey,
+    DBPoolPurchase,
     DBTeam,
     DBUser,
     DBProduct,
@@ -1455,6 +1456,67 @@ def test_create_llm_token_for_pool_team_skips_per_key_limits(
     assert "budget_duration" not in call_args["json"]
     assert "max_budget" not in call_args["json"]
     assert "rpm_limit" not in call_args["json"]
+    assert call_args["json"]["blocked"] is True
+
+    key_update_calls = [
+        call
+        for call in mock_httpx_post_client.post.call_args_list
+        if str(call.args[0]).endswith("/key/update")
+    ]
+    assert len(key_update_calls) == 1
+    assert key_update_calls[0].kwargs["json"]["blocked"] is True
+
+
+@patch("httpx.AsyncClient")
+@patch("app.core.config.settings.ENABLE_LIMITS", True)
+def test_create_llm_token_for_pool_team_with_purchase_does_not_block_key(
+    mock_client_class,
+    client,
+    admin_token,
+    test_region,
+    db,
+    test_team,
+    mock_httpx_post_client,
+):
+    test_team.budget_type = "pool"
+    db.add(
+        DBPoolPurchase(
+            team_id=test_team.id,
+            region_id=test_region.id,
+            amount_cents=1000,
+            currency="usd",
+            purchased_at=datetime.now(UTC),
+            stripe_payment_id="pi_pool_existing_purchase",
+            created_at=datetime.now(UTC),
+        )
+    )
+    db.commit()
+
+    mock_client_class.return_value = mock_httpx_post_client
+
+    response = client.post(
+        "/private-ai-keys/token",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "region_id": test_region.id,
+            "name": "Pool Team Key With Budget",
+            "team_id": test_team.id,
+        },
+    )
+
+    assert response.status_code == 200
+
+    key_generate_calls = [
+        call
+        for call in mock_httpx_post_client.post.call_args_list
+        if str(call.args[0]).endswith("/key/generate")
+        and call.kwargs.get("json", {})
+        .get("metadata", {})
+        .get("amazeeai_private_ai_key_name")
+        == "Pool Team Key With Budget"
+    ]
+    assert len(key_generate_calls) == 1
+    assert "blocked" not in key_generate_calls[0].kwargs["json"]
 
 
 def test_create_vector_db_as_system_admin(client, admin_token, test_region):

--- a/tests/test_public_models_missing.py
+++ b/tests/test_public_models_missing.py
@@ -511,7 +511,11 @@ def test_build_diff_uses_model_card_urls_for_slack_hyperlinks():
     from pathlib import Path
 
     _module = runpy.run_path(
-        str(Path(__file__).resolve().parent.parent / "scripts" / "check_missing_models.py")
+        str(
+            Path(__file__).resolve().parent.parent
+            / "scripts"
+            / "check_missing_models.py"
+        )
     )
     build_diff = _module["build_diff"]
 
@@ -552,7 +556,10 @@ def test_build_diff_uses_model_card_urls_for_slack_hyperlinks():
     summary = diff["slack_summary"]
 
     # Qwen should have a Slack hyperlink
-    assert "<https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-32b.html|Qwen3 32B (dense)>" in summary
+    assert (
+        "<https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-32b.html|Qwen3 32B (dense)>"
+        in summary
+    )
     # Claude should be plain text (no URL available)
     assert "(Anthropic / Claude Opus 4.7)" in summary
 
@@ -563,7 +570,11 @@ def test_build_diff_works_without_model_card_urls():
     from pathlib import Path
 
     _module = runpy.run_path(
-        str(Path(__file__).resolve().parent.parent / "scripts" / "check_missing_models.py")
+        str(
+            Path(__file__).resolve().parent.parent
+            / "scripts"
+            / "check_missing_models.py"
+        )
     )
     build_diff = _module["build_diff"]
 
@@ -607,25 +618,31 @@ def test_fetch_model_card_urls_parses_catalog():
     from io import BytesIO
 
     _module = runpy.run_path(
-        str(Path(__file__).resolve().parent.parent / "scripts" / "check_missing_models.py")
+        str(
+            Path(__file__).resolve().parent.parent
+            / "scripts"
+            / "check_missing_models.py"
+        )
     )
     fetch_model_card_urls = _module["fetch_model_card_urls"]
 
-    catalog = json.dumps([
-        {
-            "modelId": "qwen.qwen3-32b-v1:0",
-            "modelCard": {
-                "modelCardUrl": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-32b.html"
+    catalog = json.dumps(
+        [
+            {
+                "modelId": "qwen.qwen3-32b-v1:0",
+                "modelCard": {
+                    "modelCardUrl": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-32b.html"
+                },
             },
-        },
-        {
-            "modelId": "anthropic.claude-opus-4-7",
-            "modelCard": None,
-        },
-        {
-            "modelId": "meta.llama3-1-70b-instruct-v1:0",
-        },
-    ]).encode()
+            {
+                "modelId": "anthropic.claude-opus-4-7",
+                "modelCard": None,
+            },
+            {
+                "modelId": "meta.llama3-1-70b-instruct-v1:0",
+            },
+        ]
+    ).encode()
 
     with mock_patch("urllib.request.urlopen") as mock_urlopen:
         mock_urlopen.return_value.__enter__ = lambda s: BytesIO(catalog)
@@ -644,7 +661,11 @@ def test_fetch_model_card_urls_returns_empty_on_failure():
     from unittest.mock import patch as mock_patch
 
     _module = runpy.run_path(
-        str(Path(__file__).resolve().parent.parent / "scripts" / "check_missing_models.py")
+        str(
+            Path(__file__).resolve().parent.parent
+            / "scripts"
+            / "check_missing_models.py"
+        )
     )
     fetch_model_card_urls = _module["fetch_model_card_urls"]
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds LiteLLM's `blocked` flag as a second enforcement layer for zero-budget POOL teams and keys, complementing the existing `max_budget=0` gate. It also wires `_sync_pool_key_effective_budgets` into the purchase and budget-expiry paths so keys are automatically unblocked on purchase and re-blocked on expiry, and adds a team-budget rollback if key sync fails mid-purchase.

- **`blocked` propagation**: `create_key` and `update_key_budget` in `LiteLLMService` gain an optional `blocked` parameter; every lock/unlock path in `budgets.py`, `spend.py`, and `private_ai_keys.py` now sets it alongside `max_budget`.
- **Purchase-time key sync**: `purchase_periodic_topup` (called by both the one-time POOL purchase and the periodic top-up endpoint) now calls `_sync_pool_key_effective_budgets` after updating the team budget, and rolls back the team budget if the key sync fails.
- **Expiry-time key sync**: `sync_pool_team_budgets` fetches the expired `DBRegion` objects and passes them to `_sync_pool_key_effective_budgets` with `purchased_total=0` to re-block all keys when budget expires.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the zero-budget blocking logic is correctly layered and the rollback path is well-tested.

The core change is sound: blocked is set and cleared consistently across all lock/unlock paths, and the new rollback logic in purchase_periodic_topup correctly restores the team budget when key sync fails mid-flight. The clear_budget_duration fix in update_team_budget is a genuine improvement over the old truthiness guard. Two small style issues exist: the _sync_pool_key_effective_budgets docstring still describes only max_budget=0 for the lock path, and in private_ai_keys.py blocked=True is passed redundantly in the immediate update_key_budget call that follows a create_key that already set it.

app/api/private_ai_keys.py (redundant blocked=True on the follow-up update_key_budget call) and app/api/budgets.py (outdated docstring for _sync_pool_key_effective_budgets).
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/api/budgets.py | Adds blocked=True/False to _sync_pool_key_effective_budgets, calls it from purchase_periodic_topup and sync_pool_team_budgets; adds team budget rollback on key-sync failure; docstring is slightly out of date after the blocked changes. |
| app/api/private_ai_keys.py | Passes blocked=True on create_key for zero-budget pool teams and also redundantly on the immediate update_key_budget call; logic is correct but the second blocked=True is unnecessary. |
| app/api/spend.py | Minimal change: adds blocked=True to the _enforce_pool_no_purchase_key_lock update_key_budget call, consistent with the rest of the PR. |
| app/services/litellm.py | Adds optional blocked parameter to create_key and update_key_budget; adds clear_budget_duration to update_team_budget to allow sending budget_duration=null explicitly. |
| tests/test_litellm_service.py | Adds tests for blocked key creation, blocked toggle on key update, and clear_budget_duration sending null. |
| tests/test_pool_purchases.py | Adds test verifying team budget is rolled back when key sync fails during a purchase. |
| tests/test_private_ai.py | Extends existing zero-budget pool key test to assert blocked=True, and adds a new test confirming a pool team with an existing purchase does NOT have blocked set. |
| scripts/check_missing_models.py | Formatting-only change; no logic changes. |
| tests/test_public_models_missing.py | Formatting-only change; no logic changes. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant purchase_pool_budget
    participant purchase_periodic_topup
    participant LiteLLM
    participant _sync_pool_key_effective_budgets

    Client->>purchase_pool_budget: POST /purchase
    purchase_pool_budget->>purchase_periodic_topup: delegate
    purchase_periodic_topup->>LiteLLM: get_team_info (capture previous budget)
    purchase_periodic_topup->>LiteLLM: "update_team_budget(max_budget=new_total)"
    Note over purchase_periodic_topup: team_budget_updated = True
    purchase_periodic_topup->>_sync_pool_key_effective_budgets: "purchased_total > 0"
    loop Each key in region
        _sync_pool_key_effective_budgets->>LiteLLM: "update_key_budget(blocked=False)"
    end
    alt Key sync succeeds
        purchase_periodic_topup->>purchase_periodic_topup: db.commit()
        purchase_pool_budget-->>Client: 201 PoolPurchaseResponse
    else Key sync fails
        _sync_pool_key_effective_budgets-->>purchase_periodic_topup: errors[]
        purchase_periodic_topup->>LiteLLM: update_team_budget rollback
        purchase_periodic_topup-->>Client: 502 Bad Gateway
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/api/budgets.py`, line 200-205 ([link](https://github.com/amazeeio/amazee.ai/blob/ddb931e174dc6fe277c21cebc9b11757521e46d0/app/api/budgets.py#L200-L205)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The docstring for `_sync_pool_key_effective_budgets` describes only `max_budget=0` for the lock path. Now that `blocked=True/False` is also applied to both branches, the inline docs should reflect the dual mechanism so callers understand the full intent.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(budgets): update team budget on top..."](https://github.com/amazeeio/amazee.ai/commit/ddb931e174dc6fe277c21cebc9b11757521e46d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36515426)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->