### PR TITLE
chore: add weekly eol check

### DIFF
--- a/.github/workflows/weekly-eol-check.yaml
+++ b/.github/workflows/weekly-eol-check.yaml
@@ -1,0 +1,112 @@
+name: Weekly EOL Check
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Every Monday at 6am UTC
+  workflow_dispatch:
+    inputs:
+      api_url:
+        description: 'Override AMAZEEAI_API_URL for this run (e.g. https://api.amazee.ai)'
+        required: false
+        type: string
+      warning_days:
+        description: 'Number of days before EOL to warn (default: 30)'
+        required: false
+        type: string
+        default: '30'
+
+permissions:
+  contents: read
+
+jobs:
+  check-eol:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.x'
+
+      - name: Check for EOL models
+        id: eol
+        env:
+          AMAZEEAI_API_URL: ${{ github.event.inputs.api_url || vars.AMAZEEAI_API_URL || 'https://api.amazee.ai' }}
+          EOL_WARNING_DAYS: ${{ github.event.inputs.warning_days || '30' }}
+        run: python scripts/check_eol_models.py
+
+      - name: Notify Slack about EOL models
+        if: steps.eol.outputs.has_alerts == 'true'
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ vars.SLACK_CHANNEL_ID }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+        run: |
+          [ -n "$SLACK_BOT_TOKEN" ] || { echo "::error::Missing SLACK_BOT_TOKEN secret."; exit 1; }
+          [ -n "$SLACK_CHANNEL_ID" ] || { echo "::error::Missing SLACK_CHANNEL_ID variable."; exit 1; }
+
+          SUMMARY=$(cat eol-summary.txt)
+          EXPIRED_COUNT="${{ steps.eol.outputs.expired_count }}"
+
+          if [ "$EXPIRED_COUNT" -gt 0 ] 2>/dev/null; then
+            ICON=":rotating_light:"
+            HEADER="Model EOL Alert"
+            URGENCY="Some models are *past* their End-of-Life date and should be removed or replaced."
+          else
+            ICON=":warning:"
+            HEADER="Model EOL Warning"
+            URGENCY="Some models are approaching their End-of-Life date."
+          fi
+
+          payload=$(jq -n \
+            --arg channel "$SLACK_CHANNEL_ID" \
+            --arg icon "$ICON" \
+            --arg header "$HEADER" \
+            --arg urgency "$URGENCY" \
+            --arg summary "$SUMMARY" \
+            --arg workflow_url "$WORKFLOW_URL" \
+            --arg workflow_name "$WORKFLOW_NAME" \
+            '{
+              channel: $channel,
+              text: "\($icon) *\($header)* — \($urgency)",
+              blocks: [
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: "\($icon) *\($header)*\n\($urgency)"
+                  }
+                },
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: $summary
+                  }
+                },
+                {
+                  type: "section",
+                  fields: [
+                    {
+                      type: "mrkdwn",
+                      text: "*Workflow:*\n<\($workflow_url)|\($workflow_name)>"
+                    }
+                  ]
+                }
+              ]
+            }')
+
+          response=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$payload")
+
+          if ! echo "$response" | jq -e '.ok' > /dev/null 2>&1; then
+            echo "::error::Slack API error: $response" >&2
+            exit 1
+          fi

--- a/scripts/check_eol_models.py
+++ b/scripts/check_eol_models.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+
+"""Check for models approaching or past their End-of-Life (EOL) date.
+
+Queries ``GET /public/models`` on the configured backend (defaults to
+https://api.amazee.ai), parses the ``(EOL: YYYY-MM-DD)`` annotation from
+each model's ``metadata_raw`` field, and emits GitHub Actions outputs for
+Slack notification when models are:
+
+* **Expired**: EOL date is in the past.
+* **Approaching EOL**: EOL date is within the configured warning window
+  (default 30 days).
+
+The script is intentionally stdlib-only so the workflow doesn't need to
+install anything.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.request
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+
+
+DEFAULT_API_URL = "https://api.amazee.ai"
+# How far in advance to warn about upcoming EOL dates.
+DEFAULT_WARNING_DAYS = 30
+
+
+# Regex to extract (EOL: YYYY-MM-DD) from metadata_raw strings.
+_EOL_PATTERN = re.compile(r"\(EOL:\s*(\d{4}-\d{2}-\d{2})\)")
+
+
+def fetch_public_models(api_url: str, timeout: int = 60) -> list[dict[str, Any]]:
+    """Fetch the public models endpoint and return the JSON response."""
+    url = api_url.rstrip("/") + "/public/models"
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            data = json.load(response)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"Invalid JSON from {url}: {exc}"
+        ) from exc
+    except HTTPError as exc:
+        body = exc.read().decode("utf-8", "replace")[:500]
+        raise RuntimeError(
+            f"Backend returned HTTP {exc.code} for {url}: {body}"
+        ) from exc
+    except URLError as exc:
+        raise RuntimeError(f"Failed to reach {url}: {exc}") from exc
+
+    if not isinstance(data, list):
+        raise RuntimeError(
+            f"Unexpected response format from {url}: expected a list, got {type(data).__name__}"
+        )
+    return data
+
+
+def extract_eol_date(metadata_raw: Any) -> date | None:
+    """Extract an EOL date from metadata_raw if present.
+
+    metadata_raw can be a string or a dict; we look for the pattern in
+    string values. Returns None if no EOL date is found.
+    """
+    text = None
+    if isinstance(metadata_raw, str):
+        text = metadata_raw
+    elif isinstance(metadata_raw, dict):
+        # Check common keys that might hold a description string.
+        for key in ("description", "info", "metadata", "raw"):
+            val = metadata_raw.get(key)
+            if isinstance(val, str):
+                text = val
+                break
+        # Fallback: stringify the whole dict and search.
+        if text is None:
+            text = json.dumps(metadata_raw)
+
+    if text is None:
+        return None
+
+    match = _EOL_PATTERN.search(text)
+    if not match:
+        return None
+
+    try:
+        return date.fromisoformat(match.group(1))
+    except ValueError:
+        return None
+
+
+def check_eol_models(
+    regions: list[dict[str, Any]], warning_days: int = DEFAULT_WARNING_DAYS
+) -> dict[str, list[dict[str, Any]]]:
+    """Check all models for EOL status.
+
+    Returns a dict with two keys:
+    - "expired": models past their EOL date
+    - "approaching": models within the warning window
+    """
+    today = date.today()
+    warning_threshold = today + timedelta(days=warning_days)
+
+    expired: list[dict[str, Any]] = []
+    approaching: list[dict[str, Any]] = []
+
+    # Track model_ids we've already seen to avoid duplicates across regions.
+    seen: set[str] = set()
+
+    for region_data in regions:
+        region_name = region_data.get("region", "unknown")
+        models = region_data.get("models", [])
+        if not isinstance(models, list):
+            continue
+
+        for model in models:
+            model_id = model.get("model_id", "unknown")
+
+            # Deduplicate: same model may appear in multiple regions.
+            if model_id in seen:
+                continue
+            seen.add(model_id)
+
+            eol_date = extract_eol_date(model.get("metadata_raw"))
+            if eol_date is None:
+                continue
+
+            entry = {
+                "model_id": model_id,
+                "display_name": model.get("display_name", model_id),
+                "eol_date": eol_date.isoformat(),
+                "days_remaining": (eol_date - today).days,
+                "region": region_name,
+            }
+
+            if eol_date < today:
+                expired.append(entry)
+            elif eol_date <= warning_threshold:
+                approaching.append(entry)
+
+    # Sort: expired by most overdue first, approaching by soonest first.
+    expired.sort(key=lambda m: m["days_remaining"])
+    approaching.sort(key=lambda m: m["days_remaining"])
+
+    return {"expired": expired, "approaching": approaching}
+
+
+def build_slack_summary(results: dict[str, list[dict[str, Any]]]) -> str:
+    """Build a Slack mrkdwn summary of EOL findings."""
+    sections: list[str] = []
+
+    expired = results["expired"]
+    approaching = results["approaching"]
+
+    if expired:
+        lines = [f":rotating_light: *{len(expired)} model(s) PAST End-of-Life:*"]
+        for model in expired:
+            days_past = abs(model["days_remaining"])
+            lines.append(
+                f"• `{model['model_id']}` — EOL was *{model['eol_date']}* "
+                f"({days_past} day{'s' if days_past != 1 else ''} ago)"
+            )
+        sections.append("\n".join(lines))
+
+    if approaching:
+        lines = [f":warning: *{len(approaching)} model(s) approaching End-of-Life:*"]
+        for model in approaching:
+            days_left = model["days_remaining"]
+            lines.append(
+                f"• `{model['model_id']}` — EOL on *{model['eol_date']}* "
+                f"({days_left} day{'s' if days_left != 1 else ''} remaining)"
+            )
+        sections.append("\n".join(lines))
+
+    return "\n\n".join(sections)
+
+
+def write_github_outputs(results: dict[str, list[dict[str, Any]]], summary: str) -> None:
+    """Emit $GITHUB_OUTPUT lines for the surrounding workflow."""
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+
+    has_alerts = bool(results["expired"] or results["approaching"])
+
+    with open(output_path, "a", encoding="utf-8") as handle:
+        handle.write(f"has_alerts={'true' if has_alerts else 'false'}\n")
+        handle.write(f"expired_count={len(results['expired'])}\n")
+        handle.write(f"approaching_count={len(results['approaching'])}\n")
+
+    # Write the summary to a file the workflow can read.
+    summary_file = Path("eol-summary.txt")
+    summary_file.write_text(summary, encoding="utf-8")
+
+
+def main() -> int:
+    api_url = os.environ.get("AMAZEEAI_API_URL", DEFAULT_API_URL)
+    warning_days_raw = os.environ.get("EOL_WARNING_DAYS", str(DEFAULT_WARNING_DAYS))
+    try:
+        warning_days = int(warning_days_raw)
+        if warning_days < 0:
+            raise ValueError("must be >= 0")
+    except ValueError as exc:
+        print(
+            f"ERROR: EOL_WARNING_DAYS must be a non-negative integer (got {warning_days_raw!r}): {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        regions = fetch_public_models(api_url)
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    results = check_eol_models(regions, warning_days=warning_days)
+    summary = build_slack_summary(results)
+
+    write_github_outputs(results, summary)
+
+    # Print human-readable output for logs.
+    if results["expired"] or results["approaching"]:
+        print(summary)
+        print(
+            f"\nTotal: {len(results['expired'])} expired, "
+            f"{len(results['approaching'])} approaching EOL "
+            f"(within {warning_days} days)"
+        )
+    else:
+        print(f"No models at or approaching EOL (checked within {warning_days} days).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_eol_models.py
+++ b/tests/test_check_eol_models.py
@@ -1,0 +1,375 @@
+"""Tests for scripts/check_eol_models.py."""
+
+import json
+import runpy
+from datetime import date, timedelta
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_SCRIPT_PATH = str(
+    Path(__file__).resolve().parent.parent / "scripts" / "check_eol_models.py"
+)
+
+
+def _load_module():
+    return runpy.run_path(_SCRIPT_PATH)
+
+
+# ---------------------------------------------------------------------------
+# extract_eol_date
+# ---------------------------------------------------------------------------
+
+
+class TestExtractEolDate:
+    def test_string_with_eol(self):
+        mod = _load_module()
+        result = mod["extract_eol_date"](
+            "High speed, low cost Claude model. (EOL: 2026-10-01)"
+        )
+        assert result == date(2026, 10, 1)
+
+    def test_string_without_eol(self):
+        mod = _load_module()
+        result = mod["extract_eol_date"]("Just a normal description, no EOL.")
+        assert result is None
+
+    def test_dict_with_eol_in_description_key(self):
+        mod = _load_module()
+        result = mod["extract_eol_date"](
+            {"description": "Some model. (EOL: 2025-03-15)"}
+        )
+        assert result == date(2025, 3, 15)
+
+    def test_dict_fallback_to_json_stringify(self):
+        mod = _load_module()
+        result = mod["extract_eol_date"](
+            {"custom_key": "Will be deprecated. (EOL: 2025-12-31)"}
+        )
+        assert result == date(2025, 12, 31)
+
+    def test_none_input(self):
+        mod = _load_module()
+        assert mod["extract_eol_date"](None) is None
+
+    def test_integer_input(self):
+        mod = _load_module()
+        assert mod["extract_eol_date"](42) is None
+
+    def test_invalid_date_format(self):
+        mod = _load_module()
+        # Valid regex match but invalid date.
+        result = mod["extract_eol_date"]("(EOL: 2025-13-40)")
+        assert result is None
+
+    def test_eol_with_extra_spaces(self):
+        mod = _load_module()
+        result = mod["extract_eol_date"]("Model info. (EOL:  2026-06-15)")
+        assert result == date(2026, 6, 15)
+
+
+# ---------------------------------------------------------------------------
+# check_eol_models
+# ---------------------------------------------------------------------------
+
+
+class TestCheckEolModels:
+    def _make_regions(self, models):
+        """Helper to wrap models into the region response structure."""
+        return [{"region": "us-east-1", "status": "available", "models": models}]
+
+    def test_expired_model(self):
+        mod = _load_module()
+        yesterday = (date.today() - timedelta(days=1)).isoformat()
+        regions = self._make_regions(
+            [
+                {
+                    "model_id": "old-model",
+                    "display_name": "Old Model",
+                    "metadata_raw": f"Legacy model. (EOL: {yesterday})",
+                }
+            ]
+        )
+        result = mod["check_eol_models"](regions, warning_days=30)
+        assert len(result["expired"]) == 1
+        assert len(result["approaching"]) == 0
+        assert result["expired"][0]["model_id"] == "old-model"
+        assert result["expired"][0]["days_remaining"] < 0
+
+    def test_approaching_model(self):
+        mod = _load_module()
+        in_two_weeks = (date.today() + timedelta(days=14)).isoformat()
+        regions = self._make_regions(
+            [
+                {
+                    "model_id": "soon-model",
+                    "display_name": "Soon Model",
+                    "metadata_raw": f"Will retire. (EOL: {in_two_weeks})",
+                }
+            ]
+        )
+        result = mod["check_eol_models"](regions, warning_days=30)
+        assert len(result["expired"]) == 0
+        assert len(result["approaching"]) == 1
+        assert result["approaching"][0]["model_id"] == "soon-model"
+        assert result["approaching"][0]["days_remaining"] == 14
+
+    def test_model_beyond_warning_window(self):
+        mod = _load_module()
+        far_future = (date.today() + timedelta(days=90)).isoformat()
+        regions = self._make_regions(
+            [
+                {
+                    "model_id": "safe-model",
+                    "display_name": "Safe Model",
+                    "metadata_raw": f"Fine for now. (EOL: {far_future})",
+                }
+            ]
+        )
+        result = mod["check_eol_models"](regions, warning_days=30)
+        assert len(result["expired"]) == 0
+        assert len(result["approaching"]) == 0
+
+    def test_model_without_eol(self):
+        mod = _load_module()
+        regions = self._make_regions(
+            [
+                {
+                    "model_id": "no-eol-model",
+                    "display_name": "No EOL",
+                    "metadata_raw": "Just a regular model.",
+                }
+            ]
+        )
+        result = mod["check_eol_models"](regions, warning_days=30)
+        assert len(result["expired"]) == 0
+        assert len(result["approaching"]) == 0
+
+    def test_deduplication_across_regions(self):
+        mod = _load_module()
+        yesterday = (date.today() - timedelta(days=1)).isoformat()
+        regions = [
+            {
+                "region": "us-east-1",
+                "status": "available",
+                "models": [
+                    {
+                        "model_id": "dupe-model",
+                        "display_name": "Dupe",
+                        "metadata_raw": f"Old. (EOL: {yesterday})",
+                    }
+                ],
+            },
+            {
+                "region": "eu-central-1",
+                "status": "available",
+                "models": [
+                    {
+                        "model_id": "dupe-model",
+                        "display_name": "Dupe",
+                        "metadata_raw": f"Old. (EOL: {yesterday})",
+                    }
+                ],
+            },
+        ]
+        result = mod["check_eol_models"](regions, warning_days=30)
+        # Should only appear once despite being in two regions.
+        assert len(result["expired"]) == 1
+
+    def test_sorting_expired_most_overdue_first(self):
+        mod = _load_module()
+        three_days_ago = (date.today() - timedelta(days=3)).isoformat()
+        ten_days_ago = (date.today() - timedelta(days=10)).isoformat()
+        regions = self._make_regions(
+            [
+                {
+                    "model_id": "recently-expired",
+                    "display_name": "Recent",
+                    "metadata_raw": f"(EOL: {three_days_ago})",
+                },
+                {
+                    "model_id": "long-expired",
+                    "display_name": "Long Expired",
+                    "metadata_raw": f"(EOL: {ten_days_ago})",
+                },
+            ]
+        )
+        result = mod["check_eol_models"](regions, warning_days=30)
+        assert result["expired"][0]["model_id"] == "long-expired"
+        assert result["expired"][1]["model_id"] == "recently-expired"
+
+    def test_eol_today_counts_as_approaching(self):
+        """A model whose EOL is exactly today is NOT expired (eol_date < today is false)."""
+        mod = _load_module()
+        today = date.today().isoformat()
+        regions = self._make_regions(
+            [
+                {
+                    "model_id": "today-model",
+                    "display_name": "Today",
+                    "metadata_raw": f"(EOL: {today})",
+                }
+            ]
+        )
+        result = mod["check_eol_models"](regions, warning_days=30)
+        assert len(result["expired"]) == 0
+        assert len(result["approaching"]) == 1
+
+    def test_null_models_field_skipped(self):
+        """A region with models: null should be skipped gracefully."""
+        mod = _load_module()
+        regions = [
+            {"region": "broken-region", "status": "available", "models": None},
+            {
+                "region": "good-region",
+                "status": "available",
+                "models": [
+                    {
+                        "model_id": "valid-model",
+                        "display_name": "Valid",
+                        "metadata_raw": f"(EOL: {(date.today() - timedelta(days=1)).isoformat()})",
+                    }
+                ],
+            },
+        ]
+        result = mod["check_eol_models"](regions, warning_days=30)
+        # The null-models region is skipped; the valid region is still processed.
+        assert len(result["expired"]) == 1
+        assert result["expired"][0]["model_id"] == "valid-model"
+
+
+# ---------------------------------------------------------------------------
+# build_slack_summary
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSlackSummary:
+    def test_empty_results(self):
+        mod = _load_module()
+        summary = mod["build_slack_summary"]({"expired": [], "approaching": []})
+        assert summary == ""
+
+    def test_expired_only(self):
+        mod = _load_module()
+        results = {
+            "expired": [
+                {
+                    "model_id": "old-model",
+                    "display_name": "Old",
+                    "eol_date": "2025-01-01",
+                    "days_remaining": -5,
+                    "region": "us-east-1",
+                }
+            ],
+            "approaching": [],
+        }
+        summary = mod["build_slack_summary"](results)
+        assert ":rotating_light:" in summary
+        assert "old-model" in summary
+        assert "5 days ago" in summary
+
+    def test_approaching_only(self):
+        mod = _load_module()
+        results = {
+            "expired": [],
+            "approaching": [
+                {
+                    "model_id": "soon-model",
+                    "display_name": "Soon",
+                    "eol_date": "2026-07-01",
+                    "days_remaining": 10,
+                    "region": "us-east-1",
+                }
+            ],
+        }
+        summary = mod["build_slack_summary"](results)
+        assert ":warning:" in summary
+        assert "soon-model" in summary
+        assert "10 days remaining" in summary
+
+    def test_singular_day(self):
+        mod = _load_module()
+        results = {
+            "expired": [
+                {
+                    "model_id": "m",
+                    "display_name": "M",
+                    "eol_date": "2025-01-01",
+                    "days_remaining": -1,
+                    "region": "r",
+                }
+            ],
+            "approaching": [],
+        }
+        summary = mod["build_slack_summary"](results)
+        assert "1 day ago" in summary
+
+
+# ---------------------------------------------------------------------------
+# fetch_public_models — response validation
+# ---------------------------------------------------------------------------
+
+
+class TestFetchPublicModels:
+    def test_raises_on_non_list_response(self):
+        mod = _load_module()
+        # Simulate API returning a dict instead of a list.
+        response_body = json.dumps({"error": "unexpected"}).encode()
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__ = lambda s: BytesIO(response_body)
+            mock_urlopen.return_value.__exit__ = lambda s, *a: None
+            with pytest.raises(RuntimeError, match="expected a list"):
+                mod["fetch_public_models"]("https://api.example.com")
+
+    def test_raises_on_null_response(self):
+        mod = _load_module()
+        response_body = b"null"
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__ = lambda s: BytesIO(response_body)
+            mock_urlopen.return_value.__exit__ = lambda s, *a: None
+            with pytest.raises(RuntimeError, match="expected a list"):
+                mod["fetch_public_models"]("https://api.example.com")
+
+    def test_succeeds_on_list_response(self):
+        mod = _load_module()
+        response_body = json.dumps([{"region": "us", "models": []}]).encode()
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__ = lambda s: BytesIO(response_body)
+            mock_urlopen.return_value.__exit__ = lambda s, *a: None
+            result = mod["fetch_public_models"]("https://api.example.com")
+            assert result == [{"region": "us", "models": []}]
+
+    def test_raises_on_invalid_json(self):
+        mod = _load_module()
+        # Simulate an HTML error page or malformed response.
+        response_body = b"<html>502 Bad Gateway</html>"
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__ = lambda s: BytesIO(response_body)
+            mock_urlopen.return_value.__exit__ = lambda s, *a: None
+            with pytest.raises(RuntimeError, match="Invalid JSON"):
+                mod["fetch_public_models"]("https://api.example.com")
+
+
+# ---------------------------------------------------------------------------
+# main — EOL_WARNING_DAYS validation
+# ---------------------------------------------------------------------------
+
+
+class TestMainWarningDaysValidation:
+    def test_invalid_warning_days_returns_error(self):
+        mod = _load_module()
+        with patch.dict("os.environ", {"EOL_WARNING_DAYS": "abc", "AMAZEEAI_API_URL": "https://x.example"}):
+            exit_code = mod["main"]()
+            assert exit_code == 1
+
+    def test_negative_warning_days_returns_error(self):
+        mod = _load_module()
+        with patch.dict("os.environ", {"EOL_WARNING_DAYS": "-5", "AMAZEEAI_API_URL": "https://x.example"}):
+            exit_code = mod["main"]()
+            assert exit_code == 1


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a new weekly GitHub Actions workflow that queries the `/public/models` endpoint, extracts `(EOL: YYYY-MM-DD)` annotations from model metadata, and posts a Slack alert when any models are expired or approaching their EOL date. The implementation is stdlib-only (no pip installs required) and ships with a comprehensive unit test suite.

- **Workflow** (`.github/workflows/weekly-eol-check.yaml`): Runs on a Monday 6am UTC schedule plus `workflow_dispatch`; gates the Slack notification step on the Python script's `has_alerts` output, validates both `SLACK_BOT_TOKEN` and `SLACK_CHANNEL_ID` before use, and assembles the JSON payload with `jq --arg` to avoid shell injection.
- **Script** (`scripts/check_eol_models.py`): Fetches, validates, deduplicates, and classifies models as expired or approaching-EOL; writes `GITHUB_OUTPUT` entries and an `eol-summary.txt` file for the Slack step to consume.
- **Tests** (`tests/test_check_eol_models.py`): Covers all major code paths including sorting, deduplication, plural formatting, and the new `fetch_public_models` list-validation guard.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a net-new, read-only monitoring workflow with no impact on existing application code.

All changes are additive: a new workflow file, a new stdlib-only Python script, and a new test suite. The script only reads from the public models API and writes to a temporary workspace file; it cannot modify any application state. The workflow has no write permissions beyond `contents: read`. The only edge case found (deduplication keyed on unknown) affects models missing a model_id field, which is unlikely in the real API and does not affect any production path.

No files require special attention — all three files are self-contained additions.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/weekly-eol-check.yaml | New workflow scheduling a weekly EOL check with workflow_dispatch override support; Slack notification correctly gated on has_alerts output, secrets validated before use, and jq --arg used to safely assemble the JSON payload. |
| scripts/check_eol_models.py | Well-structured stdlib-only script; deduplication by model_id uses the sentinel value unknown as the key, which can silently drop multiple models that lack a model_id field. |
| tests/test_check_eol_models.py | Good unit test coverage across all major functions; _load_module() is called per test method rather than via a module-scoped fixture, and write_github_outputs has no coverage. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant Py as check_eol_models.py
    participant API as api.amazee.ai
    participant Slack as Slack API

    GHA->>Py: run (AMAZEEAI_API_URL, EOL_WARNING_DAYS)
    Py->>API: GET /public/models
    API-->>Py: JSON list of region objects
    Py->>Py: extract_eol_date() per model
    Py->>Py: check_eol_models() to expired or approaching
    Py->>Py: build_slack_summary()
    Py->>GHA: write GITHUB_OUTPUT (has_alerts, expired_count, approaching_count)
    Py->>GHA: write eol-summary.txt

    alt "has_alerts == true"
        GHA->>GHA: read eol-summary.txt into SUMMARY
        GHA->>GHA: validate SLACK_BOT_TOKEN + SLACK_CHANNEL_ID
        GHA->>Slack: POST chat.postMessage (blocks payload)
        Slack-->>GHA: ok true
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["chore: add weekly eol check"](https://github.com/amazeeio/amazee.ai/commit/64f82451c5d07c4499a0cdc89db407c94f51010a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36463075)</sub>

<!-- /greptile_comment -->