### PR TITLE
hotfix: blocked key issues

### DIFF
--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -43,6 +43,7 @@ from app.core.periodic_budget_ledger_service import (
 from app.core.pool_budget_service import (
     pool_available_budget_for_team_region as shared_pool_available_budget_for_team_region,
     pool_team_budget_duration_for_enforcement as shared_pool_team_budget_duration_for_enforcement,
+    pool_team_has_ever_purchased,
 )
 
 logger = logging.getLogger(__name__)
@@ -219,8 +220,11 @@ async def _sync_pool_key_effective_budgets(
     """
     Keep key-level effective limits coherent for POOL teams.
 
-    - purchased_total <= 0: hard-lock all team keys (max_budget=0)
-    - purchased_total > 0: restore key max_budget from spend_caps (or clear)
+    The block/unblock decision uses pool_team_has_ever_purchased: a key is
+    blocked only when the team has never had any purchase at all.  Remaining
+    balance does NOT affect the blocked flag — budget enforcement is handled
+    by LiteLLM max_budget.  `purchased_total` is still used to set max_budget
+    on the key (0 → $0 cap, >0 → clear or apply configured cap).
     """
     keys = get_team_region_litellm_keys(
         db,
@@ -229,6 +233,8 @@ async def _sync_pool_key_effective_budgets(
     )
     if not keys:
         return []
+
+    has_purchased = pool_team_has_ever_purchased(db, team_id, region.id)
 
     key_caps = (
         db.query(DBSpendCap.key_id, DBSpendCap.max_budget)
@@ -250,7 +256,8 @@ async def _sync_pool_key_effective_budgets(
     async def _sync_key_budget(key: DBPrivateAIKey) -> str | None:
         try:
             async with semaphore:
-                if purchased_total <= 0:
+                if not has_purchased:
+                    # Team has never paid — hard-lock the key.
                     await service.update_key_budget(
                         litellm_token=key.litellm_token,
                         budget_duration=MONTHLY_BUDGET_DURATION,

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -1,5 +1,4 @@
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import func
 from sqlalchemy.orm import Session
 from typing import List, Optional
 from fastapi import status
@@ -20,7 +19,6 @@ from app.schemas.models import (
 )
 from app.db.postgres import PostgresManager
 from app.db.models import (
-    DBPoolPurchase,
     DBPrivateAIKey,
     DBRegion,
     DBUser,
@@ -42,6 +40,7 @@ from app.core.limit_service import (
     DEFAULT_MAX_SPEND,
     DEFAULT_RPM_PER_KEY,
 )
+from app.core.pool_budget_service import pool_available_budget_for_team_region
 
 router = APIRouter(tags=["private-ai-keys"])
 
@@ -443,16 +442,14 @@ async def create_llm_token(
     )
     pool_purchased_total = None
     if is_pool_team and effective_team is not None:
-        total_cents = (
-            db.query(func.sum(DBPoolPurchase.amount_cents))
-            .filter(
-                DBPoolPurchase.team_id == effective_team.id,
-                DBPoolPurchase.region_id == region.id,
-            )
-            .scalar()
-            or 0
+        # Use pool_available_budget_for_team_region so both subscription-cycle
+        # budget (DBPeriodicBudgetLedgerEntry) and top-up purchases
+        # (DBPoolPurchase) are considered. Without this, a key created after a
+        # subscription cycle (but before any explicit top-up) would be created
+        # as blocked=True because DBPoolPurchase is empty for cycle-only teams.
+        pool_purchased_total = pool_available_budget_for_team_region(
+            db, effective_team.id, region.id
         )
-        pool_purchased_total = float(total_cents) / 100.0
 
     if (owner is not None and owner.team_id) or team_id:
         if settings.ENABLE_LIMITS and not is_pool_team:

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -40,7 +40,7 @@ from app.core.limit_service import (
     DEFAULT_MAX_SPEND,
     DEFAULT_RPM_PER_KEY,
 )
-from app.core.pool_budget_service import pool_available_budget_for_team_region
+from app.core.pool_budget_service import pool_team_has_ever_purchased
 
 router = APIRouter(tags=["private-ai-keys"])
 
@@ -442,13 +442,15 @@ async def create_llm_token(
     )
     pool_purchased_total = None
     if is_pool_team and effective_team is not None:
-        # Use pool_available_budget_for_team_region so both subscription-cycle
-        # budget (DBPeriodicBudgetLedgerEntry) and top-up purchases
-        # (DBPoolPurchase) are considered. Without this, a key created after a
-        # subscription cycle (but before any explicit top-up) would be created
-        # as blocked=True because DBPoolPurchase is empty for cycle-only teams.
-        pool_purchased_total = pool_available_budget_for_team_region(
-            db, effective_team.id, region.id
+        # Use pool_team_has_ever_purchased: the block/unblock decision is purely
+        # "has this team ever paid" — not how much budget remains.  Remaining
+        # balance enforcement is handled by LiteLLM max_budget, not the blocked
+        # flag.  A team that spent all their budget should still have unblocked
+        # keys; their requests will simply fail due to max_budget=0.
+        pool_purchased_total = (
+            0.0
+            if not pool_team_has_ever_purchased(db, effective_team.id, region.id)
+            else 1.0  # sentinel: any positive value means "has purchased"
         )
 
     if (owner is not None and owner.team_id) or team_id:

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -440,17 +440,10 @@ async def create_llm_token(
     is_pool_team = (
         effective_team is not None and effective_team.requires_pool_purchase_gate
     )
-    pool_purchased_total = None
+    has_pool_purchase = False
     if is_pool_team and effective_team is not None:
-        # Use pool_team_has_ever_purchased: the block/unblock decision is purely
-        # "has this team ever paid" — not how much budget remains.  Remaining
-        # balance enforcement is handled by LiteLLM max_budget, not the blocked
-        # flag.  A team that spent all their budget should still have unblocked
-        # keys; their requests will simply fail due to max_budget=0.
-        pool_purchased_total = (
-            0.0
-            if not pool_team_has_ever_purchased(db, effective_team.id, region.id)
-            else 1.0  # sentinel: any positive value means "has purchased"
+        has_pool_purchase = pool_team_has_ever_purchased(
+            db, effective_team.id, region.id
         )
 
     if (owner is not None and owner.team_id) or team_id:
@@ -512,19 +505,9 @@ async def create_llm_token(
             max_budget=max_max_spend,
             rpm_limit=max_rpm_limit,
             apply_limits=not is_pool_team,
-            blocked=(
-                True
-                if is_pool_team
-                and pool_purchased_total is not None
-                and pool_purchased_total <= 0
-                else None
-            ),
+            blocked=(True if is_pool_team and not has_pool_purchase else None),
         )
-        if (
-            is_pool_team
-            and pool_purchased_total is not None
-            and pool_purchased_total <= 0
-        ):
+        if is_pool_team and not has_pool_purchase:
             await litellm_service.update_key_budget(
                 litellm_token=litellm_token,
                 budget_duration=f"{settings.POOL_PURCHASE_EXPIRY_DAYS}d",

--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -119,7 +119,7 @@ def _compute_period_start(
     ),
     response_description=(
         "Team historical spend periods with per-key breakdown, plus periodic "
-        "transaction history for PERIODIC teams."
+        "transaction history for PERIODIC and POOL teams."
     ),
 )
 async def get_team_spend_history(
@@ -199,7 +199,7 @@ async def get_team_spend_history(
         )
 
     periodic_transactions: list[TeamPeriodicTransactionItem] = []
-    if team.budget_type == BudgetType.PERIODIC:
+    if team.budget_type in (BudgetType.PERIODIC, BudgetType.POOL):
         latest_ledger = aliased(DBPeriodicBudgetLedgerEntry)
         latest_payment_ids_subq = (
             db.query(

--- a/app/core/pool_budget_service.py
+++ b/app/core/pool_budget_service.py
@@ -64,6 +64,40 @@ def pool_available_budget_for_team_region(
     )
 
 
+def pool_team_has_ever_purchased(db: Session, team_id: int, region_id: int) -> bool:
+    """Return True if the team has ever had at least one subscription cycle
+    (DBPeriodicBudgetLedgerEntry) or direct pool top-up (DBPoolPurchase)
+    recorded for this region, regardless of remaining balance.
+
+    This is the sole criterion for the block/unblock decision on keys:
+    - False (no purchase ever)  → key must be created/kept blocked
+    - True  (at least one purchase) → key must be unblocked, even if all
+      budget is consumed.  Actual spend enforcement is handled by LiteLLM
+      max_budget, not the blocked flag.
+    """
+    has_ledger_entry = (
+        db.query(DBPeriodicBudgetLedgerEntry.id)
+        .filter(
+            DBPeriodicBudgetLedgerEntry.team_id == team_id,
+            DBPeriodicBudgetLedgerEntry.region_id == region_id,
+        )
+        .first()
+        is not None
+    )
+    if has_ledger_entry:
+        return True
+    has_pool_purchase = (
+        db.query(DBPoolPurchase.id)
+        .filter(
+            DBPoolPurchase.team_id == team_id,
+            DBPoolPurchase.region_id == region_id,
+        )
+        .first()
+        is not None
+    )
+    return has_pool_purchase
+
+
 def pool_team_budget_duration_for_enforcement(
     db: Session, team_id: int, region_id: int
 ) -> str:

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -1339,6 +1339,7 @@ async def apply_billing_cycle_for_team(
                             ),
                             rpm_limit=max_rpm_limit,
                             spend=0.0,
+                            blocked=False,
                         )
                         logger.info(
                             "Updated POOL key %s limits in LiteLLM: duration=%s, key_cap=%s, key_cap_duration=%s, rpm=%s, spend_reset=True",
@@ -1361,6 +1362,7 @@ async def apply_billing_cycle_for_team(
                             budget_amount=effective_key_budget,
                             rpm_limit=max_rpm_limit,
                             spend=0.0,
+                            blocked=False,
                         )
                         logger.info(
                             "Updated key %s limits in LiteLLM: duration=%s, budget=%s, rpm=%s, spend_reset=True",

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -370,6 +370,7 @@ class LiteLLMService:
         rpm_limit: int,
         budget_duration: Optional[str] = None,
         spend: Optional[float] = None,
+        blocked: Optional[bool] = None,
     ):
         """Set the restrictions for a LiteLLM API key.
 
@@ -387,6 +388,8 @@ class LiteLLMService:
             }
             if spend is not None:
                 request_data["spend"] = spend
+            if blocked is not None:
+                request_data["blocked"] = blocked
             async with httpx.AsyncClient() as client:
                 response = await client.post(
                     f"{self.api_url}/key/update",

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch, Mock, AsyncMock
 from app.db.models import (
     DBPrivateAIKey,
+    DBPeriodicBudgetLedgerEntry,
     DBPoolPurchase,
     DBTeam,
     DBUser,
@@ -1478,16 +1479,36 @@ def test_create_llm_token_for_pool_team_with_purchase_does_not_block_key(
     test_team,
     mock_httpx_post_client,
 ):
+    """Key created after a top-up purchase must NOT be blocked.
+
+    pool_available_budget_for_team_region reads from DBPeriodicBudgetLedgerEntry
+    (topup entries), not raw DBPoolPurchase rows directly. Both rows are created
+    by purchase_periodic_topup in production, so the test must seed both.
+    """
     test_team.budget_type = "pool"
+    now = datetime.now(UTC)
     db.add(
         DBPoolPurchase(
             team_id=test_team.id,
             region_id=test_region.id,
             amount_cents=1000,
             currency="usd",
-            purchased_at=datetime.now(UTC),
+            purchased_at=now,
             stripe_payment_id="pi_pool_existing_purchase",
-            created_at=datetime.now(UTC),
+            created_at=now,
+        )
+    )
+    # The ledger entry is what pool_available_budget_for_team_region reads.
+    db.add(
+        DBPeriodicBudgetLedgerEntry(
+            team_id=test_team.id,
+            region_id=test_region.id,
+            entry_type="topup",
+            amount_cents=1000,
+            consumed_cents=0,
+            is_active=True,
+            purchased_at=now,
+            expires_at=None,
         )
     )
     db.commit()
@@ -1514,6 +1535,109 @@ def test_create_llm_token_for_pool_team_with_purchase_does_not_block_key(
         .get("metadata", {})
         .get("amazeeai_private_ai_key_name")
         == "Pool Team Key With Budget"
+    ]
+    assert len(key_generate_calls) == 1
+    assert "blocked" not in key_generate_calls[0].kwargs["json"]
+
+
+@patch("httpx.AsyncClient")
+@patch("app.core.config.settings.ENABLE_LIMITS", True)
+def test_create_llm_token_for_pool_team_with_subscription_cycle_does_not_block_key(
+    mock_client_class,
+    client,
+    admin_token,
+    test_region,
+    db,
+    test_team,
+    mock_httpx_post_client,
+):
+    """Key created after a subscription cycle (no DBPoolPurchase) must NOT be blocked.
+
+    Subscription budget lives in DBPeriodicBudgetLedgerEntry with entry_type='subscription'.
+    pool_available_budget_for_team_region includes it, so the key must come out unblocked.
+    """
+    test_team.budget_type = "pool"
+    db.add(
+        DBPeriodicBudgetLedgerEntry(
+            team_id=test_team.id,
+            region_id=test_region.id,
+            entry_type="subscription",
+            amount_cents=1000,
+            consumed_cents=0,
+            is_active=True,
+            purchased_at=datetime.now(UTC),
+            expires_at=None,
+        )
+    )
+    db.commit()
+
+    mock_client_class.return_value = mock_httpx_post_client
+
+    response = client.post(
+        "/private-ai-keys/token",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "region_id": test_region.id,
+            "name": "Pool Team Key After Cycle",
+            "team_id": test_team.id,
+        },
+    )
+
+    assert response.status_code == 200
+
+    key_generate_calls = [
+        call
+        for call in mock_httpx_post_client.post.call_args_list
+        if str(call.args[0]).endswith("/key/generate")
+        and call.kwargs.get("json", {})
+        .get("metadata", {})
+        .get("amazeeai_private_ai_key_name")
+        == "Pool Team Key After Cycle"
+    ]
+    assert len(key_generate_calls) == 1
+    assert "blocked" not in key_generate_calls[0].kwargs["json"]
+
+
+@patch("httpx.AsyncClient")
+@patch("app.core.config.settings.ENABLE_LIMITS", True)
+def test_create_llm_token_for_non_gated_pool_team_is_never_blocked(
+    mock_client_class,
+    client,
+    admin_token,
+    test_region,
+    db,
+    test_team,
+    mock_httpx_post_client,
+):
+    """Non-gated POOL teams (require_purchase_for_requests=False) must never
+    produce a blocked key regardless of budget state.
+    """
+    test_team.budget_type = "pool"
+    test_team.require_purchase_for_requests = False  # not gated
+    db.commit()
+
+    mock_client_class.return_value = mock_httpx_post_client
+
+    response = client.post(
+        "/private-ai-keys/token",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "region_id": test_region.id,
+            "name": "Non-Gated Pool Key",
+            "team_id": test_team.id,
+        },
+    )
+
+    assert response.status_code == 200
+
+    key_generate_calls = [
+        call
+        for call in mock_httpx_post_client.post.call_args_list
+        if str(call.args[0]).endswith("/key/generate")
+        and call.kwargs.get("json", {})
+        .get("metadata", {})
+        .get("amazeeai_private_ai_key_name")
+        == "Non-Gated Pool Key"
     ]
     assert len(key_generate_calls) == 1
     assert "blocked" not in key_generate_calls[0].kwargs["json"]


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This hotfix resolves two related bugs affecting POOL team key states: keys were incorrectly created as `blocked=True` for subscription-cycle-funded teams (because the old code only checked `DBPoolPurchase` rows, which are empty for cycle-only teams), and keys blocked due to exhausted budget were never unblocked when the billing cycle renewed.

- **`private_ai_keys.py`**: Replaces the raw `DBPoolPurchase.amount_cents` sum with `pool_available_budget_for_team_region()`, which reads both `DBPeriodicBudgetLedgerEntry` (subscription and topup entries) and thus correctly reflects available budget regardless of whether it came from a top-up purchase or a subscription cycle.
- **`worker.py` + `litellm.py`**: Adds a `blocked` parameter to `set_key_restrictions` and passes `blocked=False` during billing-cycle renewal so that previously-exhausted keys are unblocked when fresh budget arrives.
- **`spend.py`**: Extends periodic transaction history to cover POOL teams in addition to PERIODIC teams.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the changes are tightly scoped to POOL team key-blocking logic and billing-cycle renewal.

All three fix sites are well-reasoned: the budget-availability check now reads from the authoritative ledger table instead of a subset of raw purchase rows, billing-cycle renewal explicitly unblocks keys when fresh budget arrives, and three targeted tests validate the previously-broken scenarios. The spend history extension is additive and low-risk.

No files require special attention. The assumption that DBPoolPurchase and DBPeriodicBudgetLedgerEntry are always co-created by purchase_periodic_topup is documented in the test comments and appears correct for current code paths.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/private_ai_keys.py | Replaces raw DBPoolPurchase sum with pool_available_budget_for_team_region() to correctly determine available budget for gated POOL teams during key creation; removes now-unused DBPoolPurchase and func imports. |
| app/core/worker.py | Adds blocked=False to set_key_restrictions calls during billing-cycle renewal for both POOL and PERIODIC keys, ensuring exhausted keys are re-enabled when fresh budget arrives. |
| app/services/litellm.py | Adds optional blocked parameter to set_key_restrictions, forwarded to /key/update only when explicitly set, matching the existing pattern used in create_key. |
| app/api/spend.py | Extends periodic transaction history query to POOL teams in addition to PERIODIC, with matching doc-string update. |
| tests/test_private_ai.py | Updates existing purchase test to seed the required DBPeriodicBudgetLedgerEntry row, and adds two new tests covering subscription-cycle-only POOL teams and non-gated POOL teams. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[POST /private-ai-keys/token] --> B{is_pool_team?}
    B -->|No| C[Normal key creation path]
    B -->|Yes| D[pool_available_budget_for_team_region]
    D --> E[Query subscription entries in DBPeriodicBudgetLedgerEntry]
    D --> F[compute_active_topup_remaining - topup entries]
    E --> G[Sum remaining cents]
    F --> G
    G --> H{pool_budget > 0?}
    H -->|Yes| I[Create key with blocked omitted]
    H -->|No| J[Create key with blocked=True]

    K[apply_billing_cycle_for_team] --> L{requires_pool_purchase_gate?}
    L -->|POOL| M[set_key_restrictions with spend=0.0 and blocked=False]
    L -->|PERIODIC| N[set_key_restrictions with spend=0.0 and blocked=False]
    M --> O[Key unblocked on cycle renewal]
    N --> O
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test: Add tests for key generation with ..."](https://github.com/amazeeio/amazee.ai/commit/82dae7f86b8cd5235f85c465700b9f7fbf5915dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36669247)</sub>

<!-- /greptile_comment -->