### PR TITLE
feat: add already_allocated_cents function to track consumed budget

### DIFF
--- a/app/core/periodic_budget_ledger_service.py
+++ b/app/core/periodic_budget_ledger_service.py
@@ -189,25 +189,6 @@ def add_topup_entry(
     return entry
 
 
-def already_allocated_cents(db: Session, *, team_id: int, region_id: int) -> int:
-    """Return the total consumed_cents already recorded across ALL ledger entries
-    (active and inactive) for this team+region.
-
-    Used by allocate_period_spend_fifo callers to compute incremental spend:
-        incremental = total_lifetime_spend - already_allocated
-    This prevents re-consuming entries that were settled in previous FIFO runs.
-    """
-    total = (
-        db.query(func.coalesce(func.sum(DBPeriodicBudgetLedgerEntry.consumed_cents), 0))
-        .filter(
-            DBPeriodicBudgetLedgerEntry.team_id == team_id,
-            DBPeriodicBudgetLedgerEntry.region_id == region_id,
-        )
-        .scalar()
-    )
-    return int(total or 0)
-
-
 def allocate_period_spend_fifo(
     db: Session, *, team_id: int, region_id: int, spend_cents: int
 ) -> AllocationResult:

--- a/app/core/periodic_budget_ledger_service.py
+++ b/app/core/periodic_budget_ledger_service.py
@@ -189,6 +189,25 @@ def add_topup_entry(
     return entry
 
 
+def already_allocated_cents(db: Session, *, team_id: int, region_id: int) -> int:
+    """Return the total consumed_cents already recorded across ALL ledger entries
+    (active and inactive) for this team+region.
+
+    Used by allocate_period_spend_fifo callers to compute incremental spend:
+        incremental = total_lifetime_spend - already_allocated
+    This prevents re-consuming entries that were settled in previous FIFO runs.
+    """
+    total = (
+        db.query(func.coalesce(func.sum(DBPeriodicBudgetLedgerEntry.consumed_cents), 0))
+        .filter(
+            DBPeriodicBudgetLedgerEntry.team_id == team_id,
+            DBPeriodicBudgetLedgerEntry.region_id == region_id,
+        )
+        .scalar()
+    )
+    return int(total or 0)
+
+
 def allocate_period_spend_fifo(
     db: Session, *, team_id: int, region_id: int, spend_cents: int
 ) -> AllocationResult:

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -16,6 +16,7 @@ from app.db.models import (
     DBPoolPurchase,
     DBPeriodicPayment,
     DBPeriodicBudgetLedgerEntry,
+    DBTeamSpendPeriod,
     DBAPIToken,
     DBUserAdminRegion,
     DBSpendCap,
@@ -62,7 +63,6 @@ from app.core.periodic_budget_ledger_service import (
     BudgetDriftResult,
     add_subscription_entry,
     allocate_period_spend_fifo,
-    already_allocated_cents,
     compute_active_topup_remaining,
     expire_subscription_entries,
     materialize_topup_rollovers,
@@ -963,6 +963,37 @@ async def capture_periodic_team_spend_for_period(
         )
 
 
+def _previous_period_spend_baseline_cents(
+    db: Session,
+    *,
+    team_id: int,
+    region_id: int,
+    current_period_start: datetime,
+) -> int:
+    """Return the LiteLLM total_spend (in cents) captured at the previous cycle
+    boundary — i.e. the most recent DBTeamSpendPeriod snapshot whose period_start
+    is strictly before the current one.
+
+    FIFO incremental spend = current_litellm_spend - this baseline.
+    This ensures we only allocate NEW spend (since the last cycle) against
+    active ledger entries, preventing rollovers from being consumed by
+    historical spend already settled in prior FIFO runs.
+    """
+    row = (
+        db.query(DBTeamSpendPeriod.total_spend)
+        .filter(
+            DBTeamSpendPeriod.team_id == team_id,
+            DBTeamSpendPeriod.region_id == region_id,
+            DBTeamSpendPeriod.period_start < current_period_start,
+        )
+        .order_by(DBTeamSpendPeriod.period_start.desc())
+        .first()
+    )
+    if row is None or row[0] is None:
+        return 0
+    return int(round(float(row[0]) * 100))
+
+
 async def _sync_periodic_ledger_for_invoice(
     *,
     db: Session,
@@ -1014,8 +1045,12 @@ async def _sync_periodic_ledger_for_invoice(
         else getattr(snapshot, "total_spend", 0.0)
     )
     spend_cents = int(round(float(snapshot_total_spend) * 100))
+    spend_baseline_cents = _previous_period_spend_baseline_cents(
+        db, team_id=team.id, region_id=region.id, current_period_start=period_start
+    )
+    incremental_spend_cents = max(0, spend_cents - spend_baseline_cents)
     allocate_period_spend_fifo(
-        db, team_id=team.id, region_id=region.id, spend_cents=spend_cents
+        db, team_id=team.id, region_id=region.id, spend_cents=incremental_spend_cents
     )
     materialize_topup_rollovers(
         db,
@@ -1073,10 +1108,10 @@ async def _sync_periodic_ledger_for_period(
         )
 
     spend_cents = int(round(float(snapshot_total_spend) * 100))
-    incremental_spend_cents = max(
-        0,
-        spend_cents - already_allocated_cents(db, team_id=team.id, region_id=region.id),
+    spend_baseline_cents = _previous_period_spend_baseline_cents(
+        db, team_id=team.id, region_id=region.id, current_period_start=period_start
     )
+    incremental_spend_cents = max(0, spend_cents - spend_baseline_cents)
     allocate_period_spend_fifo(
         db, team_id=team.id, region_id=region.id, spend_cents=incremental_spend_cents
     )

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -1045,13 +1045,36 @@ async def _sync_periodic_ledger_for_invoice(
         else getattr(snapshot, "total_spend", 0.0)
     )
     spend_cents = int(round(float(snapshot_total_spend) * 100))
-    spend_baseline_cents = _previous_period_spend_baseline_cents(
-        db, team_id=team.id, region_id=region.id, current_period_start=period_start
+
+    invoice_id = getattr(invoice_obj, "id", None)
+
+    # Guard FIFO against double-allocation on repeated calls with the same
+    # invoice.  add_subscription_entry and materialize_topup_rollovers are
+    # already idempotent on source_invoice_id; FIFO must be too.
+    # If a subscription entry for this invoice already exists the ledger was
+    # already settled — skip FIFO so consumed_cents are not incremented twice.
+    already_settled = bool(
+        invoice_id
+        and db.query(DBPeriodicBudgetLedgerEntry.id)
+        .filter(
+            DBPeriodicBudgetLedgerEntry.team_id == team.id,
+            DBPeriodicBudgetLedgerEntry.region_id == region.id,
+            DBPeriodicBudgetLedgerEntry.entry_type == "subscription",
+            DBPeriodicBudgetLedgerEntry.source_invoice_id == invoice_id,
+        )
+        .first()
     )
-    incremental_spend_cents = max(0, spend_cents - spend_baseline_cents)
-    allocate_period_spend_fifo(
-        db, team_id=team.id, region_id=region.id, spend_cents=incremental_spend_cents
-    )
+    if not already_settled:
+        spend_baseline_cents = _previous_period_spend_baseline_cents(
+            db, team_id=team.id, region_id=region.id, current_period_start=period_start
+        )
+        incremental_spend_cents = max(0, spend_cents - spend_baseline_cents)
+        allocate_period_spend_fifo(
+            db,
+            team_id=team.id,
+            region_id=region.id,
+            spend_cents=incremental_spend_cents,
+        )
     materialize_topup_rollovers(
         db,
         team_id=team.id,

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -62,6 +62,7 @@ from app.core.periodic_budget_ledger_service import (
     BudgetDriftResult,
     add_subscription_entry,
     allocate_period_spend_fifo,
+    already_allocated_cents,
     compute_active_topup_remaining,
     expire_subscription_entries,
     materialize_topup_rollovers,
@@ -1072,8 +1073,12 @@ async def _sync_periodic_ledger_for_period(
         )
 
     spend_cents = int(round(float(snapshot_total_spend) * 100))
+    incremental_spend_cents = max(
+        0,
+        spend_cents - already_allocated_cents(db, team_id=team.id, region_id=region.id),
+    )
     allocate_period_spend_fifo(
-        db, team_id=team.id, region_id=region.id, spend_cents=spend_cents
+        db, team_id=team.id, region_id=region.id, spend_cents=incremental_spend_cents
     )
     materialize_topup_rollovers(
         db,

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -1131,13 +1131,37 @@ async def _sync_periodic_ledger_for_period(
         )
 
     spend_cents = int(round(float(snapshot_total_spend) * 100))
-    spend_baseline_cents = _previous_period_spend_baseline_cents(
-        db, team_id=team.id, region_id=region.id, current_period_start=period_start
+
+    # Guard FIFO against double-allocation on repeated calls with the same
+    # source_invoice_id (e.g. Stripe webhook replay or direct test re-invocation).
+    # add_subscription_entry is already idempotent on source_invoice_id, but
+    # that guard does not protect the FIFO step. If a subscription entry for
+    # this invoice already exists the ledger was already settled — skip FIFO.
+    already_settled = bool(
+        source_invoice_id
+        and db.query(DBPeriodicBudgetLedgerEntry.id)
+        .filter(
+            DBPeriodicBudgetLedgerEntry.team_id == team.id,
+            DBPeriodicBudgetLedgerEntry.region_id == region.id,
+            DBPeriodicBudgetLedgerEntry.entry_type == "subscription",
+            DBPeriodicBudgetLedgerEntry.source_invoice_id == source_invoice_id,
+        )
+        .first()
     )
-    incremental_spend_cents = max(0, spend_cents - spend_baseline_cents)
-    allocate_period_spend_fifo(
-        db, team_id=team.id, region_id=region.id, spend_cents=incremental_spend_cents
-    )
+    if not already_settled:
+        spend_baseline_cents = _previous_period_spend_baseline_cents(
+            db,
+            team_id=team.id,
+            region_id=region.id,
+            current_period_start=period_start,
+        )
+        incremental_spend_cents = max(0, spend_cents - spend_baseline_cents)
+        allocate_period_spend_fifo(
+            db,
+            team_id=team.id,
+            region_id=region.id,
+            spend_cents=incremental_spend_cents,
+        )
     materialize_topup_rollovers(
         db,
         team_id=team.id,

--- a/scripts/check_eol_models.py
+++ b/scripts/check_eol_models.py
@@ -46,9 +46,7 @@ def fetch_public_models(api_url: str, timeout: int = 60) -> list[dict[str, Any]]
         with urllib.request.urlopen(request, timeout=timeout) as response:
             data = json.load(response)
     except json.JSONDecodeError as exc:
-        raise RuntimeError(
-            f"Invalid JSON from {url}: {exc}"
-        ) from exc
+        raise RuntimeError(f"Invalid JSON from {url}: {exc}") from exc
     except HTTPError as exc:
         body = exc.read().decode("utf-8", "replace")[:500]
         raise RuntimeError(
@@ -183,7 +181,9 @@ def build_slack_summary(results: dict[str, list[dict[str, Any]]]) -> str:
     return "\n\n".join(sections)
 
 
-def write_github_outputs(results: dict[str, list[dict[str, Any]]], summary: str) -> None:
+def write_github_outputs(
+    results: dict[str, list[dict[str, Any]]], summary: str
+) -> None:
     """Emit $GITHUB_OUTPUT lines for the surrounding workflow."""
     output_path = os.environ.get("GITHUB_OUTPUT")
     if not output_path:

--- a/tests/test_check_eol_models.py
+++ b/tests/test_check_eol_models.py
@@ -364,12 +364,18 @@ class TestFetchPublicModels:
 class TestMainWarningDaysValidation:
     def test_invalid_warning_days_returns_error(self):
         mod = _load_module()
-        with patch.dict("os.environ", {"EOL_WARNING_DAYS": "abc", "AMAZEEAI_API_URL": "https://x.example"}):
+        with patch.dict(
+            "os.environ",
+            {"EOL_WARNING_DAYS": "abc", "AMAZEEAI_API_URL": "https://x.example"},
+        ):
             exit_code = mod["main"]()
             assert exit_code == 1
 
     def test_negative_warning_days_returns_error(self):
         mod = _load_module()
-        with patch.dict("os.environ", {"EOL_WARNING_DAYS": "-5", "AMAZEEAI_API_URL": "https://x.example"}):
+        with patch.dict(
+            "os.environ",
+            {"EOL_WARNING_DAYS": "-5", "AMAZEEAI_API_URL": "https://x.example"},
+        ):
             exit_code = mod["main"]()
             assert exit_code == 1

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3613,3 +3613,20 @@ async def test_invoice_ledger_duplicate_invoice_id_is_idempotent(
     )
     assert len(rollover_rows) <= 1
     assert len(subscription_rows) <= 1
+
+    # The topup entry must not have been consumed twice.
+    # spend=100¢, topup=500¢ → at most 100¢ consumed; a second FIFO run
+    # would incorrectly add another 100¢ (200¢ total).
+    topup_entry = (
+        db.query(DBPeriodicBudgetLedgerEntry)
+        .filter(
+            DBPeriodicBudgetLedgerEntry.team_id == test_team.id,
+            DBPeriodicBudgetLedgerEntry.entry_type == "topup",
+        )
+        .first()
+    )
+    assert topup_entry is not None
+    assert topup_entry.consumed_cents <= 100, (
+        f"Double-allocation detected: consumed_cents={topup_entry.consumed_cents}, "
+        "expected at most 100¢ from a single FIFO run"
+    )


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces `_previous_period_spend_baseline_cents` to compute the incremental LiteLLM spend since the last billing cycle, preventing historical spend from being re-allocated against active ledger entries on every FIFO run. Both `_sync_periodic_ledger_for_invoice` and `_sync_periodic_ledger_for_period` are updated to use incremental rather than cumulative spend.

- `_sync_periodic_ledger_for_invoice` now has an `already_settled` guard that skips FIFO when a subscription entry for the same invoice already exists, providing explicit at-least-once webhook safety; the existing idempotency test is extended to assert `consumed_cents <= 100` after two identical calls.
- `_sync_periodic_ledger_for_period` receives the incremental spend computation but lacks the equivalent `already_settled` guard, meaning a Stripe webhook replay for the period path would still run FIFO twice.
- `scripts/check_eol_models.py` and its tests receive formatting-only changes.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The invoice sync path is now idempotent, but the period sync path can still double-allocate consumed budget on a Stripe webhook replay.

The period path (`_sync_periodic_ledger_for_period`) now computes incremental spend correctly on the first invocation, but nothing prevents FIFO from running again with the same incremental value if the webhook is replayed — `add_subscription_entry` idempotency does not protect the FIFO step. Stripe at-least-once delivery makes this a realistic production scenario.

app/core/worker.py — specifically `_sync_periodic_ledger_for_period` around lines 1133–1140
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/core/worker.py | Adds `_previous_period_spend_baseline_cents` helper and applies incremental FIFO spend to both sync functions; the invoice path gains an `already_settled` idempotency guard but the period path does not, leaving a double-allocation risk on webhook replay. |
| tests/test_worker.py | Extends the existing idempotency test to assert `consumed_cents <= 100` after two identical invoice sync calls; no parallel double-invocation test for `_sync_periodic_ledger_for_period`. |
| scripts/check_eol_models.py | Pure formatting changes (line length wrapping) — no logic changes. |
| tests/test_check_eol_models.py | Pure formatting changes to `patch.dict` call sites — no logic changes. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/core/worker.py`, line 1017-1019 ([link](https://github.com/amazeeio/amazee.ai/blob/2361aecc02eb4bc921823541110d93dcee6dda8c/app/core/worker.py#L1017-L1019)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`_sync_periodic_ledger_for_invoice` not updated with incremental fix**

   `_sync_periodic_ledger_for_invoice` (lines 1008–1040) is a parallel function to the updated `_sync_periodic_ledger_for_period` and still calls `allocate_period_spend_fifo` with the raw `spend_cents` — the full cumulative total — without the `already_allocated_cents` subtraction. If this function is ever wired into a production call path, it will re-consume budget on every repeated invocation. The existing `test_invoice_ledger_duplicate_invoice_id_is_idempotent` test calls it twice but only asserts row counts for rollover/subscription entries, so the double-allocation of `consumed_cents` is silently ignored and the bug goes undetected.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["feat(worker): prevent double-allocation ..."](https://github.com/amazeeio/amazee.ai/commit/964b5c63bfcee72d02f19ce64df8cb99db6e0a74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36710632)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->