### PR TITLE
feat(subscription): add FIFO allocation on subscription cancellation

### DIFF
--- a/app/api/subscription.py
+++ b/app/api/subscription.py
@@ -5,10 +5,14 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
-from app.core.periodic_budget_ledger_service import compute_active_topup_remaining
+from app.core.periodic_budget_ledger_service import (
+    allocate_period_spend_fifo,
+    compute_active_topup_remaining,
+)
 from app.core.security import get_role_min_system_admin
 from app.core.team_service import get_team_region_litellm_keys
 from app.core.worker import (
+    _previous_period_spend_baseline_cents,
     _record_periodic_payment_direct,
     _sync_periodic_ledger_for_period,
     apply_billing_cycle_for_team,
@@ -304,6 +308,45 @@ async def subscription_deactivate(
                 period_end=active_subscription_period.effective_period_end,
                 source_event_id=request.transaction_id,
             )
+            # Debit mid-period spend against top-up entries so that
+            # compute_active_topup_remaining reflects actual remaining balance.
+            # Without this, FIFO never runs on the cancel path (no invoice),
+            # and consumed_cents stays stale — leaking top-up credits.
+            try:
+                litellm_service_pre = LiteLLMService(
+                    api_url=region.litellm_api_url,
+                    api_key=region.litellm_api_key,
+                )
+                lite_team_id_pre = LiteLLMService.format_team_id(region.name, team.id)
+                team_info_pre = await litellm_service_pre.get_team_info(
+                    lite_team_id_pre
+                )
+                team_info_pre = team_info_pre.get("team_info", team_info_pre)
+                current_spend_cents = int(
+                    round(float(team_info_pre.get("spend", 0.0) or 0.0) * 100)
+                )
+                spend_baseline_cents = _previous_period_spend_baseline_cents(
+                    db,
+                    team_id=team.id,
+                    region_id=region.id,
+                    current_period_start=active_subscription_period.effective_period_start,
+                )
+                incremental_spend_cents = max(
+                    0, current_spend_cents - spend_baseline_cents
+                )
+                if incremental_spend_cents > 0:
+                    allocate_period_spend_fifo(
+                        db,
+                        team_id=team.id,
+                        region_id=region.id,
+                        spend_cents=incremental_spend_cents,
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to run FIFO allocation on cancellation for team %s: %s",
+                    team.id,
+                    exc,
+                )
 
         # Deactivation immediately ends active subscription windows.
         active_sub_rows = (

--- a/app/api/subscription.py
+++ b/app/api/subscription.py
@@ -347,6 +347,7 @@ async def subscription_deactivate(
                     "Failed to run FIFO allocation on cancellation for team %s: %s",
                     team.id,
                     exc,
+                    exc_info=True,
                 )
 
         # Deactivation immediately ends active subscription windows.

--- a/app/api/subscription.py
+++ b/app/api/subscription.py
@@ -322,9 +322,7 @@ async def subscription_deactivate(
                 team_info_resp = await litellm_service.get_team_info(lite_team_id)
                 team_info = team_info_resp.get("team_info", team_info_resp)
                 current_team_spend = float(team_info.get("spend", 0.0) or 0.0)
-                current_spend_cents = int(
-                    round(current_team_spend * 100)
-                )
+                current_spend_cents = int(round(current_team_spend * 100))
                 spend_baseline_cents = _previous_period_spend_baseline_cents(
                     db,
                     team_id=team.id,

--- a/app/api/subscription.py
+++ b/app/api/subscription.py
@@ -299,6 +299,12 @@ async def subscription_deactivate(
             )
             .first()
         )
+        litellm_service = LiteLLMService(
+            api_url=region.litellm_api_url,
+            api_key=region.litellm_api_key,
+        )
+        lite_team_id = LiteLLMService.format_team_id(region.name, team.id)
+        current_team_spend: float | None = None
         if active_subscription_period:
             await capture_periodic_team_spend_for_period(
                 db=db,
@@ -313,17 +319,11 @@ async def subscription_deactivate(
             # Without this, FIFO never runs on the cancel path (no invoice),
             # and consumed_cents stays stale — leaking top-up credits.
             try:
-                litellm_service_pre = LiteLLMService(
-                    api_url=region.litellm_api_url,
-                    api_key=region.litellm_api_key,
-                )
-                lite_team_id_pre = LiteLLMService.format_team_id(region.name, team.id)
-                team_info_pre = await litellm_service_pre.get_team_info(
-                    lite_team_id_pre
-                )
-                team_info_pre = team_info_pre.get("team_info", team_info_pre)
+                team_info_resp = await litellm_service.get_team_info(lite_team_id)
+                team_info = team_info_resp.get("team_info", team_info_resp)
+                current_team_spend = float(team_info.get("spend", 0.0) or 0.0)
                 current_spend_cents = int(
-                    round(float(team_info_pre.get("spend", 0.0) or 0.0) * 100)
+                    round(current_team_spend * 100)
                 )
                 spend_baseline_cents = _previous_period_spend_baseline_cents(
                     db,
@@ -342,6 +342,7 @@ async def subscription_deactivate(
                         spend_cents=incremental_spend_cents,
                     )
             except Exception as exc:
+                db.rollback()
                 logger.warning(
                     "Failed to run FIFO allocation on cancellation for team %s: %s",
                     team.id,
@@ -363,11 +364,6 @@ async def subscription_deactivate(
             row.is_active = False
         db.flush()
 
-        litellm_service = LiteLLMService(
-            api_url=region.litellm_api_url,
-            api_key=region.litellm_api_key,
-        )
-        lite_team_id = LiteLLMService.format_team_id(region.name, team.id)
         topup_remaining_dollars = (
             compute_active_topup_remaining(db, team_id=team.id, region_id=region.id)
             / 100.0
@@ -378,19 +374,21 @@ async def subscription_deactivate(
             topup_budget_duration = f"{settings.POOL_PURCHASE_EXPIRY_DAYS}d"
 
         projected_team_max_budget = topup_remaining_dollars
-        try:
-            team_info_resp = await litellm_service.get_team_info(lite_team_id)
-            team_info = team_info_resp.get("team_info", team_info_resp)
-            current_team_spend = float(team_info.get("spend", 0.0) or 0.0)
+        if current_team_spend is None:
+            try:
+                team_info_resp = await litellm_service.get_team_info(lite_team_id)
+                team_info = team_info_resp.get("team_info", team_info_resp)
+                current_team_spend = float(team_info.get("spend", 0.0) or 0.0)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to read LiteLLM team spend for deactivation projection (team %s): %s",
+                    team.id,
+                    exc,
+                )
+        if current_team_spend is not None:
             # LiteLLM team spend is non-resettable. Keep current spend as baseline
             # so remaining headroom stays requestable after deactivation.
             projected_team_max_budget = current_team_spend + topup_remaining_dollars
-        except Exception as exc:
-            logger.warning(
-                "Failed to read LiteLLM team spend for deactivation projection (team %s): %s",
-                team.id,
-                exc,
-            )
 
         try:
             await litellm_service.update_team_budget(

--- a/tests/test_periodic_payments.py
+++ b/tests/test_periodic_payments.py
@@ -788,6 +788,135 @@ def test_subscription_deactivate_captures_snapshot_before_reset(
     )
 
 
+@patch("app.api.subscription._record_periodic_payment_direct", new_callable=AsyncMock)
+@patch("app.api.subscription.LiteLLMService")
+def test_subscription_deactivate_fifo_debits_topup_on_cancellation(
+    mock_litellm_class,
+    mock_record_payment,
+    client,
+    admin_token,
+    db,
+    test_team,
+    test_region,
+):
+    """
+    Regression test for: Subscription cancellation ignores in-period spend
+    when computing top-up budget.
+
+    Scenario (mirrors the ticket example):
+      - Subscription budget: $1.00  (100¢)
+      - Active top-up:       $1.68  (168¢, consumed_cents=0)
+      - LiteLLM spend:       $2.10  (210¢) — overflows subscription into top-up
+      - Previous period baseline: $0 (first period)
+
+    Expected after cancellation:
+      - FIFO allocates 210¢ of spend: 100¢ consumed by subscription entry
+        (already inactive at cancel time) then 110¢ consumed by the top-up entry
+        → top-up consumed_cents becomes 110, remaining = 168 - 110 = 58¢ ($0.58)
+      - LiteLLM max_budget = current_spend ($2.10) + topup_remaining ($0.58) = $2.68
+      - Key budget_amount = $0.58
+    """
+    period_start = datetime.now(UTC) - timedelta(days=5)
+    period_end = datetime.now(UTC) + timedelta(days=26)
+
+    # Active subscription ledger entry: $1.00
+    db.add(
+        DBPeriodicBudgetLedgerEntry(
+            team_id=test_team.id,
+            region_id=test_region.id,
+            entry_type="subscription",
+            source_payment_id=None,
+            source_invoice_id="in_fifo_test_sub",
+            stripe_payment_id=None,
+            amount_cents=100,
+            consumed_cents=0,
+            purchased_at=period_start,
+            effective_period_start=period_start,
+            effective_period_end=period_end,
+            expires_at=period_end,
+            rolled_over_from_id=None,
+            is_active=True,
+        )
+    )
+    # Active top-up entry: $1.68, not yet debited
+    topup_entry = DBPeriodicBudgetLedgerEntry(
+        team_id=test_team.id,
+        region_id=test_region.id,
+        entry_type="topup",
+        source_payment_id=None,
+        source_invoice_id=None,
+        stripe_payment_id="pi_fifo_topup",
+        amount_cents=168,
+        consumed_cents=0,
+        purchased_at=period_start,
+        effective_period_start=None,
+        effective_period_end=None,
+        expires_at=datetime.now(UTC) + timedelta(days=30),
+        rolled_over_from_id=None,
+        is_active=True,
+    )
+    db.add(topup_entry)
+    db.add(
+        DBPrivateAIKey(
+            name="fifo-test-key",
+            litellm_token="fifo-test-token",
+            region_id=test_region.id,
+            team_id=test_team.id,
+        )
+    )
+    db.commit()
+
+    mock_record_payment.return_value = 999
+    mock_litellm = mock_litellm_class.return_value
+    # LiteLLM reports $2.10 total spend (overflows $1.00 subscription into top-up)
+    mock_litellm.get_team_info = AsyncMock(
+        return_value={"team_info": {"spend": 2.10, "max_budget": 5.0}}
+    )
+    mock_litellm.update_team_budget = AsyncMock()
+    mock_litellm.set_key_restrictions = AsyncMock()
+
+    response = client.post(
+        "/billing/subscription/deactivate",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "transaction_id": "txn_fifo_cancel_test",
+            "team_id": test_team.id,
+            "region_id": test_region.id,
+            "reason": "cancelled",
+        },
+    )
+
+    assert response.status_code == 200
+
+    # FIFO must have debited the top-up: 210¢ spend - 0¢ baseline = 210¢ incremental.
+    # Subscription entry absorbs 100¢ (then deactivated), top-up absorbs remaining 110¢.
+    db.refresh(topup_entry)
+    assert topup_entry.consumed_cents == 110, (
+        f"Top-up consumed_cents should be 110 after FIFO, got {topup_entry.consumed_cents}. "
+        "Cancellation is not debiting mid-period spend against top-up credits."
+    )
+
+    # Remaining top-up: 168 - 110 = 58¢ = $0.58
+    topup_remaining = 0.58
+    current_spend = 2.10
+    expected_max_budget = round(current_spend + topup_remaining, 2)
+
+    mock_litellm.update_team_budget.assert_awaited_once()
+    actual_max_budget = mock_litellm.update_team_budget.await_args.kwargs["max_budget"]
+    assert abs(actual_max_budget - expected_max_budget) < 0.01, (
+        f"Expected max_budget ~{expected_max_budget}, got {actual_max_budget}. "
+        "Top-up remaining is not being correctly reduced by mid-period spend."
+    )
+
+    mock_litellm.set_key_restrictions.assert_awaited_once()
+    actual_key_budget = mock_litellm.set_key_restrictions.await_args.kwargs[
+        "budget_amount"
+    ]
+    assert abs(actual_key_budget - topup_remaining) < 0.01, (
+        f"Expected key budget_amount ~{topup_remaining}, got {actual_key_budget}."
+    )
+
+
 def test_subscription_deactivate_endpoint_idempotent(
     client, admin_token, db, test_team
 ):

--- a/tests/test_periodic_payments.py
+++ b/tests/test_periodic_payments.py
@@ -788,11 +788,16 @@ def test_subscription_deactivate_captures_snapshot_before_reset(
     )
 
 
+@patch(
+    "app.api.subscription.capture_periodic_team_spend_for_period",
+    new_callable=AsyncMock,
+)
 @patch("app.api.subscription._record_periodic_payment_direct", new_callable=AsyncMock)
 @patch("app.api.subscription.LiteLLMService")
 def test_subscription_deactivate_fifo_debits_topup_on_cancellation(
     mock_litellm_class,
     mock_record_payment,
+    mock_capture_spend,
     client,
     admin_token,
     db,
@@ -887,6 +892,17 @@ def test_subscription_deactivate_fifo_debits_topup_on_cancellation(
     )
 
     assert response.status_code == 200
+
+    # capture_periodic_team_spend_for_period must have been called before FIFO ran.
+    mock_capture_spend.assert_awaited_once()
+    assert mock_capture_spend.await_args.kwargs["team"].id == test_team.id
+    assert mock_capture_spend.await_args.kwargs["region"].id == test_region.id
+    assert mock_capture_spend.await_args.kwargs["period_start"] == period_start
+    assert mock_capture_spend.await_args.kwargs["period_end"] == period_end
+    assert (
+        mock_capture_spend.await_args.kwargs["source_event_id"]
+        == "txn_fifo_cancel_test"
+    )
 
     # FIFO must have debited the top-up: 210¢ spend - 0¢ baseline = 210¢ incremental.
     # Subscription entry absorbs 100¢ (then deactivated), top-up absorbs remaining 110¢.

--- a/tests/test_periodic_payments.py
+++ b/tests/test_periodic_payments.py
@@ -902,6 +902,7 @@ def test_subscription_deactivate_fifo_debits_topup_on_cancellation(
     expected_max_budget = round(current_spend + topup_remaining, 2)
 
     mock_litellm.update_team_budget.assert_awaited_once()
+    assert mock_litellm.get_team_info.await_count == 1
     actual_max_budget = mock_litellm.update_team_budget.await_args.kwargs["max_budget"]
     assert abs(actual_max_budget - expected_max_budget) < 0.01, (
         f"Expected max_budget ~{expected_max_budget}, got {actual_max_budget}. "


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds FIFO (first-in, first-out) budget allocation on subscription cancellation so that mid-period spend is properly debited against top-up credits at cancel time — fixing the pre-existing leak where `consumed_cents` stayed stale on the cancel path (which has no invoice trigger).

- Moves `LiteLLMService` / `lite_team_id` construction earlier in `subscription_deactivate` so the same instance is reused for both the new FIFO step and the existing budget-projection step; a `current_team_spend` sentinel avoids a second `get_team_info` round-trip when the FIFO block already fetched the value.
- Inside the `if active_subscription_period` block, fetches the current LiteLLM spend, subtracts the prior-period baseline via `_previous_period_spend_baseline_cents`, and calls `allocate_period_spend_fifo` with the incremental amount; errors are caught with a `db.rollback()` to discard partial flushes and fall back to the old behaviour rather than aborting the deactivation.
- A new regression test exercises the full scenario: $1.00 subscription + $1.68 top-up, $2.10 total LiteLLM spend → top-up `consumed_cents` = 110, remaining = $0.58, and `update_team_budget` receives the correct `max_budget`.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the new FIFO path is wrapped in a broad exception handler that rolls back partial flushes and falls back to the old (non-FIFO) behaviour, so a LiteLLM outage or DB error during allocation will not abort the cancellation.

The production logic is well-structured and the test covers the intended scenario correctly. The only gap is in the test itself: `capture_periodic_team_spend_for_period` is not mocked despite the analogous existing test doing so, which means the snapshot-capture step is exercised against a real (unavailable) LiteLLM endpoint during CI and any regression in the call ordering between snapshot capture and FIFO would go undetected.

tests/test_periodic_payments.py — the new test is missing the `capture_periodic_team_spend_for_period` mock that the preceding similar test has; app/api/subscription.py looks correct.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/subscription.py | Adds FIFO allocation on cancellation: fetches LiteLLM spend, computes incremental spend relative to the prior-period baseline, and calls `allocate_period_spend_fifo` before deactivating subscription entries. `LiteLLMService` and `lite_team_id` are moved earlier to be reused. A `db.rollback()` in the FIFO exception handler safely discards partial flushes without affecting the already-committed snapshot. |
| tests/test_periodic_payments.py | Adds a regression test for FIFO debit on cancellation. Missing `@patch("app.api.subscription.capture_periodic_team_spend_for_period")` means the real function runs, makes an unmocked HTTP call (silently fails), and leaves `capture_periodic_team_spend_for_period` unverified—unlike the analogous existing test which mocks it explicitly. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant subscription_deactivate
    participant capture_periodic_team_spend_for_period
    participant LiteLLMService
    participant allocate_period_spend_fifo
    participant DB

    Client->>subscription_deactivate: POST /billing/subscription/deactivate
    subscription_deactivate->>DB: query active_subscription_period
    
    alt active_subscription_period found
        subscription_deactivate->>capture_periodic_team_spend_for_period: capture spend snapshot
        capture_periodic_team_spend_for_period->>DB: upsert DBTeamSpendPeriod + db.commit()
        subscription_deactivate->>LiteLLMService: get_team_info(lite_team_id)
        LiteLLMService-->>subscription_deactivate: current_team_spend
        subscription_deactivate->>DB: _previous_period_spend_baseline_cents()
        DB-->>subscription_deactivate: spend_baseline_cents
        Note over subscription_deactivate: incremental = current - baseline
        alt "incremental_spend_cents > 0"
            subscription_deactivate->>allocate_period_spend_fifo: "spend_cents=incremental"
            allocate_period_spend_fifo->>DB: update consumed_cents (subscription first, then topup) + db.flush()
        end
    end

    subscription_deactivate->>DB: "set subscription entries is_active=False + db.flush()"
    subscription_deactivate->>DB: compute_active_topup_remaining()
    DB-->>subscription_deactivate: topup_remaining_dollars

    alt current_team_spend is None
        subscription_deactivate->>LiteLLMService: get_team_info(lite_team_id)
        LiteLLMService-->>subscription_deactivate: current_team_spend
    end

    subscription_deactivate->>LiteLLMService: "update_team_budget(max_budget = spend + topup_remaining)"
    subscription_deactivate->>LiteLLMService: "set_key_restrictions(budget_amount=topup_remaining)"
    subscription_deactivate->>DB: _record_periodic_payment_direct + db.commit()
    subscription_deactivate-->>Client: 200 OK
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Potential fix for pull request finding"](https://github.com/amazeeio/amazee.ai/commit/ac924042bb48c11d53ebc82581bcf1db2fb6ced9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37186712)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->