### PR TITLE
docs: Update CHANGELOG with new features and fixes for version 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-- None yet.
+- **Pool Team Subscriptions**: Add periodic top-up support for pool teams (#562)
+- **Budget Ledger**: Track subscription-driven budget allocations and ledger entries (#562)
+- **Marketing Updates**: Allow users to update marketing preferences by email (#562)
 
 ### Fixes
 
-- None yet.
+- **Stripe Processing**: Harden event handling and idempotency for budget and subscription flows (#562)
+- **Budget Enforcement**: Block requests from zero-budget pool teams/keys and tighten budget validation (#562)
 
 ## 0.2.0 - 2026-05-28
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR populates the `Unreleased` section of `CHANGELOG.md` with features and fixes from PR #562, replacing the "None yet." placeholders. The entries cover pool team subscription top-ups, budget ledger tracking, marketing preference updates, Stripe event hardening, and zero-budget enforcement.

- **5 new CHANGELOG entries** (3 features, 2 fixes) added under `## Unreleased`, all referencing PR #562.
- The PR title says "for version 0.2.0", but `0.2.0` was released 2026-05-28 and these entries sit in the `Unreleased` block — the title is inaccurate.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — pure documentation change with no code impact.

The only notable issue is a mismatch between the PR title and where the entries actually land in the Unreleased section. The content of the entries themselves looks correct and well-formed.

CHANGELOG.md — verify whether the new entries are intentionally in Unreleased or should have been appended to the 0.2.0 block.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds 5 new entries (3 features, 2 fixes) to the Unreleased section, replacing "None yet." placeholders. PR title references version 0.2.0, but entries are placed in Unreleased — a minor labelling inconsistency. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR #563 - CHANGELOG Update] --> B[CHANGELOG.md]
    B --> C[Unreleased Section]
    C --> D[Features]
    C --> E[Fixes]
    D --> D1[Pool Team Subscriptions #562]
    D --> D2[Budget Ledger #562]
    D --> D3[Marketing Updates #562]
    E --> E1[Stripe Processing #562]
    E --> E2[Budget Enforcement #562]
    B --> F[0.2.0 - 2026-05-28]
    F --> G[Already released - unchanged]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `CHANGELOG.md`, line 8-19 ([link](https://github.com/amazeeio/amazee.ai/blob/ac3375fb90be45f5a30b28cfe91008970dfa7a3a/CHANGELOG.md#L8-L19)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **PR title mismatches the actual placement of entries**

   The PR title says "Update CHANGELOG with new features and fixes for version 0.2.0", but all five new entries are placed under the `## Unreleased` section, not under `## 0.2.0 - 2026-05-28`. Since 0.2.0 was already released on 2026-05-28, these entries (#562) appear to be targeting the next release. The PR title is misleading and may cause confusion about which release these changes belong to.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["docs: Update CHANGELOG with new features..."](https://github.com/amazeeio/amazee.ai/commit/ac3375fb90be45f5a30b28cfe91008970dfa7a3a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37596344)</sub>

<!-- /greptile_comment -->