### PR TITLE
feat(budgets): allow retry on purchase with sync failure handling

### DIFF
--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -361,15 +361,28 @@ async def purchase_pool_budget(
             .filter(DBPeriodicPayment.stripe_payment_id == purchase.stripe_payment_id)
             .first()
         )
-        if matching_payment and matching_payment.sync_status != "sync_failed":
+        if matching_payment is None:
+            # No downstream payment record exists — this implies the purchase
+            # row was created but the payment was never recorded (e.g. a crash
+            # before purchase_periodic_topup ran). Treat as a retryable state
+            # only if the DBPoolPurchase has no corresponding budget allocation;
+            # to be safe, raise 409 so an operator can explicitly investigate
+            # rather than silently allowing a potentially duplicate allocation.
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    "A purchase with this stripe_payment_id already exists "
+                    "but has no payment record — investigate before retrying"
+                ),
+            )
+        if matching_payment.sync_status != "sync_failed":
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="A purchase with this stripe_payment_id already exists",
             )
         # Prior attempt was sync_failed — clean up the stale records so the
         # full purchase flow runs fresh and commits atomically.
-        if matching_payment:
-            db.delete(matching_payment)
+        db.delete(matching_payment)
         db.delete(existing_purchase)
         db.flush()
 

--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -352,10 +352,26 @@ async def purchase_pool_budget(
     )
 
     if existing_purchase:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="A purchase with this stripe_payment_id already exists",
+        # Allow retry when the prior attempt failed to sync to LiteLLM.
+        # Check whether the downstream DBPeriodicPayment ended in sync_failed;
+        # if so, the budget was never actually applied and the operator should
+        # be able to resubmit with the same stripe_payment_id.
+        matching_payment = (
+            db.query(DBPeriodicPayment)
+            .filter(DBPeriodicPayment.stripe_payment_id == purchase.stripe_payment_id)
+            .first()
         )
+        if matching_payment and matching_payment.sync_status != "sync_failed":
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="A purchase with this stripe_payment_id already exists",
+            )
+        # Prior attempt was sync_failed — clean up the stale records so the
+        # full purchase flow runs fresh and commits atomically.
+        if matching_payment:
+            db.delete(matching_payment)
+        db.delete(existing_purchase)
+        db.flush()
 
     # Stage the POOL audit row before the ledger/LiteLLM sync so both are
     # committed atomically inside purchase_periodic_topup(). Without this,

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -641,8 +641,15 @@ async def _run_cycle_from_stripe_event(
                 if payment_record and payment_record.sync_status == "pending":
                     payment_record.sync_status = "sync_failed"
                     db.commit()
-            except Exception:
+            except Exception as commit_exc:
                 db.rollback()
+                logger.warning(
+                    "Failed to mark payment %s as sync_failed during error recovery: %s"
+                    " — record may be stuck in 'pending' and will block retries for stripe_payment_id=%s",
+                    payment_id,
+                    commit_exc,
+                    transaction_id,
+                )
 
 
 async def handle_stripe_event_background(event):

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -385,7 +385,7 @@ async def _record_periodic_payment_direct(
                 currency=currency.lower(),
                 payment_type=payment_type,
                 status="completed",
-                sync_status="success",
+                sync_status="pending",
                 payment_date=datetime.now(UTC),
             )
             db.add(payment_record)
@@ -555,6 +555,7 @@ async def _run_cycle_from_stripe_event(
     )
 
     try:
+        payment_id: Optional[int] = None
         if not is_first_cycle:
             for region in target_regions:
                 await capture_periodic_team_spend_for_period(
@@ -599,6 +600,20 @@ async def _run_cycle_from_stripe_event(
             )
             sync_errors.extend(region_errors)
 
+        # Full pipeline succeeded — promote the payment record to success.
+        # This must happen after apply_billing_cycle_for_team so that any
+        # retry via /cycle or the webhook path does not skip a partially-applied
+        # cycle (the idempotency guard at line 532 only skips on "success").
+        if payment_id:
+            payment_record = (
+                db.query(DBPeriodicPayment)
+                .filter(DBPeriodicPayment.id == payment_id)
+                .first()
+            )
+            if payment_record:
+                payment_record.sync_status = "success"
+                db.commit()
+
         logger.info(
             "Webhook invoice.paid cycle complete: team=%s invoice=%s budget=%s errors=%s",
             team.id,
@@ -614,6 +629,20 @@ async def _run_cycle_from_stripe_event(
             exc,
             exc_info=True,
         )
+        # Mark the payment record as sync_failed so retries are not blocked
+        # by the idempotency guard (which only skips on "success").
+        if payment_id:
+            try:
+                payment_record = (
+                    db.query(DBPeriodicPayment)
+                    .filter(DBPeriodicPayment.id == payment_id)
+                    .first()
+                )
+                if payment_record and payment_record.sync_status == "pending":
+                    payment_record.sync_status = "sync_failed"
+                    db.commit()
+            except Exception:
+                db.rollback()
 
 
 async def handle_stripe_event_background(event):

--- a/tests/test_periodic_payments.py
+++ b/tests/test_periodic_payments.py
@@ -39,7 +39,9 @@ async def test_record_periodic_payment_direct_subscription(db, test_team):
     assert payment.stripe_payment_id == "txn_subscription_1"
     assert payment.amount_cents == 1000
     assert payment.payment_type == "subscription"
-    assert payment.sync_status == "success"
+    assert (
+        payment.sync_status == "pending"
+    )  # promoted to "success" only after the full pipeline completes
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds retry support for pool budget purchases that previously failed mid-sync, and introduces a two-phase commit pattern for the webhook billing pipeline where `sync_status` starts as `\"pending\"` and is only promoted to `\"success\"` after the full pipeline completes.

- **`budgets.py`**: `purchase_pool_budget` now checks whether an existing `DBPoolPurchase` has a matching `DBPeriodicPayment` with `sync_status=\"sync_failed\"` before raising a 409; if so, it deletes the stale records and re-runs the full purchase flow atomically.
- **`worker.py`**: `_record_periodic_payment_direct` now writes `sync_status=\"pending\"` on insert and `_run_cycle_from_stripe_event` promotes the record to `\"success\"` at the end of the pipeline, with an exception handler that writes `\"sync_failed\"` on failure. This breaks the existing idempotency guard, which only short-circuits on `\"success\"`, creating a window where two concurrent webhook deliveries for the same invoice can both run the billing cycle.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge without addressing the broken idempotency guard — concurrent Stripe event deliveries can double-apply billing cycles.

The webhook billing pipeline now has a window during which concurrent deliveries of the same Stripe invoice event can both run the full billing cycle, since the idempotency guard relied on the payment record being written as success immediately. The deferred status update is the central risk.

app/core/worker.py requires the most scrutiny — the interaction between the deferred status update and the idempotency guard, and the silent exception swallow in the error-recovery path.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/core/worker.py | Changes _record_periodic_payment_direct to write sync_status=pending initially and promotes to success only after the full pipeline completes; the deferred status update breaks the existing idempotency guard, opening a window for duplicate billing cycle application on concurrent webhook deliveries. |
| app/api/budgets.py | Adds retry logic for purchase_pool_budget when a prior attempt left a sync_failed DBPeriodicPayment; logic is mostly sound but silently allows retry when an existing purchase has no matching payment record. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Stripe
    participant Runner as _run_cycle_from_stripe_event
    participant DB as Database
    participant LiteLLM

    Stripe->>Runner: "invoice.paid event_id=X"
    Runner->>DB: "Query DBPeriodicPayment transaction_id=X"
    DB-->>Runner: None or pending
    Note over Runner: Guard only returns early on success
    Runner->>DB: "INSERT sync_status=pending"
    DB-->>Runner: payment_id
    Runner->>LiteLLM: _sync_periodic_ledger_for_period
    Runner->>LiteLLM: apply_billing_cycle_for_team
    alt Pipeline succeeds
        Runner->>DB: "UPDATE sync_status=success"
    else Exception raised
        Runner->>DB: "UPDATE sync_status=sync_failed"
    end
    Note over Stripe,Runner: 2nd concurrent delivery sees pending and runs full cycle again
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/core/worker.py`, line 527-537 ([link](https://github.com/amazeeio/amazee.ai/blob/34db40a21e5459b514d0959d37bb0018036c9a72/app/core/worker.py#L527-L537)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Idempotency guard now ineffective during pipeline execution**

   Changing the initial `sync_status` to `"pending"` breaks the idempotency check at line 532, which only returns early when `sync_status == "success"`. Before this PR, `_record_periodic_payment_direct` wrote `"success"` immediately, so any concurrent webhook re-delivery for the same `transaction_id` would find the record and skip. Now there is a window — from the moment the payment record is inserted as `"pending"` until it is promoted to `"success"` at the end of the pipeline — during which a second concurrent invocation will find the record, see `"pending"`, fall through the guard, and run the full billing cycle again. Stripe can deliver the same `invoice.paid` event multiple times in quick succession, so this window is reachable in practice.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(budgets): allow retry on purchase w..."](https://github.com/amazeeio/amazee.ai/commit/34db40a21e5459b514d0959d37bb0018036c9a72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37600118)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->