### PR TITLE
fix(deploy): build DATABASE_URL from POSTGRES_* vars on Lagoon startup

### DIFF
--- a/backend-start.sh
+++ b/backend-start.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -euo pipefail
 
+# Build DATABASE_URL from Lagoon-injected POSTGRES_* vars if not already set.
+# On Lagoon (DBaaS), DATABASE_URL is not injected directly — only the individual
+# POSTGRES_HOST / POSTGRES_PORT / POSTGRES_DATABASE / POSTGRES_USERNAME / POSTGRES_PASSWORD
+# vars are available. The Python default falls back to @postgres which does not
+# resolve in the DBaaS network, causing startup failure.
+if [ -z "${DATABASE_URL:-}" ] && [ -n "${POSTGRES_HOST:-}" ]; then
+    export DATABASE_URL="postgresql://${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE}"
+    echo "DATABASE_URL built from POSTGRES_* vars: postgresql://${POSTGRES_USERNAME}:***@${POSTGRES_HOST}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE}"
+fi
+
 # Wait for PostgreSQL to be ready and create database if needed
 echo "Waiting for PostgreSQL to be ready..."
 python /app/scripts/wait_for_database.py


### PR DESCRIPTION
## Problem

PROD deploy failed — backend pod crashed during startup because `initialise_resources.py` tried to connect to hostname `postgres` which does not resolve in Lagoon's DBaaS network.

On Lagoon, `DATABASE_URL` is never injected directly. Only the individual `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DATABASE`, `POSTGRES_USERNAME`, `POSTGRES_PASSWORD` vars are available. The Python config falls back to the hardcoded default `postgresql://...@postgres/...` → `OperationalError` → `set -euo pipefail` kills the script → uvicorn never starts → pod unready → rollout times out after 10 min.

## Fix

Construct `DATABASE_URL` from the `POSTGRES_*` vars in `backend-start.sh` before any Python script runs — only when `DATABASE_URL` is not already set. No impact on local docker-compose (where `DATABASE_URL` is explicitly set).

## DB State

Clean — migrations from the failed deploy did **not** apply (Alembic still stamped at `2f7c9d1e4aab`). Once this fix deploys, migrations will run correctly and the app will start.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a shell-level workaround in `backend-start.sh` that constructs `DATABASE_URL` from the individual `POSTGRES_*` environment variables that Lagoon DBaaS injects, fixing a pod-crash-on-startup caused by the Python fallback URL pointing to an unresolvable hostname. The change is conditional — it only fires when `DATABASE_URL` is absent and `POSTGRES_HOST` is present — so local docker-compose environments are unaffected.

- `backend-start.sh` gains a new block (lines 9–12) that assembles and exports `DATABASE_URL` before any Python script runs, with the password masked in the accompanying log line.
- The password is interpolated directly into the URL without percent-encoding; if Lagoon's DBaaS generates a password containing `@`, `/`, `:`, or `%`, the resulting URL will be malformed and `wait_for_database.py` / `psycopg2` will fail to parse it, reproducing the startup failure the fix is meant to cure.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The fix resolves the immediate Lagoon startup failure for the common case, but will silently reproduce the same crash if the DBaaS-generated password contains URL-reserved characters.

The core logic — gate on DATABASE_URL being absent and POSTGRES_HOST being present, then export the assembled URL — is sound. However, the password is embedded into the URL string without percent-encoding. Lagoon DBaaS passwords are auto-generated and often contain characters like @, /, :, or %. Any such character causes urlparse in wait_for_database.py and psycopg2.connect to misparse the URL, so the fix would fail in the same way as the original bug on those deployments. The change is otherwise minimal and well-scoped.

backend-start.sh — specifically the URL construction at line 10 where the password is not encoded before being embedded.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend-start.sh | Adds DATABASE_URL construction from POSTGRES_* vars on Lagoon startup; password is not URL-encoded before embedding, which can cause the same connection failure the fix aims to prevent when the DBaaS-generated password contains URL-reserved characters. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Lagoon as Lagoon (DBaaS)
    participant Script as backend-start.sh
    participant WaitPy as wait_for_database.py
    participant InitPy as initialise_resources.py
    participant Uvicorn as uvicorn

    Lagoon->>Script: Inject POSTGRES_HOST/PORT/DATABASE/USERNAME/PASSWORD
    Note over Script: DATABASE_URL absent?<br/>POSTGRES_HOST present?
    Script->>Script: "Build & export DATABASE_URL"
    Script->>WaitPy: python wait_for_database.py
    WaitPy->>WaitPy: urlparse(DATABASE_URL)
    WaitPy->>Lagoon: psycopg2.connect(database_url)
    Lagoon-->>WaitPy: OK
    WaitPy-->>Script: exit 0
    Script->>InitPy: python initialise_resources.py
    InitPy->>Lagoon: Alembic migrations
    Lagoon-->>InitPy: OK
    InitPy-->>Script: exit 0
    Script->>Uvicorn: exec uvicorn (production mode)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(deploy): build DATABASE\_URL from POS..."](https://github.com/amazeeio/amazee.ai/commit/9936b00b917e62f895aaf91ed55133500eac1a33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37614783)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->