### PR TITLE
Fix/517 public models litellm config

### DIFF
--- a/app/api/public.py
+++ b/app/api/public.py
@@ -357,19 +357,11 @@ def _extract_model_summary(
         _safe_float(model_info.get("cache_read_input_token_cost")), profit_margin
     )
     supports_prompt_caching = bool(model_info.get("supports_prompt_caching"))
-    # prompt_caching_enabled reflects whether caching is operationally active.
-    # Ideally this would be derived from cache_control_injection_points in the
-    # LiteLLM cluster config, but that field is not exposed via the LiteLLM API.
-    # For now we use supports_prompt_caching (LiteLLM static model DB) as the
-    # best available signal. See: https://github.com/amazeeio/moad/issues/517
-    prompt_caching_enabled = supports_prompt_caching
-
     capabilities = PublicModelCapabilities(
         supports_vision=bool(model_info.get("supports_vision")),
         supports_function_calling=bool(model_info.get("supports_function_calling")),
         supports_reasoning=bool(model_info.get("supports_reasoning")),
         supports_prompt_caching=supports_prompt_caching,
-        prompt_caching_enabled=prompt_caching_enabled,
     )
 
     aliases = _extract_aliases(item, model_id)
@@ -393,13 +385,19 @@ def _extract_model_summary(
             output_cost_per_million_tokens=_per_million(output_cost_per_token),
             cache_creation_input_cost_per_million_tokens=_per_million(
                 cache_creation_input_cost_per_token
-            ) if prompt_caching_enabled else None,
+            )
+            if supports_prompt_caching
+            else None,
             cache_creation_input_cost_above_1hr_per_million_tokens=_per_million(
                 cache_creation_input_cost_above_1hr_per_token
-            ) if prompt_caching_enabled else None,
+            )
+            if supports_prompt_caching
+            else None,
             cache_read_input_cost_per_million_tokens=_per_million(
                 cache_read_input_cost_per_token
-            ) if prompt_caching_enabled else None,
+            )
+            if supports_prompt_caching
+            else None,
         ),
     )
 

--- a/app/api/public.py
+++ b/app/api/public.py
@@ -356,11 +356,20 @@ def _extract_model_summary(
     cache_read_input_cost_per_token = _apply_profit_margin(
         _safe_float(model_info.get("cache_read_input_token_cost")), profit_margin
     )
+    supports_prompt_caching = bool(model_info.get("supports_prompt_caching"))
+    # prompt_caching_enabled reflects whether caching is operationally active.
+    # Ideally this would be derived from cache_control_injection_points in the
+    # LiteLLM cluster config, but that field is not exposed via the LiteLLM API.
+    # For now we use supports_prompt_caching (LiteLLM static model DB) as the
+    # best available signal. See: https://github.com/amazeeio/moad/issues/517
+    prompt_caching_enabled = supports_prompt_caching
+
     capabilities = PublicModelCapabilities(
         supports_vision=bool(model_info.get("supports_vision")),
         supports_function_calling=bool(model_info.get("supports_function_calling")),
         supports_reasoning=bool(model_info.get("supports_reasoning")),
-        supports_prompt_caching=bool(model_info.get("supports_prompt_caching")),
+        supports_prompt_caching=supports_prompt_caching,
+        prompt_caching_enabled=prompt_caching_enabled,
     )
 
     aliases = _extract_aliases(item, model_id)
@@ -384,13 +393,13 @@ def _extract_model_summary(
             output_cost_per_million_tokens=_per_million(output_cost_per_token),
             cache_creation_input_cost_per_million_tokens=_per_million(
                 cache_creation_input_cost_per_token
-            ),
+            ) if prompt_caching_enabled else None,
             cache_creation_input_cost_above_1hr_per_million_tokens=_per_million(
                 cache_creation_input_cost_above_1hr_per_token
-            ),
+            ) if prompt_caching_enabled else None,
             cache_read_input_cost_per_million_tokens=_per_million(
                 cache_read_input_cost_per_token
-            ),
+            ) if prompt_caching_enabled else None,
         ),
     )
 

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -227,6 +227,7 @@ class PublicModelCapabilities(BaseModel):
     supports_function_calling: bool = False
     supports_reasoning: bool = False
     supports_prompt_caching: bool = False
+    prompt_caching_enabled: bool = False
 
 
 class PublicModelManufacturer(BaseModel):

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -227,7 +227,6 @@ class PublicModelCapabilities(BaseModel):
     supports_function_calling: bool = False
     supports_reasoning: bool = False
     supports_prompt_caching: bool = False
-    prompt_caching_enabled: bool = False
 
 
 class PublicModelManufacturer(BaseModel):

--- a/tests/test_public_models.py
+++ b/tests/test_public_models.py
@@ -138,6 +138,7 @@ def test_public_models_pricing_numeric_values(client, db):
                         "litellm_params": {},
                         "model_info": {
                             "mode": "chat",
+                            "supports_prompt_caching": True,
                             "input_cost_per_token": 0.000005,
                             "output_cost_per_token": 0.000015,
                             "cache_creation_input_token_cost": 0.00000625,
@@ -196,6 +197,7 @@ def test_public_models_pricing_uses_litellm_global_margin(client, db):
                         "litellm_params": {},
                         "model_info": {
                             "mode": "chat",
+                            "supports_prompt_caching": True,
                             "input_cost_per_token": 0.000005,
                             "output_cost_per_token": 0.000015,
                             "cache_creation_input_token_cost": 0.00000625,
@@ -256,6 +258,7 @@ def test_public_models_pricing_falls_back_to_default_margin(client, db):
                         "litellm_params": {},
                         "model_info": {
                             "mode": "chat",
+                            "supports_prompt_caching": True,
                             "input_cost_per_token": 0.000005,
                             "output_cost_per_token": 0.000015,
                             "cache_creation_input_token_cost": 0.00000625,
@@ -381,6 +384,155 @@ def test_public_models_pricing_non_numeric_values(client, db):
         assert pricing["cache_creation_input_cost_per_million_tokens"] is None
         assert pricing["cache_creation_input_cost_above_1hr_per_million_tokens"] is None
         assert pricing["cache_read_input_cost_per_million_tokens"] is None
+
+
+def test_prompt_caching_enabled_when_supports_and_costs_present(client, db):
+    """prompt_caching_enabled is True only when supports_prompt_caching=True AND cache costs are set."""
+    _clear_public_models_cache()
+    region = DBRegion(
+        name="caching-enabled-region",
+        postgres_host="host",
+        postgres_port=5432,
+        postgres_admin_user="user",
+        postgres_admin_password="pass",
+        litellm_api_url="https://litellm.example",
+        litellm_api_key="key",
+        is_active=True,
+        is_dedicated=False,
+    )
+    db.add(region)
+    db.commit()
+
+    with patch("app.api.public.LiteLLMService") as mock_service_cls:
+        mock_service = mock_service_cls.return_value
+        mock_service.get_model_info = AsyncMock(
+            return_value={
+                "data": [
+                    {
+                        "model_name": "claude-3-sonnet",
+                        "litellm_params": {},
+                        "model_info": {
+                            "mode": "chat",
+                            "supports_prompt_caching": True,
+                            "cache_creation_input_token_cost": 0.000003,
+                            "cache_creation_input_token_cost_above_1hr": 0.000006,
+                            "cache_read_input_token_cost": 0.0000003,
+                        },
+                    }
+                ]
+            }
+        )
+        mock_service.get_cost_margin_config = AsyncMock(return_value={"values": {"global": 0.0}})
+
+        response = client.get("/public/models")
+        assert response.status_code == 200
+        data = response.json()
+        region_data = next(r for r in data if r["region"] == "caching-enabled-region")
+        model = region_data["models"][0]
+        assert model["capabilities"]["supports_prompt_caching"] is True
+        assert model["capabilities"]["prompt_caching_enabled"] is True
+        assert model["pricing"]["cache_creation_input_cost_per_million_tokens"] == pytest.approx(3.0)
+        assert model["pricing"]["cache_creation_input_cost_above_1hr_per_million_tokens"] == pytest.approx(6.0)
+        assert model["pricing"]["cache_read_input_cost_per_million_tokens"] == pytest.approx(0.3)
+
+
+def test_prompt_caching_enabled_matches_supports_prompt_caching(client, db):
+    """prompt_caching_enabled mirrors supports_prompt_caching as the best available signal."""
+    _clear_public_models_cache()
+    region = DBRegion(
+        name="caching-no-cost-region",
+        postgres_host="host",
+        postgres_port=5432,
+        postgres_admin_user="user",
+        postgres_admin_password="pass",
+        litellm_api_url="https://litellm.example",
+        litellm_api_key="key",
+        is_active=True,
+        is_dedicated=False,
+    )
+    db.add(region)
+    db.commit()
+
+    with patch("app.api.public.LiteLLMService") as mock_service_cls:
+        mock_service = mock_service_cls.return_value
+        mock_service.get_model_info = AsyncMock(
+            return_value={
+                "data": [
+                    {
+                        "model_name": "claude-3-haiku",
+                        "litellm_params": {},
+                        "model_info": {
+                            "mode": "chat",
+                            "supports_prompt_caching": True,
+                            # No cache cost fields
+                        },
+                    }
+                ]
+            }
+        )
+        mock_service.get_cost_margin_config = AsyncMock(return_value={"values": {"global": 0.0}})
+
+        response = client.get("/public/models")
+        assert response.status_code == 200
+        data = response.json()
+        region_data = next(r for r in data if r["region"] == "caching-no-cost-region")
+        model = region_data["models"][0]
+        # prompt_caching_enabled follows supports_prompt_caching
+        assert model["capabilities"]["supports_prompt_caching"] is True
+        assert model["capabilities"]["prompt_caching_enabled"] is True
+        assert model["pricing"]["cache_creation_input_cost_per_million_tokens"] is None
+        assert model["pricing"]["cache_creation_input_cost_above_1hr_per_million_tokens"] is None
+        assert model["pricing"]["cache_read_input_cost_per_million_tokens"] is None
+
+
+def test_prompt_caching_enabled_false_when_supports_false(client, db):
+    """prompt_caching_enabled is False when supports_prompt_caching is False/null, cache pricing nulled."""
+    _clear_public_models_cache()
+    region = DBRegion(
+        name="caching-unsupported-region",
+        postgres_host="host",
+        postgres_port=5432,
+        postgres_admin_user="user",
+        postgres_admin_password="pass",
+        litellm_api_url="https://litellm.example",
+        litellm_api_key="key",
+        is_active=True,
+        is_dedicated=False,
+    )
+    db.add(region)
+    db.commit()
+
+    with patch("app.api.public.LiteLLMService") as mock_service_cls:
+        mock_service = mock_service_cls.return_value
+        mock_service.get_model_info = AsyncMock(
+            return_value={
+                "data": [
+                    {
+                        "model_name": "gpt-4o",
+                        "litellm_params": {},
+                        "model_info": {
+                            "mode": "chat",
+                            "supports_prompt_caching": False,
+                            # LiteLLM static DB might still return cache costs — should be nulled
+                            "cache_creation_input_token_cost": 0.000003,
+                            "cache_read_input_token_cost": 0.0000003,
+                        },
+                    }
+                ]
+            }
+        )
+        mock_service.get_cost_margin_config = AsyncMock(return_value={"values": {"global": 0.0}})
+
+        response = client.get("/public/models")
+        assert response.status_code == 200
+        data = response.json()
+        region_data = next(r for r in data if r["region"] == "caching-unsupported-region")
+        model = region_data["models"][0]
+        assert model["capabilities"]["supports_prompt_caching"] is False
+        assert model["capabilities"]["prompt_caching_enabled"] is False
+        assert model["pricing"]["cache_creation_input_cost_per_million_tokens"] is None
+        assert model["pricing"]["cache_creation_input_cost_above_1hr_per_million_tokens"] is None
+        assert model["pricing"]["cache_read_input_cost_per_million_tokens"] is None
 
 
 def test_public_models_uses_region_key_for_model_info(client, db):

--- a/tests/test_public_models.py
+++ b/tests/test_public_models.py
@@ -386,8 +386,64 @@ def test_public_models_pricing_non_numeric_values(client, db):
         assert pricing["cache_read_input_cost_per_million_tokens"] is None
 
 
-def test_prompt_caching_enabled_when_supports_and_costs_present(client, db):
-    """prompt_caching_enabled is True only when supports_prompt_caching=True AND cache costs are set."""
+def test_prompt_caching_cache_pricing_nulled_when_not_supported(client, db):
+    """Cache pricing fields are null when supports_prompt_caching is False."""
+    _clear_public_models_cache()
+    region = DBRegion(
+        name="caching-unsupported-region",
+        postgres_host="host",
+        postgres_port=5432,
+        postgres_admin_user="user",
+        postgres_admin_password="pass",
+        litellm_api_url="https://litellm.example",
+        litellm_api_key="key",
+        is_active=True,
+        is_dedicated=False,
+    )
+    db.add(region)
+    db.commit()
+
+    with patch("app.api.public.LiteLLMService") as mock_service_cls:
+        mock_service = mock_service_cls.return_value
+        mock_service.get_model_info = AsyncMock(
+            return_value={
+                "data": [
+                    {
+                        "model_name": "gpt-4o",
+                        "litellm_params": {},
+                        "model_info": {
+                            "mode": "chat",
+                            "supports_prompt_caching": False,
+                            # LiteLLM static DB may still return cache costs — should be nulled
+                            "cache_creation_input_token_cost": 0.000003,
+                            "cache_read_input_token_cost": 0.0000003,
+                        },
+                    }
+                ]
+            }
+        )
+        mock_service.get_cost_margin_config = AsyncMock(
+            return_value={"values": {"global": 0.0}}
+        )
+
+        response = client.get("/public/models")
+        assert response.status_code == 200
+        data = response.json()
+        region_data = next(
+            r for r in data if r["region"] == "caching-unsupported-region"
+        )
+        model = region_data["models"][0]
+        assert model["capabilities"]["supports_prompt_caching"] is False
+        assert model["pricing"]["cache_creation_input_cost_per_million_tokens"] is None
+        assert (
+            model["pricing"]["cache_creation_input_cost_above_1hr_per_million_tokens"]
+            is None
+        )
+        assert model["pricing"]["cache_read_input_cost_per_million_tokens"] is None
+
+
+def test_prompt_caching_cache_pricing_present_when_supported(client, db):
+    """Cache pricing fields are populated when supports_prompt_caching is True."""
     _clear_public_models_cache()
     region = DBRegion(
         name="caching-enabled-region",
@@ -422,7 +478,9 @@ def test_prompt_caching_enabled_when_supports_and_costs_present(client, db):
                 ]
             }
         )
-        mock_service.get_cost_margin_config = AsyncMock(return_value={"values": {"global": 0.0}})
+        mock_service.get_cost_margin_config = AsyncMock(
+            return_value={"values": {"global": 0.0}}
+        )
 
         response = client.get("/public/models")
         assert response.status_code == 200
@@ -430,109 +488,15 @@ def test_prompt_caching_enabled_when_supports_and_costs_present(client, db):
         region_data = next(r for r in data if r["region"] == "caching-enabled-region")
         model = region_data["models"][0]
         assert model["capabilities"]["supports_prompt_caching"] is True
-        assert model["capabilities"]["prompt_caching_enabled"] is True
-        assert model["pricing"]["cache_creation_input_cost_per_million_tokens"] == pytest.approx(3.0)
-        assert model["pricing"]["cache_creation_input_cost_above_1hr_per_million_tokens"] == pytest.approx(6.0)
-        assert model["pricing"]["cache_read_input_cost_per_million_tokens"] == pytest.approx(0.3)
-
-
-def test_prompt_caching_enabled_matches_supports_prompt_caching(client, db):
-    """prompt_caching_enabled mirrors supports_prompt_caching as the best available signal."""
-    _clear_public_models_cache()
-    region = DBRegion(
-        name="caching-no-cost-region",
-        postgres_host="host",
-        postgres_port=5432,
-        postgres_admin_user="user",
-        postgres_admin_password="pass",
-        litellm_api_url="https://litellm.example",
-        litellm_api_key="key",
-        is_active=True,
-        is_dedicated=False,
-    )
-    db.add(region)
-    db.commit()
-
-    with patch("app.api.public.LiteLLMService") as mock_service_cls:
-        mock_service = mock_service_cls.return_value
-        mock_service.get_model_info = AsyncMock(
-            return_value={
-                "data": [
-                    {
-                        "model_name": "claude-3-haiku",
-                        "litellm_params": {},
-                        "model_info": {
-                            "mode": "chat",
-                            "supports_prompt_caching": True,
-                            # No cache cost fields
-                        },
-                    }
-                ]
-            }
-        )
-        mock_service.get_cost_margin_config = AsyncMock(return_value={"values": {"global": 0.0}})
-
-        response = client.get("/public/models")
-        assert response.status_code == 200
-        data = response.json()
-        region_data = next(r for r in data if r["region"] == "caching-no-cost-region")
-        model = region_data["models"][0]
-        # prompt_caching_enabled follows supports_prompt_caching
-        assert model["capabilities"]["supports_prompt_caching"] is True
-        assert model["capabilities"]["prompt_caching_enabled"] is True
-        assert model["pricing"]["cache_creation_input_cost_per_million_tokens"] is None
-        assert model["pricing"]["cache_creation_input_cost_above_1hr_per_million_tokens"] is None
-        assert model["pricing"]["cache_read_input_cost_per_million_tokens"] is None
-
-
-def test_prompt_caching_enabled_false_when_supports_false(client, db):
-    """prompt_caching_enabled is False when supports_prompt_caching is False/null, cache pricing nulled."""
-    _clear_public_models_cache()
-    region = DBRegion(
-        name="caching-unsupported-region",
-        postgres_host="host",
-        postgres_port=5432,
-        postgres_admin_user="user",
-        postgres_admin_password="pass",
-        litellm_api_url="https://litellm.example",
-        litellm_api_key="key",
-        is_active=True,
-        is_dedicated=False,
-    )
-    db.add(region)
-    db.commit()
-
-    with patch("app.api.public.LiteLLMService") as mock_service_cls:
-        mock_service = mock_service_cls.return_value
-        mock_service.get_model_info = AsyncMock(
-            return_value={
-                "data": [
-                    {
-                        "model_name": "gpt-4o",
-                        "litellm_params": {},
-                        "model_info": {
-                            "mode": "chat",
-                            "supports_prompt_caching": False,
-                            # LiteLLM static DB might still return cache costs — should be nulled
-                            "cache_creation_input_token_cost": 0.000003,
-                            "cache_read_input_token_cost": 0.0000003,
-                        },
-                    }
-                ]
-            }
-        )
-        mock_service.get_cost_margin_config = AsyncMock(return_value={"values": {"global": 0.0}})
-
-        response = client.get("/public/models")
-        assert response.status_code == 200
-        data = response.json()
-        region_data = next(r for r in data if r["region"] == "caching-unsupported-region")
-        model = region_data["models"][0]
-        assert model["capabilities"]["supports_prompt_caching"] is False
-        assert model["capabilities"]["prompt_caching_enabled"] is False
-        assert model["pricing"]["cache_creation_input_cost_per_million_tokens"] is None
-        assert model["pricing"]["cache_creation_input_cost_above_1hr_per_million_tokens"] is None
-        assert model["pricing"]["cache_read_input_cost_per_million_tokens"] is None
+        assert model["pricing"][
+            "cache_creation_input_cost_per_million_tokens"
+        ] == pytest.approx(3.0)
+        assert model["pricing"][
+            "cache_creation_input_cost_above_1hr_per_million_tokens"
+        ] == pytest.approx(6.0)
+        assert model["pricing"][
+            "cache_read_input_cost_per_million_tokens"
+        ] == pytest.approx(0.3)
 
 
 def test_public_models_uses_region_key_for_model_info(client, db):


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

When LiteLLM's static model database populates cache cost fields for models that don't actually support prompt caching, those costs were previously surfaced in the public API. This PR gates all three cache pricing fields (`cache_creation_input_cost_per_million_tokens`, `cache_creation_input_cost_above_1hr_per_million_tokens`, `cache_read_input_cost_per_million_tokens`) behind the `supports_prompt_caching` flag, returning `null` when the model doesn't support it.

- **`app/api/public.py`**: Extracts `supports_prompt_caching` into a local variable and applies it as a conditional guard on all three cache pricing fields in `_extract_model_summary`.
- **`tests/test_public_models.py`**: Adds `supports_prompt_caching: True` to three existing pricing fixtures and introduces two new tests covering the unsupported (fields null) and supported (fields populated) scenarios.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The production change is correct and safe to merge; the only concern is a test that now passes its cache-field assertions via the new guard rather than the non-numeric coercion it was written to verify.

The implementation change in `public.py` is straightforward and well-covered by the two new tests. The one gap is in `test_public_models_pricing_non_numeric_values`, whose cache pricing `None` assertions now pass because `supports_prompt_caching` defaults to `False`, bypassing the `_per_million` call entirely — so the "non-numeric values are coerced to null" contract for cache fields goes untested.

`tests/test_public_models.py` — the non-numeric pricing test needs `supports_prompt_caching: True` to keep its cache-field assertions meaningful.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/api/public.py | Extracts `supports_prompt_caching` flag and uses it to null out cache pricing fields when the model doesn't support caching — clean, correct change with no issues. |
| tests/test_public_models.py | Adds `supports_prompt_caching: True` to existing fixtures and two new focused tests; the non-numeric-values test now silently passes its cache assertions via the caching guard rather than the coercion path. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[LiteLLM model_info] --> B{supports_prompt_caching?}
    B -- True --> C[Compute cache pricing with profit margin]
    C --> D[cache_creation_input_cost_per_million_tokens]
    C --> E[cache_creation_input_cost_above_1hr_per_million_tokens]
    C --> F[cache_read_input_cost_per_million_tokens]
    B -- False / absent --> G[null]
    G --> D
    G --> E
    G --> F
    D & E & F --> H[PublicModelPricing response]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[LiteLLM model_info] --> B{supports_prompt_caching?}
    B -- True --> C[Compute cache pricing with profit margin]
    C --> D[cache_creation_input_cost_per_million_tokens]
    C --> E[cache_creation_input_cost_above_1hr_per_million_tokens]
    C --> F[cache_read_input_cost_per_million_tokens]
    B -- False / absent --> G[null]
    G --> D
    G --> E
    G --> F
    D & E & F --> H[PublicModelPricing response]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/test_public_models.py`, line 337-386 ([link](https://github.com/amazeeio/amazee.ai/blob/6c8550e41c4547aec71abee8aa5c4a82d02dd964/tests/test_public_models.py#L337-L386)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`test_public_models_pricing_non_numeric_values` no longer exercises non-numeric coercion for cache fields**

   The fixture in this test omits `supports_prompt_caching`, so `bool(model_info.get("supports_prompt_caching"))` evaluates to `False`. All three cache pricing assertions (`cache_creation_input_cost_per_million_tokens is None`, etc.) now pass because the new `supports_prompt_caching` guard short-circuits before `_per_million` is ever called — not because the non-numeric `"n/a"` values are properly coerced. If someone later removes the guard, the `"n/a"` coercion path for cache fields would be untested and the test would give a false sense of coverage. Add `"supports_prompt_caching": True` to this fixture to keep the test verifying what its docstring claims.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["refactor(api): remove unused prompt\_cach..."](https://github.com/amazeeio/amazee.ai/commit/6c8550e41c4547aec71abee8aa5c4a82d02dd964) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37912575)</sub>

<!-- /greptile_comment -->