### PR TITLE
feat(internal): add internal API endpoint for key provisioning process

### DIFF
--- a/app/api/internal.py
+++ b/app/api/internal.py
@@ -1,0 +1,60 @@
+"""
+Internal API endpoints — machine-to-machine only, not for end users.
+
+POST /internal/provision-key
+    Called exclusively by moad during the external key provisioning flow.
+    Authenticated via the existing admin API token mechanism (same as all
+    other moad → amazee.ai calls).  moad passes AMAZEEAI_ADMIN_API_TOKEN
+    which security.py resolves to an admin DBUser via the api_tokens table.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.core.dependencies import get_limit_service
+from app.core.limit_service import LimitService
+from app.core.security import get_current_user_from_auth, get_role_min_system_admin
+from app.core.roles import UserRole
+from app.db.database import get_db
+from app.db.models import DBUser
+from app.schemas.models import PrivateAIKey, PrivateAIKeyCreate
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["internal"])
+
+
+@router.post(
+    "/provision-key",
+    response_model=PrivateAIKey,
+    dependencies=[Depends(get_role_min_system_admin)],
+)
+async def internal_provision_key(
+    private_ai_key: PrivateAIKeyCreate,
+    current_user: DBUser = Depends(get_current_user_from_auth),
+    db: Session = Depends(get_db),
+    limit_service: LimitService = Depends(get_limit_service),
+):
+    """
+    Create a private AI key (LiteLLM token + vector database) on behalf of moad.
+
+    Called exclusively by moad as part of the external key provisioning flow
+    (``POST /api/external/provision-key`` on the moad side).  The caller must
+    present a valid amazee.ai admin API token via ``Authorization: Bearer <token>``.
+
+    moad is expected to supply a valid ``team_id`` referencing the Applications
+    workspace team it has already registered on this backend.
+    """
+    # Import here to avoid a circular import — internal.py and private_ai_keys.py
+    # are sibling modules; deferring the import keeps the module graph clean.
+    from app.api.private_ai_keys import create_private_ai_key
+
+    return await create_private_ai_key(
+        private_ai_key=private_ai_key,
+        current_user=current_user,
+        user_role=UserRole.SYSTEM_ADMIN,
+        db=db,
+        limit_service=limit_service,
+    )

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -1175,9 +1175,16 @@ async def _delegate_to_moad(
             detail="Key provisioning failed.",
         )
 
-    data = response.json()
-    litellm_token = data.get("llm", {}).get("token")
+    try:
+        data = response.json()
+    except ValueError as exc:
+        logger.error("moad provision-key returned invalid JSON: %s", response.text)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Key provisioning returned an invalid response.",
+        ) from exc
 
+    litellm_token = data.get("llm", {}).get("token")
     if not litellm_token:
         logger.error("moad provision-key response missing llm.token: %s", data)
         raise HTTPException(

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -4,6 +4,8 @@ from typing import List, Optional
 from fastapi import status
 import logging
 
+import httpx
+
 from app.db.database import get_db
 from app.core.dependencies import get_limit_service
 from app.schemas.models import (
@@ -242,7 +244,20 @@ async def create_private_ai_key(
     - Key budgets apply per key.
     - For team workflows with shared pool budget, prefer team-owned keys
       (`team_id`).
+
+    Non-admin users (e.g. Drupal email/code sign-in flow) are delegated to the
+    moad dashboard backend which handles workspace and Keycloak provisioning
+    before calling back via ``POST /internal/provision-key``.
     """
+    # --- moad delegation for regular (non-admin) users ---
+    # Only plain DEFAULT users (Drupal email/code sign-in) are delegated to
+    # moad. This requires BOTH conditions:
+    #   - role == UserRole.DEFAULT (not a team admin, key creator, etc.)
+    #   - not is_admin (system admins have role="user" by default but must
+    #     bypass delegation — they include moad's AMAZEEAI_ADMIN_API_TOKEN)
+    if current_user.role == UserRole.DEFAULT and not current_user.is_admin:
+        return await _delegate_to_moad(private_ai_key, current_user, db)
+
     llm_token = None
     db_info = None
     region = None
@@ -1091,3 +1106,101 @@ async def extend_token_life(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to extend token life: {str(e)}",
         )
+
+
+async def _delegate_to_moad(
+    private_ai_key: PrivateAIKeyCreate,
+    current_user,
+    db,
+) -> PrivateAIKey:
+    """
+    Delegate key creation to the moad dashboard backend.
+
+    Called when a regular (non-admin) user hits ``POST /private-ai-keys``
+    — the Drupal email/code sign-in workflow.  moad handles Keycloak user
+    creation, workspace provisioning, and calls back via
+    ``POST /internal/provision-key`` (with its admin API token) to create
+    the actual LiteLLM token + vector DB on this backend.
+
+    The ``{ llm, vectorDb }`` response from moad is mapped back to the
+    ``PrivateAIKey`` shape expected by the Drupal module, and the newly
+    created key is looked up in the local DB by its ``litellm_token`` so
+    that a fully populated record (including ``id``, ``team_id``, region
+    info, etc.) is returned and remains visible via ``GET /private-ai-keys``.
+    """
+    if not settings.MOAD_DASHBOARD_API_URL or not settings.MOAD_DASHBOARD_API_TOKEN:
+        logger.error(
+            "MOAD_DASHBOARD_API_URL or MOAD_DASHBOARD_API_TOKEN is not configured"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Key provisioning service is not configured.",
+        )
+
+    payload = {
+        "email": current_user.email,
+        "appName": private_ai_key.name,
+        "regionId": private_ai_key.region_id,
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.post(
+                f"{settings.MOAD_DASHBOARD_API_URL}/api/external/provision-key",
+                json=payload,
+                headers={
+                    "Authorization": f"Bearer {settings.MOAD_DASHBOARD_API_TOKEN}"
+                },
+            )
+    except httpx.RequestError as exc:
+        logger.error("Failed to reach moad for key provisioning: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Key provisioning service is unreachable.",
+        )
+
+    if response.status_code == 404:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Region not found.",
+        )
+    if response.status_code >= 400:
+        logger.error(
+            "moad returned %s for provision-key: %s",
+            response.status_code,
+            response.text,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Key provisioning failed.",
+        )
+
+    data = response.json()
+    litellm_token = data.get("llm", {}).get("token")
+
+    if not litellm_token:
+        logger.error("moad provision-key response missing llm.token: %s", data)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Key provisioning returned an invalid response.",
+        )
+
+    # Look up the key that moad just created via /internal/provision-key so we
+    # return a fully populated PrivateAIKey (with id, team_id, region, etc.).
+    # This also ensures the key is visible via GET /private-ai-keys.
+    db_key = (
+        db.query(DBPrivateAIKey)
+        .filter(DBPrivateAIKey.litellm_token == litellm_token)
+        .first()
+    )
+
+    if not db_key:
+        logger.error(
+            "Could not find newly provisioned key by litellm_token after moad call"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Key provisioning failed: key not found after creation.",
+        )
+
+    return PrivateAIKey.model_validate(db_key.to_dict())

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -1110,8 +1110,8 @@ async def extend_token_life(
 
 async def _delegate_to_moad(
     private_ai_key: PrivateAIKeyCreate,
-    current_user,
-    db,
+    current_user: DBUser,
+    db: Session,
 ) -> PrivateAIKey:
     """
     Delegate key creation to the moad dashboard backend.

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -245,7 +245,7 @@ async def create_private_ai_key(
     - For team workflows with shared pool budget, prefer team-owned keys
       (`team_id`).
 
-    Non-admin users (e.g. Drupal email/code sign-in flow) are delegated to the
+    DEFAULT (non-admin) users (e.g. Drupal email/code sign-in flow) are delegated to the
     moad dashboard backend which handles workspace and Keycloak provisioning
     before calling back via ``POST /internal/provision-key``.
     """

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -1122,11 +1122,11 @@ async def _delegate_to_moad(
     ``POST /internal/provision-key`` (with its admin API token) to create
     the actual LiteLLM token + vector DB on this backend.
 
-    The ``{ llm, vectorDb }`` response from moad is mapped back to the
-    ``PrivateAIKey`` shape expected by the Drupal module, and the newly
-    created key is looked up in the local DB by its ``litellm_token`` so
-    that a fully populated record (including ``id``, ``team_id``, region
-    info, etc.) is returned and remains visible via ``GET /private-ai-keys``.
+    The moad response is used to extract the newly created LiteLLM token.
+    A fully populated key record (including ``id``, ``team_id``, region info,
+    etc.) is then loaded from the local DB using ``litellm_token`` so the
+    result matches the ``PrivateAIKey`` shape expected by the Drupal module
+    and remains visible via ``GET /private-ai-keys``.
     """
     if not settings.MOAD_DASHBOARD_API_URL or not settings.MOAD_DASHBOARD_API_TOKEN:
         logger.error(

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -56,7 +56,8 @@ class Settings(BaseSettings):
     HUBSPOT_MARKETING_SUBSCRIPTION_ID: str | None = os.getenv(
         "HUBSPOT_MARKETING_SUBSCRIPTION_ID"
     )
-    MOAD_API_KEY: str = os.getenv("MOAD_API_KEY", "changeme")
+    MOAD_DASHBOARD_API_URL: str = os.getenv("MOAD_DASHBOARD_API_URL", "")
+    MOAD_DASHBOARD_API_TOKEN: str = os.getenv("MOAD_DASHBOARD_API_TOKEN", "")
     ENABLE_METRICS: bool = os.getenv("ENABLE_METRICS", "false") == "true"
     PROMETHEUS_API_KEY: str = os.getenv("PROMETHEUS_API_KEY", "")
     POOL_PURCHASE_EXPIRY_DAYS: int = int(os.getenv("POOL_PURCHASE_EXPIRY_DAYS", "365"))

--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ from app.api import (
     auth,
     billing,
     budgets,
+    internal,
     limits,
     pricing_tables,
     private_ai_keys,
@@ -189,6 +190,7 @@ async def get_version():
 
 
 # Include routers
+app.include_router(internal.router, prefix="/internal", tags=["internal"])
 app.include_router(auth.router, prefix="/auth", tags=["auth"])
 app.include_router(
     private_ai_keys.router, prefix="/private-ai-keys", tags=["private-ai-keys"]

--- a/app/main.py
+++ b/app/main.py
@@ -190,7 +190,7 @@ async def get_version():
 
 
 # Include routers
-app.include_router(internal.router, prefix="/internal", tags=["internal"])
+app.include_router(internal.router, prefix="/internal")
 app.include_router(auth.router, prefix="/auth", tags=["auth"])
 app.include_router(
     private_ai_keys.router, prefix="/private-ai-keys", tags=["private-ai-keys"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,8 @@ services:
       AMAZEEAI_JWT_SECRET: ${AMAZEEAI_JWT_SECRET}
       ENABLE_METRICS: "true"  # Enable Prometheus metrics
       AI_TRIAL_REGION: ${AI_TRIAL_REGION:-eu-west}
-      MOAD_DASHBOARD_API_URL: ""
-      MOAD_DASHBOARD_API_TOKEN: ""
+      MOAD_DASHBOARD_API_URL: ${MOAD_DASHBOARD_API_URL:-}
+      MOAD_DASHBOARD_API_TOKEN: ${MOAD_DASHBOARD_API_TOKEN:-}
     ports:
       - "8800:8800"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,8 @@ services:
       AMAZEEAI_JWT_SECRET: ${AMAZEEAI_JWT_SECRET}
       ENABLE_METRICS: "true"  # Enable Prometheus metrics
       AI_TRIAL_REGION: ${AI_TRIAL_REGION:-eu-west}
-      MOAD_API_KEY: changeme
+      MOAD_DASHBOARD_API_URL: ""
+      MOAD_DASHBOARD_API_TOKEN: ""
     ports:
       - "8800:8800"
     volumes:

--- a/tests/test_internal_provision_key.py
+++ b/tests/test_internal_provision_key.py
@@ -1,0 +1,209 @@
+"""
+Tests for POST /internal/provision-key.
+
+This endpoint is called exclusively by moad (via AMAZEEAI_ADMIN_API_TOKEN)
+to create a LiteLLM token + vector DB as part of the external key provisioning
+flow.  Auth is the standard amazee.ai admin API token mechanism.
+"""
+
+import os
+
+os.environ["AMAZEEAI_JWT_SECRET"] = "test-secret-key-for-tests"
+
+import pytest
+from unittest.mock import patch, AsyncMock, Mock
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app.db.database import get_db
+from app.db.models import Base, DBRegion, DBUser, DBTeam
+from app.core.security import get_password_hash
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://postgres:postgres@amazee-test-postgres/postgres_service",
+)
+
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture
+def db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def client(db):
+    def override_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def admin_user(db):
+    user = DBUser(
+        email="admin@amazee.ai",
+        hashed_password=get_password_hash("adminpass"),
+        is_active=True,
+        is_admin=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@pytest.fixture
+def admin_token(client, admin_user):
+    response = client.post(
+        "/auth/login",
+        data={"username": admin_user.email, "password": "adminpass"},
+    )
+    return response.json()["access_token"]
+
+
+@pytest.fixture
+def regular_user(db):
+    user = DBUser(
+        email="user@example.com",
+        hashed_password=get_password_hash("userpass"),
+        is_active=True,
+        is_admin=False,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@pytest.fixture
+def regular_token(client, regular_user):
+    response = client.post(
+        "/auth/login",
+        data={"username": regular_user.email, "password": "userpass"},
+    )
+    return response.json()["access_token"]
+
+
+@pytest.fixture
+def test_team(db):
+    team = DBTeam(
+        name="Test Team",
+        admin_email="team@example.com",
+        phone="123",
+        billing_address="123 St",
+        is_active=True,
+        budget_type="periodic",
+    )
+    db.add(team)
+    db.commit()
+    db.refresh(team)
+    return team
+
+
+@pytest.fixture
+def test_region(db):
+    region = DBRegion(
+        name="test-region",
+        label="Test Region",
+        is_active=True,
+        litellm_api_url="http://test-litellm",
+        litellm_api_key="test-api-key",
+    )
+    db.add(region)
+    db.commit()
+    db.refresh(region)
+    return region
+
+
+# ─── Auth tests ───────────────────────────────────────────────────────────────
+
+
+def test_internal_provision_key_rejects_no_auth(client, test_region, test_team):
+    """Requests without Authorization header must be rejected."""
+    response = client.post(
+        "/internal/provision-key",
+        json={"region_id": test_region.id, "name": "test-key", "team_id": test_team.id},
+    )
+    assert response.status_code == 401
+
+
+def test_internal_provision_key_rejects_non_admin(
+    client, regular_token, test_region, test_team
+):
+    """Regular users must not be able to call the internal endpoint."""
+    response = client.post(
+        "/internal/provision-key",
+        headers={"Authorization": f"Bearer {regular_token}"},
+        json={"region_id": test_region.id, "name": "test-key", "team_id": test_team.id},
+    )
+    assert response.status_code in (401, 403)
+
+
+# ─── Happy path ───────────────────────────────────────────────────────────────
+
+
+@patch("app.db.postgres.PostgresManager.create_database")
+@patch("httpx.AsyncClient")
+def test_internal_provision_key_success(
+    mock_client_class, mock_create_db, client, admin_token, test_region, test_team
+):
+    """Admin (moad's AMAZEEAI_ADMIN_API_TOKEN) can create a key via the internal endpoint."""
+    mock_create_db.return_value = {
+        "database_name": "db_test",
+        "database_host": "pghost",
+        "database_username": "dbuser",
+        "database_password": "dbpass",
+    }
+
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"key": "sk-internal-test-key"}
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+    mock_client_class.return_value = mock_client
+
+    response = client.post(
+        "/internal/provision-key",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "region_id": test_region.id,
+            "name": "Drupal CMS - 2026-06-17",
+            "team_id": test_team.id,
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Drupal CMS - 2026-06-17"
+    assert data["team_id"] == test_team.id
+    assert "litellm_token" in data
+    assert "database_host" in data
+
+
+def test_internal_provision_key_invalid_region(client, admin_token, test_team):
+    """Returns 404 when the region does not exist."""
+    response = client.post(
+        "/internal/provision-key",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"region_id": 99999, "name": "test-key", "team_id": test_team.id},
+    )
+    assert response.status_code == 404

--- a/tests/test_internal_provision_key.py
+++ b/tests/test_internal_provision_key.py
@@ -7,10 +7,6 @@ flow.  Auth is the standard amazee.ai admin API token mechanism.
 """
 
 import os
-
-os.environ["AMAZEEAI_JWT_SECRET"] = "test-secret-key-for-tests"
-
-import pytest
 from unittest.mock import patch, AsyncMock, Mock
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine

--- a/tests/test_internal_provision_key.py
+++ b/tests/test_internal_provision_key.py
@@ -64,13 +64,13 @@ def admin_user(db):
 
 
 @pytest.fixture
-def admin_token(client, admin_user):
-    response = client.post(
-        "/auth/login",
-        data={"username": admin_user.email, "password": "adminpass"},
-    )
-    return response.json()["access_token"]
+def admin_token(db, admin_user):
+    from app.db.models import DBAPIToken
 
+    api_token = DBAPIToken(name="moad", token="moad-admin-token-123", user_id=admin_user.id)
+    db.add(api_token)
+    db.commit()
+    return api_token.token
 
 @pytest.fixture
 def regular_user(db):

--- a/tests/test_internal_provision_key.py
+++ b/tests/test_internal_provision_key.py
@@ -7,6 +7,7 @@ flow.  Auth is the standard amazee.ai admin API token mechanism.
 """
 
 import os
+import pytest
 from unittest.mock import patch, AsyncMock, Mock
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
@@ -67,10 +68,13 @@ def admin_user(db):
 def admin_token(db, admin_user):
     from app.db.models import DBAPIToken
 
-    api_token = DBAPIToken(name="moad", token="moad-admin-token-123", user_id=admin_user.id)
+    api_token = DBAPIToken(
+        name="moad", token="moad-admin-token-123", user_id=admin_user.id
+    )
     db.add(api_token)
     db.commit()
     return api_token.token
+
 
 @pytest.fixture
 def regular_user(db):

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -19,18 +19,61 @@ from app.core.limit_service import (
 )
 
 
+@patch("app.api.private_ai_keys.settings")
 @patch("httpx.AsyncClient")
 def test_create_private_ai_key(
     mock_client_class,
+    mock_settings,
     client,
     test_token,
     test_region,
     test_user,
-    mock_httpx_post_client,
+    db,
 ):
-    """Test creating a private AI key in a specific region"""
-    # Use the httpx POST client fixture
-    mock_client_class.return_value = mock_httpx_post_client
+    """Test that a DEFAULT user's key creation is delegated to moad.
+
+    The moad call is mocked. A matching DBPrivateAIKey is pre-inserted to
+    simulate moad calling back via POST /internal/provision-key.
+    """
+    mock_settings.MOAD_DASHBOARD_API_URL = "http://mock-moad"
+    mock_settings.MOAD_DASHBOARD_API_TOKEN = "mock-token"
+
+    litellm_token = "test-private-key-123"
+
+    # Simulate the key that moad would create via /internal/provision-key
+    pre_created_key = DBPrivateAIKey(
+        name="Test AI Key",
+        litellm_token=litellm_token,
+        litellm_api_url="http://test-llm",
+        database_name="test-db",
+        database_host="test-host",
+        database_username="test-user",
+        database_password="test-pass",
+        region_id=test_region.id,
+        team_id=None,
+        owner_id=None,
+    )
+    db.add(pre_created_key)
+    db.commit()
+    db.refresh(pre_created_key)
+
+    # Mock the httpx call to moad returning credentials
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "llm": {"apiUrl": "http://test-llm", "token": litellm_token},
+        "vectorDb": {
+            "host": "test-host",
+            "database": "test-db",
+            "username": "test-user",
+            "password": "test-pass",
+        },
+    }
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+    mock_client_class.return_value = mock_client
 
     response = client.post(
         "/private-ai-keys/",
@@ -40,15 +83,35 @@ def test_create_private_ai_key(
 
     assert response.status_code == 200
     data = response.json()
-    assert data["region"] == test_region.name
-    assert data["region_label"] == test_region.label
-    assert data["litellm_token"] == "test-private-key-123"
-    assert data["owner_id"] == test_user.id
-    assert data["id"] != -1
+    assert data["litellm_token"] == litellm_token
+    assert data["id"] == pre_created_key.id
+
+    # Verify moad was called with the correct payload
+    call_kwargs = mock_client.post.call_args
+    assert "/api/external/provision-key" in call_kwargs[0][0]
+    assert call_kwargs[1]["json"]["email"] == test_user.email
+    assert call_kwargs[1]["json"]["appName"] == "Test AI Key"
+    assert call_kwargs[1]["json"]["regionId"] == test_region.id
 
 
-def test_create_private_ai_key_invalid_region(client, test_token):
-    """Test creating a private AI key with an invalid region ID"""
+@patch("app.api.private_ai_keys.settings")
+@patch("httpx.AsyncClient")
+def test_create_private_ai_key_invalid_region(
+    mock_client_class, mock_settings, client, test_token
+):
+    """Test that a DEFAULT user gets 404 when moad reports region not found."""
+    mock_settings.MOAD_DASHBOARD_API_URL = "http://mock-moad"
+    mock_settings.MOAD_DASHBOARD_API_TOKEN = "mock-token"
+
+    mock_response = Mock()
+    mock_response.status_code = 404
+    mock_response.text = '{"error": "Region not found"}'
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+    mock_client_class.return_value = mock_client
+
     response = client.post(
         "/private-ai-keys/",
         headers={"Authorization": f"Bearer {test_token}"},
@@ -56,7 +119,6 @@ def test_create_private_ai_key_invalid_region(client, test_token):
     )
 
     assert response.status_code == 404
-    assert "Region not found or inactive" in response.json()["detail"]
 
 
 def test_list_private_ai_keys(client, test_token, test_region, db, test_user):
@@ -2563,7 +2625,7 @@ def test_create_private_ai_key_cleanup_on_vector_db_failure(
     mock_create_db,
     mock_client_class,
     client,
-    test_token,
+    admin_token,
     test_region,
     mock_httpx_post_client,
 ):
@@ -2580,7 +2642,7 @@ def test_create_private_ai_key_cleanup_on_vector_db_failure(
 
     response = client.post(
         "/private-ai-keys/",
-        headers={"Authorization": f"Bearer {test_token}"},
+        headers={"Authorization": f"Bearer {admin_token}"},
         json={"region_id": test_region.id, "name": "Test AI Key"},
     )
 
@@ -2603,7 +2665,7 @@ def test_create_private_ai_key_cleanup_on_vector_db_failure(
 
     # Verify no key was stored in the database
     stored_keys = client.get(
-        "/private-ai-keys/", headers={"Authorization": f"Bearer {test_token}"}
+        "/private-ai-keys/", headers={"Authorization": f"Bearer {admin_token}"}
     ).json()
     assert len([k for k in stored_keys if k["name"] == "Test AI Key"]) == 0
 
@@ -2618,7 +2680,7 @@ def test_create_private_ai_key_cleanup_on_db_storage_failure(
     mock_create_db,
     mock_client_class,
     client,
-    test_token,
+    admin_token,
     test_region,
     mock_httpx_post_client,
 ):
@@ -2646,7 +2708,7 @@ def test_create_private_ai_key_cleanup_on_db_storage_failure(
 
     response = client.post(
         "/private-ai-keys/",
-        headers={"Authorization": f"Bearer {test_token}"},
+        headers={"Authorization": f"Bearer {admin_token}"},
         json={"region_id": test_region.id, "name": "Test AI Key"},
     )
 
@@ -2665,7 +2727,7 @@ def test_create_private_ai_key_cleanup_on_db_storage_failure(
 
     # Verify no key was stored in the database
     stored_keys = client.get(
-        "/private-ai-keys/", headers={"Authorization": f"Bearer {test_token}"}
+        "/private-ai-keys/", headers={"Authorization": f"Bearer {admin_token}"}
     ).json()
     assert len([k for k in stored_keys if k["name"] == "Test AI Key"]) == 0
 
@@ -2676,7 +2738,7 @@ def test_create_private_ai_key_cleanup_failure_handling(
     mock_create_db,
     mock_client_class,
     client,
-    test_token,
+    admin_token,
     test_region,
     mock_httpx_post_client,
 ):
@@ -2707,7 +2769,7 @@ def test_create_private_ai_key_cleanup_failure_handling(
 
     response = client.post(
         "/private-ai-keys/",
-        headers={"Authorization": f"Bearer {test_token}"},
+        headers={"Authorization": f"Bearer {admin_token}"},
         json={"region_id": test_region.id, "name": "Test AI Key"},
     )
 
@@ -2726,7 +2788,7 @@ def test_create_private_ai_key_http_exception_preservation(
     mock_create_db,
     mock_client_class,
     client,
-    test_token,
+    admin_token,
     test_region,
     mock_httpx_post_client,
 ):
@@ -2745,7 +2807,7 @@ def test_create_private_ai_key_http_exception_preservation(
 
     response = client.post(
         "/private-ai-keys/",
-        headers={"Authorization": f"Bearer {test_token}"},
+        headers={"Authorization": f"Bearer {admin_token}"},
         json={"region_id": test_region.id, "name": "Test AI Key"},
     )
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a new `POST /internal/provision-key` endpoint (admin-only, machine-to-machine) and wires up a moad delegation path so that DEFAULT (Drupal email/code sign-in) users calling `POST /private-ai-keys` are transparently proxied through moad's external provisioning flow rather than creating keys directly.

- **New `/internal/provision-key` route** (`app/api/internal.py`): restricted to system admins via `get_role_min_system_admin`, delegates directly to `create_private_ai_key` with `SYSTEM_ADMIN` role; uses a function-level import to avoid a circular dependency with `private_ai_keys.py`.
- **moad delegation in `create_private_ai_key`** (`app/api/private_ai_keys.py`): DEFAULT non-admin users are forwarded to moad's `/api/external/provision-key`; after moad synchronously calls back `/internal/provision-key` and returns the `litellm_token`, the newly committed key is looked up by token and returned to the caller.
- **Config/env update**: `MOAD_API_KEY` replaced by `MOAD_DASHBOARD_API_URL` + `MOAD_DASHBOARD_API_TOKEN`; missing config surfaces as a clear 503.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with minor follow-ups; the auth boundary is correct and the delegation loop is prevented by the is_admin guard.

The core auth boundary is solid — the internal endpoint requires is_admin=True and FastAPI's dependency cache ensures get_current_user_from_auth is only called once per request. The delegation check correctly uses is_admin to prevent looping. The main concerns are style/robustness: the circular import workaround, missing type annotations on _delegate_to_moad, and the fact that DEFAULT users skip the local region is_active check before delegating to moad.

app/api/private_ai_keys.py — the new _delegate_to_moad function and the delegation guard in create_private_ai_key warrant a close read; app/api/internal.py — the deferred import pattern is worth a second look.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/internal.py | New internal router exposing POST /internal/provision-key, restricted to system admins via get_role_min_system_admin; delegates to create_private_ai_key with SYSTEM_ADMIN role; uses a function-level import to avoid a circular dependency with private_ai_keys.py |
| app/api/private_ai_keys.py | Added moad delegation path for DEFAULT non-admin users at the top of create_private_ai_key; added _delegate_to_moad helper that calls moad, extracts the litellm_token from the response, and looks up the newly committed key by token; region is not locally pre-validated for DEFAULT users |
| app/core/config.py | Replaced MOAD_API_KEY with MOAD_DASHBOARD_API_URL and MOAD_DASHBOARD_API_TOKEN; both default to empty string so missing config produces a clear 503 rather than a silent no-op |
| app/main.py | Registers the new internal router under the /internal prefix; change is minimal and correct |
| docker-compose.yml | Swaps the old MOAD_API_KEY env var for MOAD_DASHBOARD_API_URL and MOAD_DASHBOARD_API_TOKEN, both defaulting to empty; aligns with config.py changes |
| tests/test_internal_provision_key.py | New test file covering auth rejection (no token, non-admin), happy path (admin token creates key), and invalid region; happy path mock returns {"key": "sk-..."} which matches what create_llm_token expects from LiteLLM |
| tests/test_private_ai.py | Existing tests updated to reflect the new delegation flow: DEFAULT user tests now mock the moad HTTP call and pre-insert the key that moad would create; cleanup/error-path tests switched to admin_token to bypass delegation |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Drupal
    participant AmazeeAI as amazee.ai /private-ai-keys
    participant Moad as moad /api/external/provision-key
    participant Internal as amazee.ai /internal/provision-key
    participant DB as PostgreSQL

    Drupal->>AmazeeAI: POST /private-ai-keys (JWT, DEFAULT user)
    AmazeeAI->>AmazeeAI: "role==DEFAULT and not is_admin - delegate to moad"
    AmazeeAI->>Moad: "POST provision-key {email, appName, regionId} + dashboard API token"
    Moad->>Internal: "POST /internal/provision-key {region_id, name, team_id} + admin API token"
    Internal->>DB: create LiteLLM token + vector DB, commit
    DB-->>Internal: ok
    Internal-->>Moad: "PrivateAIKey {litellm_token, ...}"
    Moad-->>AmazeeAI: "{llm: {token: ...}, vectorDb: {...}}"
    AmazeeAI->>DB: "SELECT WHERE litellm_token = returned token"
    DB-->>AmazeeAI: DBPrivateAIKey row
    AmazeeAI-->>Drupal: PrivateAIKey response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Drupal
    participant AmazeeAI as amazee.ai /private-ai-keys
    participant Moad as moad /api/external/provision-key
    participant Internal as amazee.ai /internal/provision-key
    participant DB as PostgreSQL

    Drupal->>AmazeeAI: POST /private-ai-keys (JWT, DEFAULT user)
    AmazeeAI->>AmazeeAI: "role==DEFAULT and not is_admin - delegate to moad"
    AmazeeAI->>Moad: "POST provision-key {email, appName, regionId} + dashboard API token"
    Moad->>Internal: "POST /internal/provision-key {region_id, name, team_id} + admin API token"
    Internal->>DB: create LiteLLM token + vector DB, commit
    DB-->>Internal: ok
    Internal-->>Moad: "PrivateAIKey {litellm_token, ...}"
    Moad-->>AmazeeAI: "{llm: {token: ...}, vectorDb: {...}}"
    AmazeeAI->>DB: "SELECT WHERE litellm_token = returned token"
    DB-->>AmazeeAI: DBPrivateAIKey row
    AmazeeAI-->>Drupal: PrivateAIKey response
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["test: Add pytest import to test\_internal..."](https://github.com/amazeeio/amazee.ai/commit/242b5d65dd27fe68e7662be5e42d7eb050adee60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38187213)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->