### PR TITLE
chore: restore db with option for db name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       dockerfile: Dockerfile
       target: backend
     environment:
-      DATABASE_URL: postgresql://postgres:postgres@postgres/postgres_service
+      DATABASE_URL: ${DATABASE_URL:-postgresql://postgres:postgres@postgres/postgres_service}
       AMAZEEAI_JWT_SECRET: ${AMAZEEAI_JWT_SECRET}
       ENABLE_METRICS: "true"  # Enable Prometheus metrics
       AI_TRIAL_REGION: ${AI_TRIAL_REGION:-eu-west}
@@ -45,7 +45,7 @@ services:
       dockerfile: Dockerfile
       target: cli
     environment:
-      DATABASE_URL: postgresql://postgres:postgres@postgres/postgres_service
+      DATABASE_URL: ${DATABASE_URL:-postgresql://postgres:postgres@postgres/postgres_service}
     volumes:
       - ./app:/app/app
       - ./scripts:/app/scripts

--- a/scripts/restore_database.py
+++ b/scripts/restore_database.py
@@ -33,12 +33,20 @@ Usage:
 import argparse
 import os
 import pathlib
+import re
 import shutil
 import subprocess
 import sys
 import tarfile
 import tempfile
 from urllib.parse import quote, unquote, urlparse, urlunparse
+
+
+def validate_db_name(name):
+    """Validate that a database name contains only safe identifier characters (alphanumeric, underscores, and hyphens)."""
+    if not name:
+        return False
+    return bool(re.match(r"^[a-zA-Z0-9_-]+$", name))
 
 
 REQUIRED_TOOLS = ("pg_dump", "pg_restore", "psql")
@@ -302,60 +310,128 @@ def extract_backup(backup_path, extract_dir):
     sys.exit(1)
 
 
-def apply_restore(config, dump_dir):
+def detect_database_name(dump_dir, config):
+    """Run pg_restore -l to find the database name in the TOC header."""
+    cmd = ["pg_restore", "-l", dump_dir]
+    try:
+        result = run_pg_tool(cmd, config, capture=True)
+        for line in result.stdout.splitlines():
+            stripped = line.strip()
+            if re.match(r"^;\s+dbname:", stripped):
+                return stripped.split(":", 1)[1].strip()
+    except Exception as e:
+        print(sanitize(f"  Warning: Could not detect source database name from backup: {e}", config))
+    return None
+
+
+def recreate_target_db(config):
+    """Drop and recreate the target database to ensure a clean restore without constraint errors."""
+    db_name = config["database"]
+    if not validate_db_name(db_name):
+        raise SystemExit("Error: Database name is invalid. Only alphanumeric characters and underscores are allowed.")
+
+    print("  Recreating target database...")
+
+    # 1. Terminate other connections to target database (best effort)
+    terminate_cmd = [
+        "psql",
+        "--dbname",
+        config["maintenance_url"],
+        "-v",
+        f"target_db={db_name}",
+        "-tAc",
+        "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = :'target_db' AND pid <> pg_backend_pid()",
+    ]
+    try:
+        run_pg_tool(terminate_cmd, config, check=False)
+    except subprocess.CalledProcessError:
+        warning_msg = (
+            "  Warning: Could not terminate all active connections for database (continuing)."
+        )
+        print(warning_msg)
+
+    # 2. Drop database if exists
+    drop_cmd = [
+        "psql",
+        "--dbname",
+        config["maintenance_url"],
+        "-c",
+        f'DROP DATABASE IF EXISTS "{db_name}"',
+    ]
+    try:
+        run_pg_tool(drop_cmd, config)
+    except subprocess.CalledProcessError as e:
+        raise SystemExit(sanitize(f"  Failed to drop target database: {e.stderr or e}", config))
+
+    # 3. Create database
+    create_cmd = [
+        "psql",
+        "--dbname",
+        config["maintenance_url"],
+        "-c",
+        f'CREATE DATABASE "{db_name}"',
+    ]
+    try:
+        run_pg_tool(create_cmd, config)
+    except subprocess.CalledProcessError as e:
+        raise SystemExit(sanitize(f"  Failed to create target database '{db_name}': {e.stderr or e}", config))
+
+
+def apply_restore(config, dump_dir, restore_mode="target"):
     """Apply the database restore from a pg_dump directory-format archive.
 
-    Connects to the `postgres` maintenance DB and lets pg_restore itself
-    drop and recreate the target with the source's recorded metadata
-    (encoding, collation, locale provider) replayed from `toc.dat`.
+    If restore_mode is 'as-is':
+      Connects to the `postgres` maintenance DB and lets pg_restore itself
+      drop and recreate the target with the source's recorded metadata
+      (encoding, collation, locale provider) replayed from `toc.dat`.
 
-    Flag rationale:
-      --create / --clean / --if-exists
-          Replay the source's `CREATE DATABASE` (preserving encoding and
-          collation, fixing the cluster-defaults correctness gap that a
-          plain `createdb` would introduce). `--clean --if-exists` makes
-          the preceding `DROP DATABASE` idempotent so re-running the
-          script is safe even when the target does not exist.
-      --no-owner / --no-privileges
-          Skip OWNER and GRANT clauses (both for the database itself and
-          for objects inside it), so the restore does not require the
-          source's roles to exist on the target cluster. The restoring
-          role takes ownership.
-      --no-tablespaces
-          Strip TABLESPACE clauses, so the restore does not require the
-          source's tablespaces to exist on the target cluster (the DB
-          and its objects land in the default tablespace).
-      --exit-on-error
-          Fail fast on the first error rather than logging warnings and
-          continuing with a half-restored database.
+    If restore_mode is 'target':
+      Recreates the configured local target database (to ensure it is clean
+      and avoids foreign key constraint errors) and runs pg_restore directly
+      into the target database without --create.
     """
     db_name = config["database"]
 
-    # Refuse to wipe the maintenance DB. (`pg_restore --clean --create`
-    # would happily DROP DATABASE postgres if asked.)
+    # Refuse to wipe the maintenance DB.
     if db_name == "postgres":
         raise SystemExit(
             "Error: Cannot restore over the 'postgres' maintenance database. "
             "Set DATABASE_URL to point to a different target database."
         )
 
-    cmd = [
-        "pg_restore",
-        "--format=directory",
-        "--create",
-        "--clean",
-        "--if-exists",
-        "--no-owner",
-        "--no-privileges",
-        "--no-tablespaces",
-        "--exit-on-error",
-        # Connect to the maintenance DB so pg_restore can drop/create the
-        # target. `maintenance_url` carries every libpq param from the
-        # configured DATABASE_URL (sslmode, connect_timeout, etc.).
-        "--dbname",
-        config["maintenance_url"],
-        dump_dir,
-    ]
+    if restore_mode == "as-is":
+        cmd = [
+            "pg_restore",
+            "--format=directory",
+            "--create",
+            "--clean",
+            "--if-exists",
+            "--no-owner",
+            "--no-privileges",
+            "--no-tablespaces",
+            "--exit-on-error",
+            "--dbname",
+            config["maintenance_url"],
+            dump_dir,
+        ]
+    else:
+        # Recreate the target database to ensure constraint-free restore
+        recreate_target_db(config)
+
+        cmd = [
+            "pg_restore",
+            "--format=directory",
+            "--clean",
+            "--if-exists",
+            "--no-owner",
+            "--no-privileges",
+            "--no-tablespaces",
+            "--exit-on-error",
+            "--dbname",
+            config["url"],
+            dump_dir,
+        ]
+
     try:
         run_pg_tool(cmd, config, capture=False)
     except subprocess.CalledProcessError as e:
@@ -413,6 +489,12 @@ def main():
         help="Directory to extract the backup into (default: system temp directory)",
     )
     parser.add_argument(
+        "--restore-mode",
+        choices=["target", "as-is"],
+        default="target",
+        help="Whether to restore directly into the configured local target database ('target') or recreate the original database name from the dump ('as-is')",
+    )
+    parser.add_argument(
         "--yes",
         "-y",
         action="store_true",
@@ -458,42 +540,108 @@ def main():
                 sys.exit(0)
 
     config = get_db_config()
+    target_db = config["database"]
+    if not validate_db_name(target_db):
+        print("Error: Target database name is invalid. Only alphanumeric characters and underscores are allowed.")
+        sys.exit(1)
+
+    display_host = _presence(config.get("host"))
+    display_target_db = _presence(target_db)
+    display_user = _presence(config.get("user"))
 
     print("\nDatabase restore configuration:")
     print(f"  Backup file : {args.backup_file}")
-    print(f"  Target host : {_presence(config.get('host'))}")
-    print(f"  Target DB   : {_presence(config.get('database'))}")
-    print(f"  User        : {_presence(config.get('user'))}")
+    print(f"  Target host : {display_host}")
+    print(f"  Target DB   : {display_target_db}")
+    print(f"  User        : {display_user}")
     print()
-
-    if not args.yes:
-        print("WARNING: This will DROP the existing database and restore from backup.")
-        if not args.no_backup:
-            print("A safety backup of the current database will be created first.")
-        else:
-            print("No safety backup will be created (--no-backup specified).")
-        response = (
-            input("\nAre you sure you want to proceed? [yes/no]: ").strip().lower()
-        )
-        if response not in ("yes", "y"):
-            print("Aborted.")
-            sys.exit(0)
 
     tmpdir = tempfile.mkdtemp(prefix="db_restore_", dir=args.extract_dir)
     os.chmod(tmpdir, 0o700)
 
     try:
-        # Step 1: Backup current database (unless skipped)
+        # Step 1: Extract the backup archive
+        print("\n[1/3] Extracting backup archive...")
+        extract_dir = os.path.join(tmpdir, "extracted")
+        os.makedirs(extract_dir, exist_ok=True)
+        dump_dir = extract_backup(args.backup_file, extract_dir)
+        dump_contents = os.listdir(dump_dir)
+        dat_count = sum(
+            1 for f in dump_contents if f.endswith(".dat") and f != "toc.dat"
+        )
+        print(f"  Dump directory: {dump_dir}")
+        print(f"  Found: toc.dat + {dat_count} data files")
+
+        # Detect source database name
+        source_db = detect_database_name(dump_dir, config)
+        if source_db:
+            print("  Detected source database name in backup.")
+        else:
+            print("  Could not detect source database name in backup.")
+
+        # Determine restore mode (target vs as-is)
+        restore_mode = args.restore_mode
+        if not args.yes:
+            if source_db and source_db != target_db:
+                print("\nWARNING: The backup source database name differs from your locally-configured target database.")
+                print("How would you like to restore this database?")
+                print("  1) Restore directly into the configured target database (Recommended for local dev - no .env changes needed)")
+                print("  2) Recreate and restore using the backup's original database name (Requires updating DATABASE_URL in .env)")
+                while True:
+                    choice = input("\nSelect option [1 or 2]: ").strip()
+                    if choice == "1":
+                        restore_mode = "target"
+                        break
+                    elif choice == "2":
+                        restore_mode = "as-is"
+                        break
+                    else:
+                        print("Invalid choice. Please enter 1 or 2.")
+            else:
+                print("\nWARNING: This will DROP the existing database and restore from backup.")
+                if not args.no_backup:
+                    print("A safety backup of the current database will be created first.")
+                else:
+                    print("No safety backup will be created (--no-backup specified).")
+                response = (
+                    input("\nAre you sure you want to proceed? [yes/no]: ").strip().lower()
+                )
+                if response not in ("yes", "y"):
+                    print("Aborted.")
+                    sys.exit(0)
+        else:
+            # Non-interactive mode
+            if restore_mode == "as-is":
+                print("  Non-interactive: Restoring as-is into configured target database")
+            else:
+                print("  Non-interactive: Restoring into target database")
+
+        # Validate source_db ONLY if we are actually using it in as-is mode
+        if restore_mode == "as-is" and source_db:
+            if not validate_db_name(source_db):
+                print("Error: Detected source database name is invalid for 'as-is' restore.")
+                print("Only alphanumeric characters and underscores are allowed for database names.")
+                sys.exit(1)
+
+        # Step 2: Backup current database (unless skipped)
         if not args.no_backup:
-            print("\n[1/3] Backing up current database...")
+            active_db = source_db if (restore_mode == "as-is" and source_db) else target_db
+            backup_msg = "\n[2/3] Backing up current database before restore..."
+            print(backup_msg)
             backup_dir = args.backup_dir or os.path.dirname(
                 os.path.abspath(args.backup_file)
             )
             os.makedirs(backup_dir, exist_ok=True)
+
+            # Create a temporary config for the active database to backup
+            backup_config = config.copy()
+            backup_config["database"] = active_db
+            parsed_url = urlparse(config["url"])
+            backup_config["url"] = urlunparse(parsed_url._replace(path=f"/{active_db}"))
+
             safety_backup_path = os.path.join(
-                backup_dir, f"{config['database']}_pre_restore.dump"
+                backup_dir, f"{active_db}_pre_restore.dump"
             )
-            # Avoid overwriting an existing backup
             if os.path.exists(safety_backup_path):
                 base, ext = os.path.splitext(safety_backup_path)
                 i = 1
@@ -502,8 +650,32 @@ def main():
                 safety_backup_path = f"{base}_{i}{ext}"
 
             try:
-                backup_current_database(config, safety_backup_path)
-                print("  Safety backup created successfully.")
+                # Check if the database exists before trying to backup
+                check_cmd = [
+                    "psql",
+                    "--dbname",
+                    config["maintenance_url"],
+                    "-v",
+                    f"active_db={active_db}",
+                    "-tAc",
+                    "SELECT 1 FROM pg_database WHERE datname=:'active_db'",
+                ]
+                db_exists = False
+                try:
+                    res = run_pg_tool(check_cmd, config)
+                    db_exists = (res.stdout.strip() == "1")
+                except Exception:
+                    print(
+                        "  Warning: Could not verify whether the target database exists. Assuming it does not exist and skipping safety backup.",
+                        file=sys.stderr,
+                    )
+                    db_exists = False
+
+                if db_exists:
+                    backup_current_database(backup_config, safety_backup_path)
+                    print("  Safety backup created successfully.")
+                else:
+                    print("  Skipping backup: Target database does not exist yet.")
             except SystemExit as exc:
                 print(f"  {exc}", file=sys.stderr)
                 if args.yes:
@@ -519,30 +691,17 @@ def main():
                     print("Aborted.")
                     sys.exit(0)
         else:
-            print("\n[1/3] Skipping backup (--no-backup)")
+            print("\n[2/3] Skipping backup (--no-backup)")
 
-        # Step 2: Extract the backup archive
-        print("\n[2/3] Extracting backup archive...")
-        extract_dir = os.path.join(tmpdir, "extracted")
-        os.makedirs(extract_dir, exist_ok=True)
-        dump_dir = extract_backup(args.backup_file, extract_dir)
-        dump_contents = os.listdir(dump_dir)
-        dat_count = sum(
-            1 for f in dump_contents if f.endswith(".dat") and f != "toc.dat"
-        )
-        print(f"  Dump directory: {dump_dir}")
-        print(f"  Found: toc.dat + {dat_count} data files")
-
-        # Step 3: Apply the restore. pg_restore --create --clean handles
-        # the drop/recreate so the target DB is rebuilt with the source's
-        # encoding/collation rather than cluster defaults.
+        # Step 3: Apply the restore
         print("\n[3/3] Applying database restore...")
-        apply_restore(config, dump_dir)
-
+        apply_restore(config, dump_dir, restore_mode=restore_mode)
         print("\nRestore complete!")
 
+        if restore_mode == "as-is" and source_db and source_db != target_db:
+            print("\nIMPORTANT: To connect your application to this database, update DATABASE_URL in your .env file.")
+
     finally:
-        # Clean up temp extraction directory
         shutil.rmtree(tmpdir, ignore_errors=True)
 
 

--- a/tests/test_restore_database.py
+++ b/tests/test_restore_database.py
@@ -1,0 +1,43 @@
+import os
+from unittest.mock import patch, MagicMock
+from scripts.restore_database import validate_db_name, get_db_config, detect_database_name
+
+def test_validate_db_name():
+    assert validate_db_name("my_db") is True
+    assert validate_db_name("mydb123") is True
+    assert validate_db_name("my_db_2") is True
+    assert validate_db_name("my-db") is True
+    assert validate_db_name("db; drop database") is False
+    assert validate_db_name("") is False
+    assert validate_db_name("../etc/passwd") is False
+
+@patch.dict(os.environ, {"DATABASE_URL": "postgres://user:pass@host:5432/my_db"})
+def test_get_db_config_strips_password():
+    config = get_db_config()
+    assert config["database"] == "my_db"
+    assert "pass" not in config["url"]
+    assert "pass" not in config["maintenance_url"]
+    assert config["password"] == "pass"
+    assert config["user"] == "user"
+    assert config["host"] == "host"
+    assert config["port"] == 5432
+
+@patch("scripts.restore_database.run_pg_tool")
+def test_detect_database_name(mock_run_pg_tool):
+    config = {"url": "postgres://host/db"}
+    
+    # Test different whitespace styles in TOC headers
+    headers = [
+        ";     dbname: my_detected_db",
+        "; dbname: my_detected_db",
+        ";\tdbname: my_detected_db",
+        ";      dbname: my_detected_db",
+    ]
+    
+    for header in headers:
+        mock_res = MagicMock()
+        mock_res.stdout = f"{header}\n; other fields"
+        mock_run_pg_tool.return_value = mock_res
+        
+        detected = detect_database_name("/mock/dump", config)
+        assert detected == "my_detected_db", f"Failed for header: {header}"


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `--restore-mode` flag to `restore_database.py` (defaulting to `target`) that lets operators choose between restoring directly into the configured target database or recreating the backup's original database name; it also makes `DATABASE_URL` overridable in `docker-compose.yml` via an env-var fallback.

- **`detect_database_name`** parses the pg_restore TOC to identify the backup's source database; when the names differ and the script runs interactively, the user is prompted to pick a mode before any destructive action.
- **`recreate_target_db`** replaces the previous `--create`/`--clean` approach for the `target` mode, explicitly terminating connections, dropping, and recreating the database to avoid foreign-key constraint failures.
- **Security and correctness**: fixes the prior `NameError` on `target_db`, parameterises the `pg_stat_activity` query with `-v` to avoid SQL injection from backup-sourced names, and validates all database names with `validate_db_name` before use.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the restore logic and security fixes are correct, with only minor wording inconsistencies in log messages and error text.

The target_db NameError, hardcoded credential hint, and SQL injection issues flagged in prior review rounds are all addressed. The new detect_database_name, recreate_target_db, and validate_db_name functions work correctly and are covered by tests. The remaining findings are a misleading log message in non-interactive as-is mode and error text that omits hyphens despite the validator permitting them — neither affects runtime behaviour.

scripts/restore_database.py — the non-interactive as-is print message and the error-message wording around hyphens are worth a quick look before merging.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/restore_database.py | Major refactor adding --restore-mode flag, detect_database_name, recreate_target_db, and interactive DB-name mismatch prompt; fixes the previous NameError on target_db and SQL injection via -v binding; non-interactive as-is log message is misleading and error messages omit hyphens |
| tests/test_restore_database.py | New test file covering validate_db_name, get_db_config password-stripping, and detect_database_name TOC header parsing; good coverage of the newly introduced functions |
| docker-compose.yml | Wraps the hardcoded DATABASE_URL in both backend and cli services with an env-var override pattern, allowing external configuration without editing the file |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start: main] --> B[get_db_config and validate target_db]
    B --> C[Extract backup archive]
    C --> D[detect_database_name from TOC]
    D --> E{Interactive mode?}
    E -->|yes, names differ| F[Prompt: option 1 or 2]
    F -->|1| G[restore_mode = target]
    F -->|2| H[restore_mode = as-is]
    E -->|yes, names match| I[Show DROP WARNING and confirm]
    I --> G
    E -->|no, flag --yes| J{restore-mode arg}
    J -->|target| G
    J -->|as-is| H
    G --> K{no-backup flag?}
    H --> K
    K -->|no| L[Check if active_db exists]
    L -->|exists| M[backup_current_database]
    L -->|not found| N[Skip backup]
    K -->|yes| O[Skip backup]
    M --> P[apply_restore]
    N --> P
    O --> P
    P -->|target mode| Q[recreate_target_db then pg_restore into config.url]
    P -->|as-is mode| R[pg_restore with --create into maintenance_url]
    Q --> S[Done]
    R --> T{names differ?}
    T -->|yes| U[Print: update DATABASE_URL in .env]
    T -->|no| S
    U --> S
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Start: main] --> B[get_db_config and validate target_db]
    B --> C[Extract backup archive]
    C --> D[detect_database_name from TOC]
    D --> E{Interactive mode?}
    E -->|yes, names differ| F[Prompt: option 1 or 2]
    F -->|1| G[restore_mode = target]
    F -->|2| H[restore_mode = as-is]
    E -->|yes, names match| I[Show DROP WARNING and confirm]
    I --> G
    E -->|no, flag --yes| J{restore-mode arg}
    J -->|target| G
    J -->|as-is| H
    G --> K{no-backup flag?}
    H --> K
    K -->|no| L[Check if active_db exists]
    L -->|exists| M[backup_current_database]
    L -->|not found| N[Skip backup]
    K -->|yes| O[Skip backup]
    M --> P[apply_restore]
    N --> P
    O --> P
    P -->|target mode| Q[recreate_target_db then pg_restore into config.url]
    P -->|as-is mode| R[pg_restore with --create into maintenance_url]
    Q --> S[Done]
    R --> T{names differ?}
    T -->|yes| U[Print: update DATABASE_URL in .env]
    T -->|no| S
    U --> S
```

</a>
</details>

<sub>Reviews (5): Last reviewed commit: ["chore: restore db with option for db nam..."](https://github.com/amazeeio/amazee.ai/commit/6f34ee7e77037ac051f6b60c6c584518e2ec2847) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38388433)</sub>

<!-- /greptile_comment -->