### PR TITLE
AI-528 unblock keys on purchase

### DIFF
--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -220,10 +220,10 @@ async def _sync_pool_key_effective_budgets(
     Keep key-level effective limits coherent for POOL teams.
 
     All callers are reached only after at least one purchase exists, so keys
-    are always unblocked here. Budget enforcement uses max_budget on the key:
-    - purchased_total > 0 → clear cap (or apply configured key cap)
-    - purchased_total == 0 (expired) → max_budget stays at team level; key
-      cap is cleared so LiteLLM falls back to the team budget of $0.
+    are always unblocked here. This sync only reconciles key-level overrides:
+    - No configured key cap → clear key max_budget and budget_duration
+      so the key inherits the team budget.
+    - Configured key cap → set key max_budget to the configured value (unblocked).
     """
     keys = get_team_region_litellm_keys(
         db,

--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -43,7 +43,6 @@ from app.core.periodic_budget_ledger_service import (
 from app.core.pool_budget_service import (
     pool_available_budget_for_team_region as shared_pool_available_budget_for_team_region,
     pool_team_budget_duration_for_enforcement as shared_pool_team_budget_duration_for_enforcement,
-    pool_team_has_ever_purchased,
 )
 
 logger = logging.getLogger(__name__)
@@ -220,11 +219,11 @@ async def _sync_pool_key_effective_budgets(
     """
     Keep key-level effective limits coherent for POOL teams.
 
-    Keys are never blocked here — blocking is driven solely by the purchase
-    gate at key-creation time (private_ai_keys.py) and unblocked as soon as
-    the team records any purchase (cycle or top-up).  `purchased_total` is
-    used to set max_budget on the key (0 → $0 cap, >0 → clear or apply
-    configured cap).
+    All callers are reached only after at least one purchase exists, so keys
+    are always unblocked here. Budget enforcement uses max_budget on the key:
+    - purchased_total > 0 → clear cap (or apply configured key cap)
+    - purchased_total == 0 (expired) → max_budget stays at team level; key
+      cap is cleared so LiteLLM falls back to the team budget of $0.
     """
     keys = get_team_region_litellm_keys(
         db,
@@ -233,8 +232,6 @@ async def _sync_pool_key_effective_budgets(
     )
     if not keys:
         return []
-
-    has_purchased = pool_team_has_ever_purchased(db, team_id, region.id)
 
     key_caps = (
         db.query(DBSpendCap.key_id, DBSpendCap.max_budget)
@@ -257,36 +254,24 @@ async def _sync_pool_key_effective_budgets(
         try:
             async with semaphore:
                 configured_cap = cap_map.get(key.id)
-                if has_purchased:
-                    # Team has at least one purchase (cycle or top-up) —
-                    # unblock and apply budget caps.
-                    if configured_cap is None:
-                        # No user-defined key cap — clear both max_budget
-                        # and budget_duration so no stale duration remains.
-                        await service.update_key_budget(
-                            litellm_token=key.litellm_token,
-                            budget_duration=None,
-                            max_budget=None,
-                            clear_max_budget=True,
-                            clear_budget_duration=True,
-                            blocked=False,
-                        )
-                    else:
-                        await service.update_key_budget(
-                            litellm_token=key.litellm_token,
-                            budget_duration=MONTHLY_BUDGET_DURATION,
-                            max_budget=configured_cap,
-                            clear_max_budget=False,
-                            blocked=False,
-                        )
+                if configured_cap is None:
+                    # No user-defined key cap — clear both max_budget
+                    # and budget_duration so no stale duration remains.
+                    await service.update_key_budget(
+                        litellm_token=key.litellm_token,
+                        budget_duration=None,
+                        max_budget=None,
+                        clear_max_budget=True,
+                        clear_budget_duration=True,
+                        blocked=False,
+                    )
                 else:
-                    # No purchase yet — enforce $0 budget via max_budget;
-                    # do NOT set blocked=True (keys stay unblocked).
                     await service.update_key_budget(
                         litellm_token=key.litellm_token,
                         budget_duration=MONTHLY_BUDGET_DURATION,
-                        max_budget=0.0,
+                        max_budget=configured_cap,
                         clear_max_budget=False,
+                        blocked=False,
                     )
             return None
         except Exception as exc:

--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -219,11 +219,19 @@ async def _sync_pool_key_effective_budgets(
     """
     Keep key-level effective limits coherent for POOL teams.
 
-    All callers are reached only after at least one purchase exists, so keys
-    are always unblocked here. This sync only reconciles key-level overrides:
+    Two caller contexts:
+    - Purchase creation (`purchase_periodic_topup`): passes purchased_total > 0;
+      keys are unblocked and caps are cleared or applied.
+    - Budget expiry (`sync_pool_team_budgets`): passes purchased_total=0.0 after
+      the team's balance has lapsed; the team-level max_budget is already set
+      to $0 by the caller so LiteLLM enforces the spend limit at team level.
+
+    In both cases the team has at least one historical purchase record, so keys
+    are always unblocked (blocked=False). Budget enforcement is handled by
+    max_budget, not the blocked flag.
     - No configured key cap → clear key max_budget and budget_duration
       so the key inherits the team budget.
-    - Configured key cap → set key max_budget to the configured value (unblocked).
+    - Configured key cap → set key max_budget to the configured value.
     """
     keys = get_team_region_litellm_keys(
         db,

--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -220,11 +220,11 @@ async def _sync_pool_key_effective_budgets(
     """
     Keep key-level effective limits coherent for POOL teams.
 
-    The block/unblock decision uses pool_team_has_ever_purchased: a key is
-    blocked only when the team has never had any purchase at all.  Remaining
-    balance does NOT affect the blocked flag — budget enforcement is handled
-    by LiteLLM max_budget.  `purchased_total` is still used to set max_budget
-    on the key (0 → $0 cap, >0 → clear or apply configured cap).
+    Keys are never blocked here — blocking is driven solely by the purchase
+    gate at key-creation time (private_ai_keys.py) and unblocked as soon as
+    the team records any purchase (cycle or top-up).  `purchased_total` is
+    used to set max_budget on the key (0 → $0 cap, >0 → clear or apply
+    configured cap).
     """
     keys = get_team_region_litellm_keys(
         db,
@@ -256,17 +256,10 @@ async def _sync_pool_key_effective_budgets(
     async def _sync_key_budget(key: DBPrivateAIKey) -> str | None:
         try:
             async with semaphore:
-                if not has_purchased:
-                    # Team has never paid — hard-lock the key.
-                    await service.update_key_budget(
-                        litellm_token=key.litellm_token,
-                        budget_duration=MONTHLY_BUDGET_DURATION,
-                        max_budget=0.0,
-                        clear_max_budget=False,
-                        blocked=True,
-                    )
-                else:
-                    configured_cap = cap_map.get(key.id)
+                configured_cap = cap_map.get(key.id)
+                if has_purchased:
+                    # Team has at least one purchase (cycle or top-up) —
+                    # unblock and apply budget caps.
                     if configured_cap is None:
                         # No user-defined key cap — clear both max_budget
                         # and budget_duration so no stale duration remains.
@@ -286,6 +279,15 @@ async def _sync_pool_key_effective_budgets(
                             clear_max_budget=False,
                             blocked=False,
                         )
+                else:
+                    # No purchase yet — enforce $0 budget via max_budget;
+                    # do NOT set blocked=True (keys stay unblocked).
+                    await service.update_key_budget(
+                        litellm_token=key.litellm_token,
+                        budget_duration=MONTHLY_BUDGET_DURATION,
+                        max_budget=0.0,
+                        clear_max_budget=False,
+                    )
             return None
         except Exception as exc:
             return f"Key {key.id}: {str(exc)}"

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -520,7 +520,7 @@ async def create_llm_token(
             max_budget=max_max_spend,
             rpm_limit=max_rpm_limit,
             apply_limits=not is_pool_team,
-            blocked=(True if is_pool_team and not has_pool_purchase else None),
+            blocked=None,
         )
         if is_pool_team and not has_pool_purchase:
             await litellm_service.update_key_budget(

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -520,7 +520,7 @@ async def create_llm_token(
             max_budget=max_max_spend,
             rpm_limit=max_rpm_limit,
             apply_limits=not is_pool_team,
-            blocked=None,
+            blocked=(True if is_pool_team and not has_pool_purchase else None),
         )
         if is_pool_team and not has_pool_purchase:
             await litellm_service.update_key_budget(

--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -532,67 +532,6 @@ def _pool_team_budget_duration_for_enforcement(
     return shared_pool_team_budget_duration_for_enforcement(db, team_id, region_id)
 
 
-async def _enforce_pool_no_purchase_key_lock(
-    db: Session,
-    team: DBTeam | None,
-    region: DBRegion,
-    service: LiteLLMService,
-    key_id: int | None = None,
-    user_id: int | None = None,
-    purchased_budget: float | None = None,
-) -> bool:
-    """
-    For prepaid-pool teams with no purchased budget in a region, hard-lock
-    keys in LiteLLM to avoid the team budget zero-edge.
-    """
-    if team is None or not team.requires_pool_purchase_gate:
-        return False
-    if purchased_budget is None:
-        purchased_budget = _pool_available_budget_for_team_region(
-            db, team.id, region.id
-        )
-    if purchased_budget > 0:
-        return False
-    region_keys = get_team_region_litellm_keys(
-        db,
-        team_id=team.id,
-        region_id=region.id,
-        key_id=key_id,
-        user_id=user_id,
-    )
-    if not region_keys:
-        return False
-
-    semaphore = asyncio.Semaphore(10)
-
-    async def _lock_key(key: DBPrivateAIKey) -> str | None:
-        try:
-            async with semaphore:
-                await service.update_key_budget(
-                    litellm_token=key.litellm_token,
-                    budget_duration=MONTHLY_BUDGET_DURATION,
-                    max_budget=0.0,
-                    clear_max_budget=False,
-                    blocked=True,
-                )
-            return None
-        except Exception as exc:
-            return f"Key {key.id}: {str(exc)}"
-
-    errors = [
-        error
-        for error in await asyncio.gather(*[_lock_key(key) for key in region_keys])
-        if error is not None
-    ]
-    if errors:
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=(
-                "Failed to enforce no-purchase key lock in LiteLLM: "
-                + "; ".join(errors)
-            ),
-        )
-    return True
 
 
 def _upsert_spend_cap(
@@ -1491,19 +1430,6 @@ async def update_team_budget(
         max_budget=effective_max_budget,
         budget_duration=effective_duration,
     )
-    if (
-        body.max_budget is not None
-        and team.requires_pool_purchase_gate
-        and available_total is not None
-        and available_total <= 0
-    ):
-        await _enforce_pool_no_purchase_key_lock(
-            db,
-            team,
-            region,
-            service,
-            purchased_budget=available_total,
-        )
     _upsert_spend_cap(
         db,
         scope="team",
@@ -1603,7 +1529,6 @@ async def update_team_member_budget(
         max_budget_in_team=body.max_budget,
         budget_duration=effective_duration,
     )
-    await _enforce_pool_no_purchase_key_lock(db, team, region, service, user_id=user_id)
     _upsert_spend_cap(
         db,
         scope="team_member",
@@ -1891,34 +1816,11 @@ async def update_key_budget(
             # Preserve existing key duration anchor when only cap value changes.
             effective_duration = None
 
-    # For purchase-gated POOL teams with no purchases, skip the initial key
-    # budget update (which would be immediately overridden) to avoid a brief
-    # unlocked window. The lock call below will hard-set max_budget=0 directly.
-    purchased_budget: float | None = None
-    skip_initial_update = False
-    if (
-        team_for_budget_check is not None
-        and team_for_budget_check.requires_pool_purchase_gate
-        and body.max_budget is not None
-    ):
-        purchased_budget = _pool_available_budget_for_team_region(
-            db, team_for_budget_check.id, region_id
-        )
-        skip_initial_update = purchased_budget <= 0
-    if not skip_initial_update:
-        await service.update_key_budget(
-            litellm_token=key.litellm_token,
-            budget_duration=effective_duration,
-            max_budget=body.max_budget,
-            clear_max_budget=body.max_budget is None,
-        )
-    lock_applied = await _enforce_pool_no_purchase_key_lock(
-        db,
-        team_for_budget_check,
-        region,
-        service,
-        key_id=key.id,
-        purchased_budget=purchased_budget,
+    await service.update_key_budget(
+        litellm_token=key.litellm_token,
+        budget_duration=effective_duration,
+        max_budget=body.max_budget,
+        clear_max_budget=body.max_budget is None,
     )
     existing_key_cap_row = (
         db.query(DBSpendCap)
@@ -1973,12 +1875,7 @@ async def update_key_budget(
             else info.get("max_budget")
         ),
         budget_duration=info.get("budget_duration"),
-        note=(
-            "If key has team_id, team/team-member budgets may take precedence during enforcement. "
-            "No-purchase prepaid-pool teams keep keys hard-locked at max_budget=0 while preserving configured caps for post-purchase restore."
-            if lock_applied
-            else "If key has team_id, team/team-member budgets may take precedence during enforcement."
-        ),
+        note="If key has team_id, team/team-member budgets may take precedence during enforcement.",
     )
 
 

--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -1,5 +1,4 @@
 import logging
-import asyncio
 import re
 from datetime import UTC, date, datetime, timedelta
 
@@ -13,7 +12,6 @@ from app.core.config import settings
 from app.core.limit_service import DEFAULT_MAX_SPEND, LimitService
 from app.core.litellm_user_sync import team_role_for_litellm
 from app.core.roles import UserRole
-from app.core.team_service import get_team_region_litellm_keys
 from app.core.periodic_budget_ledger_service import compute_active_topup_remaining
 from app.core.pool_budget_service import (
     pool_available_budget_for_team_region as shared_pool_available_budget_for_team_region,
@@ -530,8 +528,6 @@ def _pool_team_budget_duration_for_enforcement(
     db: Session, team_id: int, region_id: int
 ) -> str:
     return shared_pool_team_budget_duration_for_enforcement(db, team_id, region_id)
-
-
 
 
 def _upsert_spend_cap(

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -1486,10 +1486,26 @@ def test_create_llm_token_for_pool_team_skips_per_key_limits(
     test_team,
     mock_httpx_post_client,
 ):
-    """POOL teams without the purchase gate should never have keys blocked."""
+    """Gated POOL teams skip per-key budget/rate limits (apply_limits=False).
+    With a prior purchase the key must not be blocked."""
     test_team.budget_type = "pool"
-    test_team.require_purchase_for_requests = False
-    # Explicitly disable the purchase gate — keys must never be blocked regardless of purchase history.
+    test_team.require_purchase_for_requests = True
+    db.commit()
+    # Seed a purchase so the key is not blocked.
+    from app.db.models import DBPeriodicBudgetLedgerEntry
+    from datetime import UTC, datetime
+    db.add(
+        DBPeriodicBudgetLedgerEntry(
+            team_id=test_team.id,
+            region_id=test_region.id,
+            entry_type="topup",
+            amount_cents=1000,
+            consumed_cents=0,
+            is_active=True,
+            purchased_at=datetime.now(UTC),
+            expires_at=None,
+        )
+    )
     db.commit()
 
     mock_client_class.return_value = mock_httpx_post_client

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -1486,8 +1486,10 @@ def test_create_llm_token_for_pool_team_skips_per_key_limits(
     test_team,
     mock_httpx_post_client,
 ):
-    """POOL teams should only get key expiry, without per-key budget/rate limits."""
+    """POOL teams without the purchase gate should never have keys blocked."""
     test_team.budget_type = "pool"
+    # require_purchase_for_requests is False by default, so requires_pool_purchase_gate
+    # is False — keys must never be blocked regardless of purchase history.
     db.commit()
 
     mock_client_class.return_value = mock_httpx_post_client
@@ -1519,15 +1521,7 @@ def test_create_llm_token_for_pool_team_skips_per_key_limits(
     assert "budget_duration" not in call_args["json"]
     assert "max_budget" not in call_args["json"]
     assert "rpm_limit" not in call_args["json"]
-    assert call_args["json"]["blocked"] is True
-
-    key_update_calls = [
-        call
-        for call in mock_httpx_post_client.post.call_args_list
-        if str(call.args[0]).endswith("/key/update")
-    ]
-    assert len(key_update_calls) == 1
-    assert "blocked" not in key_update_calls[0].kwargs["json"]
+    assert "blocked" not in call_args["json"]
 
 
 @patch("httpx.AsyncClient")

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -1488,8 +1488,8 @@ def test_create_llm_token_for_pool_team_skips_per_key_limits(
 ):
     """POOL teams without the purchase gate should never have keys blocked."""
     test_team.budget_type = "pool"
-    # require_purchase_for_requests is False by default, so requires_pool_purchase_gate
-    # is False — keys must never be blocked regardless of purchase history.
+    test_team.require_purchase_for_requests = False
+    # Explicitly disable the purchase gate — keys must never be blocked regardless of purchase history.
     db.commit()
 
     mock_client_class.return_value = mock_httpx_post_client

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -1330,8 +1330,9 @@ def test_update_pool_key_budget_allows_setting_cap_before_first_purchase(
         json={"max_budget": 60.0},
     )
     assert response.status_code == 200, response.json()
+    # Without the no-purchase lock, the cap is applied directly to LiteLLM.
     mock_update_key_budget.assert_awaited_once()
-    assert mock_update_key_budget.await_args.kwargs["max_budget"] == 0.0
+    assert mock_update_key_budget.await_args.kwargs["max_budget"] == 60.0
     assert mock_update_key_budget.await_args.kwargs["clear_max_budget"] is False
     assert response.json()["max_budget"] == 60.0
     cap = (
@@ -1349,7 +1350,7 @@ def test_update_pool_key_budget_allows_setting_cap_before_first_purchase(
 
 @patch("app.api.spend.LiteLLMService.get_key_info", new_callable=AsyncMock)
 @patch("app.api.spend.LiteLLMService.update_key_budget", new_callable=AsyncMock)
-def test_update_prepaid_pool_key_budget_locks_dedicated_team_before_purchase(
+def test_update_prepaid_pool_key_budget_applies_cap_before_purchase(
     mock_update_key_budget,
     mock_get_key_info,
     client,
@@ -1393,8 +1394,9 @@ def test_update_prepaid_pool_key_budget_locks_dedicated_team_before_purchase(
         json={"max_budget": 50.0},
     )
     assert response.status_code == 200, response.json()
+    # Without the no-purchase lock, the cap is applied directly to LiteLLM.
     mock_update_key_budget.assert_awaited_once()
-    assert mock_update_key_budget.await_args.kwargs["max_budget"] == 0.0
+    assert mock_update_key_budget.await_args.kwargs["max_budget"] == 50.0
     assert mock_update_key_budget.await_args.kwargs["clear_max_budget"] is False
 
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes the "no-purchase key lock" enforcement that was scattered across budget-update endpoints and consolidates the key-blocking lifecycle: keys are blocked at creation time (in `private_ai_keys.py`, unchanged) and unblocked exclusively through the purchase flow via `_sync_pool_key_effective_budgets`. The root cause being fixed is that the old `_sync_pool_key_effective_budgets` called `pool_team_has_ever_purchased` against the DB before the purchase was committed, so the guard could return `False` even after a valid purchase, leaving keys permanently blocked.

- **`app/api/budgets.py`**: `_sync_pool_key_effective_budgets` drops the `pool_team_has_ever_purchased` guard; all invocations of this function now unconditionally unblock keys and reconcile cap overrides.
- **`app/api/spend.py`**: Removes `_enforce_pool_no_purchase_key_lock` and all three call sites (`update_team_budget`, `update_team_member_budget`, `update_key_budget`), simplifying the key-budget update path.
- **`tests/test_private_ai.py`**: Test for non-purchase-gated pool teams now correctly asserts `blocked` is absent from key-creation payloads and removes the stale `/key/update` assertion.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the core fix correctly eliminates a pre-commit DB race in the purchase flow, and no existing blocking mechanism is removed without a replacement.

The architectural change is well-reasoned: the only meaningful risk is that `purchased_total` is now a dead parameter in `_sync_pool_key_effective_budgets`, and the function's docstring misstates the call-site contract for the budget-expiry paths. Neither causes wrong runtime behavior, but both leave the code in a state that could confuse future maintainers making changes around key-blocking logic.

app/api/budgets.py — the `purchased_total` parameter and the docstring for `_sync_pool_key_effective_budgets` need a second look before this function is touched again.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/api/budgets.py | Removes `pool_team_has_ever_purchased` guard from `_sync_pool_key_effective_budgets`; keys are always unblocked when this function runs. The `purchased_total` parameter is now dead (never read inside the function). |
| app/api/spend.py | Removes `_enforce_pool_no_purchase_key_lock` helper and all its call sites from `update_team_budget`, `update_team_member_budget`, and `update_key_budget`. Budget-update paths no longer re-apply the no-purchase hard-lock; key-blocking is now solely managed at creation time and lifted by the purchase flow. |
| tests/test_private_ai.py | Updates `test_create_llm_token_for_pool_team_skips_per_key_limits` to set `require_purchase_for_requests=False` explicitly; asserts `blocked` is absent from key-creation call rather than asserting `blocked=True`. Removes the now-absent `/key/update` follow-up call assertions. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant BudgetsAPI as budgets.py (purchase endpoint)
    participant LiteLLM
    participant DB

    Client->>BudgetsAPI: POST /purchase
    BudgetsAPI->>DB: insert payment_record (uncommitted)
    BudgetsAPI->>LiteLLM: "update_team_budget(max_budget=desired_remaining)"
    Note over BudgetsAPI: OLD: _sync_pool_key_effective_budgets<br/>called pool_team_has_ever_purchased(DB)<br/>returned False (not yet committed)<br/>keys stayed blocked
    BudgetsAPI->>BudgetsAPI: "_sync_pool_key_effective_budgets(purchased_total>0)"
    Note over BudgetsAPI: NEW: no DB look-up — always unblock
    loop each key
        BudgetsAPI->>LiteLLM: "update_key_budget(blocked=False, cap or clear)"
    end
    BudgetsAPI->>DB: "commit(payment_record, sync_status=success)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant BudgetsAPI as budgets.py (purchase endpoint)
    participant LiteLLM
    participant DB

    Client->>BudgetsAPI: POST /purchase
    BudgetsAPI->>DB: insert payment_record (uncommitted)
    BudgetsAPI->>LiteLLM: "update_team_budget(max_budget=desired_remaining)"
    Note over BudgetsAPI: OLD: _sync_pool_key_effective_budgets<br/>called pool_team_has_ever_purchased(DB)<br/>returned False (not yet committed)<br/>keys stayed blocked
    BudgetsAPI->>BudgetsAPI: "_sync_pool_key_effective_budgets(purchased_total>0)"
    Note over BudgetsAPI: NEW: no DB look-up — always unblock
    loop each key
        BudgetsAPI->>LiteLLM: "update_key_budget(blocked=False, cap or clear)"
    end
    BudgetsAPI->>DB: "commit(payment_record, sync_status=success)"
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/api/budgets.py`, line 217 ([link](https://github.com/amazeeio/amazee.ai/blob/20195c86fc478eed7996739a828e6ddae53f60f2/app/api/budgets.py#L217)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Unused `purchased_total` parameter**

   `purchased_total` is accepted by the function signature and is passed in by every caller, but nothing inside `_sync_pool_key_effective_budgets` actually reads it. The old guard (`pool_team_has_ever_purchased`) was removed and no replacement logic consumes `purchased_total`, so the parameter is now dead. Keeping it in the signature while never reading it will mislead future authors into thinking the value influences key-level decisions. The parameter should either be removed from the signature and all call sites, or the blocking logic should be rebuilt around `purchased_total > 0` instead of the removed DB look-up.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Potential fix for pull request finding"](https://github.com/amazeeio/amazee.ai/commit/20195c86fc478eed7996739a828e6ddae53f60f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38422248)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->