### PR TITLE
fix(webhooks): replace event.get() with getattr() for Stripe v15 comp…

### DIFF
--- a/app/api/webhooks.py
+++ b/app/api/webhooks.py
@@ -62,8 +62,12 @@ async def handle_events(
         # the background task. If a duplicate webhook arrives concurrently,
         # the UniqueViolation on stripe_event_id means the event is already
         # being processed — return 200 immediately (Stripe doesn't retry on 200).
-        event_id = event.get("id")
-        event_type = event.get("type", "unknown")
+        #
+        # NOTE: use getattr(), not event.get(). Since stripe-python v15,
+        # StripeObject no longer subclasses dict, so event.get("id") raises
+        # AttributeError("get"). The worker already uses attribute access.
+        event_id = getattr(event, "id", None)
+        event_type = getattr(event, "type", "unknown")
         if event_id:
             try:
                 db.add(

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -469,7 +469,7 @@ async def _run_cycle_from_stripe_event(
             sub = stripe_sdk.Subscription.retrieve(subscription_id)
             meta = getattr(sub, "metadata", {}) or {}
             if getattr(meta, "regionId", None):
-                region_id = int(meta["regionId"])
+                region_id = int(getattr(meta, "regionId", None))
         except Exception as exc:
             logger.warning(
                 "Failed to retrieve subscription %s: %s", subscription_id, exc

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -437,7 +437,7 @@ async def _run_cycle_from_stripe_event(
     # then try Stripe API, then fall back to DBTeamRegion
     region_id: int | None = None
     subscription_id = getattr(event_object, "subscription", None)
-    sub_meta: dict = {}
+    sub_meta: object = {}
 
     # Check parent.subscription_details on the invoice object
     if hasattr(event_object, "parent"):
@@ -450,16 +450,18 @@ async def _run_cycle_from_stripe_event(
                 "Invoice parent.subscription_details not available; continuing with fallback region resolution"
             )
 
-    # NOTE: getattr() not .get() — stripe-python v15 StripeObject no
-    # longer subclasses dict, so sub_meta.get() raises AttributeError.
-    if getattr(sub_meta, "regionId", None):
+    # NOTE: getattr() not .get() — stripe-python v15 StripeObject no longer
+    # subclasses dict, so sub_meta.get() raises AttributeError. Test fixtures
+    # and prod both supply StripeObject metadata here.
+    _sub_region_id = getattr(sub_meta, "regionId", None)
+    if _sub_region_id:
         try:
-            region_id = int(sub_meta["regionId"])
+            region_id = int(_sub_region_id)
         except (TypeError, ValueError) as exc:
             logger.warning(
                 "Invalid regionId in subscription metadata for customer_id=%s: %r (%s)",
                 customer_id,
-                getattr(sub_meta, "regionId", None),
+                _sub_region_id,
                 exc,
             )
 
@@ -468,8 +470,9 @@ async def _run_cycle_from_stripe_event(
         try:
             sub = stripe_sdk.Subscription.retrieve(subscription_id)
             meta = getattr(sub, "metadata", {}) or {}
-            if getattr(meta, "regionId", None):
-                region_id = int(getattr(meta, "regionId", None))
+            _meta_region_id = getattr(meta, "regionId", None)
+            if _meta_region_id:
+                region_id = int(_meta_region_id)
         except Exception as exc:
             logger.warning(
                 "Failed to retrieve subscription %s: %s", subscription_id, exc

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -319,9 +319,11 @@ async def _record_periodic_payment(db: Session, event_object: any) -> Optional[i
         currency = str(raw_currency).lower() if isinstance(raw_currency, str) else "usd"
 
         # Determine payment type from metadata
+        # NOTE: getattr() not .get() — stripe-python v15 StripeObject no
+        # longer subclasses dict, so metadata.get() raises AttributeError.
         metadata = getattr(event_object, "metadata", {})
         payment_type = "subscription"
-        if metadata and metadata.get("ai_budget_increase"):
+        if metadata and getattr(metadata, "ai_budget_increase", None):
             payment_type = "topup"
 
         # Check if record already exists to avoid duplicates
@@ -448,14 +450,16 @@ async def _run_cycle_from_stripe_event(
                 "Invoice parent.subscription_details not available; continuing with fallback region resolution"
             )
 
-    if sub_meta.get("regionId"):
+    # NOTE: getattr() not .get() — stripe-python v15 StripeObject no
+    # longer subclasses dict, so sub_meta.get() raises AttributeError.
+    if getattr(sub_meta, "regionId", None):
         try:
             region_id = int(sub_meta["regionId"])
         except (TypeError, ValueError) as exc:
             logger.warning(
                 "Invalid regionId in subscription metadata for customer_id=%s: %r (%s)",
                 customer_id,
-                sub_meta.get("regionId"),
+                getattr(sub_meta, "regionId", None),
                 exc,
             )
 
@@ -464,7 +468,7 @@ async def _run_cycle_from_stripe_event(
         try:
             sub = stripe_sdk.Subscription.retrieve(subscription_id)
             meta = getattr(sub, "metadata", {}) or {}
-            if meta.get("regionId"):
+            if getattr(meta, "regionId", None):
                 region_id = int(meta["regionId"])
         except Exception as exc:
             logger.warning(
@@ -697,8 +701,9 @@ async def handle_stripe_event_background(event):
                     db, customer_id, product_id, datetime.now(UTC)
                 )
             else:
+                # getattr() not .get() — see note re: stripe-python v15.
                 metadata = getattr(event_object, "metadata", {})
-                if metadata and metadata.get("ai_budget_increase"):
+                if metadata and getattr(metadata, "ai_budget_increase", None):
                     team = (
                         db.query(DBTeam)
                         .filter(DBTeam.stripe_customer_id == customer_id)

--- a/tests/test_periodic_payments.py
+++ b/tests/test_periodic_payments.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
+import stripe
 
 from app.core.config import settings
 from app.core.worker import (
@@ -19,6 +20,16 @@ from app.db.models import (
     DBTeam,
 )
 from app.schemas.models import BudgetType
+
+
+def _stripe_meta(data: dict) -> stripe.StripeObject:
+    """Build a real StripeObject metadata instead of a bare dict.
+
+    stripe-python v15 StripeObject no longer subclasses dict, so production
+    code reads metadata via getattr(). Test fixtures must supply the same
+    shape or they silently diverge from prod.
+    """
+    return stripe.StripeObject.construct_from(data, key="sk_test")
 
 
 @pytest.mark.asyncio
@@ -538,7 +549,7 @@ async def test_webhook_cycle_first_cycle_is_region_scoped(
         parent=SimpleNamespace(
             subscription_details=SimpleNamespace(
                 subscription="sub_region_scope",
-                metadata={"regionId": str(test_region.id)},
+                metadata=_stripe_meta({"regionId": str(test_region.id)}),
             )
         ),
     )
@@ -1072,7 +1083,7 @@ async def test_pool_team_invoice_paid_not_skipped(
         parent=SimpleNamespace(
             subscription_details=SimpleNamespace(
                 subscription="sub_pool_1",
-                metadata={"regionId": str(test_region.id)},
+                metadata=_stripe_meta({"regionId": str(test_region.id)}),
             )
         ),
     )

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -1498,6 +1498,7 @@ def test_create_llm_token_for_pool_team_skips_per_key_limits(
     # Seed a purchase so the key is not blocked.
     from app.db.models import DBPeriodicBudgetLedgerEntry
     from datetime import UTC, datetime
+
     db.add(
         DBPeriodicBudgetLedgerEntry(
             team_id=test_team.id,

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,0 +1,211 @@
+"""Regression tests for the Stripe webhook endpoint (`POST /billing/events`).
+
+These guard against the stripe-python v15 breaking change where ``StripeObject``
+no longer subclasses ``dict``. Under v14.x, ``StripeObject`` inherited from
+``Dict`` so ``event.get("id")`` worked; under v15+, ``event.get("id")`` raises
+``AttributeError("get")``, which surfaced as an HTTP 500 on every webhook
+delivery from Stripe (see Stripe's migration guide):
+    https://github.com/stripe/stripe-python/wiki/Migration-guide-for-v15
+
+IMPORTANT: these tests build REAL ``stripe.Event`` objects (via
+``construct_from``), not ``SimpleNamespace`` mocks. A ``SimpleNamespace`` with
+dict ``metadata`` would let ``.get()`` succeed and silently hide the regression.
+A real ``Event`` under the pinned ``requirements.txt`` (``stripe==15.2.0``)
+exhibits the same ``StripeObject`` internals as production and therefore
+reproduces the bug. The handler must use attribute access (``getattr``).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import stripe
+from stripe import Event
+
+from app.db.models import DBStripeProcessedEvent
+
+WEBHOOK_SECRET_KEY = "stripe_webhook_secret"
+
+
+def _make_real_stripe_event(
+    event_id: str = "evt_test_regression_v15",
+    event_type: str = "invoice.paid",
+    customer_id: str = "cus_test_regression",
+    metadata: dict | None = None,
+) -> Event:
+    """Build a REAL ``stripe.Event`` (not a SimpleNamespace).
+
+    Under ``stripe >= 15`` the returned object's internals are ``StripeObject``
+    instances that do NOT support ``.get()`` — exactly matching production.
+    """
+    return Event.construct_from(
+        {
+            "id": event_id,
+            "type": event_type,
+            "data": {
+                "object": {
+                    "customer": customer_id,
+                    "metadata": metadata or {},
+                }
+            },
+        },
+        key="sk_test_regression",
+    )
+
+
+@pytest.fixture
+def webhook_secret_env(monkeypatch):
+    """Set ``WEBHOOK_SIG`` so the handler passes its secret guard.
+
+    The secret value is irrelevant here because ``decode_stripe_event`` is
+    patched in each test; we only need a non-empty value to avoid the 404
+    "not configured" branch.
+    """
+    monkeypatch.setenv("WEBHOOK_SIG", "whsec_test_regression")
+    yield
+
+
+def test_webhook_endpoint_returns_200_for_real_stripe_event(
+    client, db, webhook_secret_env
+):
+    """``POST /billing/events`` must return 200 for a real ``stripe.Event``.
+
+    Regression for the v15 break: the handler previously called
+    ``event.get("id")`` / ``event.get("type")``, which raises
+    ``AttributeError("get")`` under ``stripe >= 15`` and made Stripe see a
+    500 on every webhook delivery. The endpoint must read ``id``/``type`` via
+    attribute access (``getattr``) instead.
+    """
+    real_event = _make_real_stripe_event()
+
+    # decode_stripe_event already handles signature verification (tested
+    # elsewhere); here we feed the handler a real Event to verify the
+    # request path after verification can process a v15 StripeObject.
+    with (
+        patch("app.api.webhooks.decode_stripe_event", return_value=real_event),
+        patch(
+            "app.api.webhooks.handle_stripe_event_background", new_callable=AsyncMock
+        ) as mock_background,
+    ):
+        response = client.post(
+            "/billing/events",
+            content=b'{"id": "evt_test_regression_v15"}',
+            headers={
+                "stripe-signature": "t=1,v1=fake",
+                "content-type": "application/json",
+            },
+        )
+
+    assert response.status_code == 200, (
+        f"expected 200, got {response.status_code}: {response.text}"
+    )
+    # Background processing must be dispatched with the REAL event object.
+    mock_background.assert_awaited_once_with(real_event)
+
+
+def test_webhook_writes_idempotency_claim_from_real_stripe_event(
+    client, db, webhook_secret_env
+):
+    """The idempotency claim row must be written using the real event id.
+
+    This proves the handler extracts ``id``/``type`` from the real
+    ``stripe.Event`` (via ``getattr``) rather than crashing before the insert.
+    Under the buggy ``event.get("id")`` code this raised AttributeError -> 500
+    and no row was ever written.
+    """
+    event_id = "evt_claim_from_real_event"
+    real_event = _make_real_stripe_event(
+        event_id=event_id, event_type="customer.subscription.created"
+    )
+
+    with (
+        patch("app.api.webhooks.decode_stripe_event", return_value=real_event),
+        patch(
+            "app.api.webhooks.handle_stripe_event_background", new_callable=AsyncMock
+        ),
+    ):
+        response = client.post(
+            "/billing/events",
+            content=b'{"id": "evt_claim_from_real_event"}',
+            headers={
+                "stripe-signature": "t=1,v1=fake",
+                "content-type": "application/json",
+            },
+        )
+
+    assert response.status_code == 200, response.text
+
+    claim = (
+        db.query(DBStripeProcessedEvent)
+        .filter(DBStripeProcessedEvent.stripe_event_id == event_id)
+        .first()
+    )
+    assert claim is not None, "idempotency claim row was not written"
+    assert claim.event_type == "customer.subscription.created"
+
+
+def test_webhook_duplicate_real_event_returns_200_not_500(
+    client, db, webhook_secret_env
+):
+    """A duplicate real event hits the idempotency guard and returns 200.
+
+    This exercises the ``IntegrityError`` branch — which the buggy code never
+    reached (it 500'd before the insert). With the fix, the first delivery
+    writes the claim row and a second delivery returns 200 cleanly.
+    """
+    event_id = "evt_duplicate_real_event"
+    real_event = _make_real_stripe_event(event_id=event_id)
+
+    with (
+        patch("app.api.webhooks.decode_stripe_event", return_value=real_event),
+        patch(
+            "app.api.webhooks.handle_stripe_event_background", new_callable=AsyncMock
+        ),
+    ):
+        first = client.post(
+            "/billing/events",
+            content=b'{"id": "evt_duplicate_real_event"}',
+            headers={"stripe-signature": "t=1,v1=fake"},
+        )
+        second = client.post(
+            "/billing/events",
+            content=b'{"id": "evt_duplicate_real_event"}',
+            headers={"stripe-signature": "t=1,v1=fake"},
+        )
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    # Exactly one claim row, despite two deliveries.
+    claims = (
+        db.query(DBStripeProcessedEvent)
+        .filter(DBStripeProcessedEvent.stripe_event_id == event_id)
+        .all()
+    )
+    assert len(claims) == 1
+
+
+def test_real_stripe_metadata_is_not_dict_like():
+    """Guard test: documents the v15 contract that makes ``.get()`` unsafe.
+
+    A real Stripe ``metadata`` object (``StripeObject``) must NOT be a ``dict``
+    subclass under the pinned SDK. If this ever flips back (e.g. a downgrade or
+    SDK revert), ``.get()`` would silently work again and the regression tests
+    above would stop catching it — so this test makes the dependency explicit.
+
+    Under ``stripe < 15`` this test is skipped (metadata IS dict-like there).
+    """
+    if int(stripe.VERSION.split(".")[0]) < 15:
+        pytest.skip(
+            f"stripe-python {stripe.VERSION} still subclasses dict; "
+            "regression only applies to v15+"
+        )
+
+    event = _make_real_stripe_event(metadata={"regionId": "us103"})
+    metadata = event.data.object.metadata
+
+    # Under v15+ this must be a StripeObject, NOT a dict subclass.
+    assert not isinstance(metadata, dict), (
+        "stripe metadata is dict-like; the v15 .get() regression would NOT be "
+        "caught by the endpoint tests above"
+    )
+    # Attribute access is the supported path.
+    assert getattr(metadata, "regionId", None) == "us103"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,4 +1,5 @@
 import pytest
+import stripe
 from app.db.models import (
     DBProduct,
     DBTeamProduct,
@@ -176,7 +177,7 @@ async def test_handle_checkout_session_completed_calls_backfill(
     event_object = SimpleNamespace(
         customer="cus_checkout_completed",
         subscription="sub_checkout_123",
-        metadata={},
+        metadata=stripe.StripeObject.construct_from({}, key="sk_test"),
         client_reference_id=f"{test_team.id}-1",
     )
     event = SimpleNamespace(


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a production regression introduced by upgrading to `stripe-python` v15, where `StripeObject` no longer subclasses `dict`, causing `event.get("id")` and `metadata.get(...)` calls to raise `AttributeError` and return HTTP 500 on every Stripe webhook delivery.

- `app/api/webhooks.py`: replaces `event.get("id")` / `event.get("type")` with `getattr(event, "id", None)` / `getattr(event, "type", "unknown")`.
- `app/core/worker.py`: replaces `metadata.get()`, `sub_meta.get()`, and `meta.get()` across the three impacted call sites with `getattr()`.
- `tests/test_webhooks.py`: adds regression tests using real `stripe.Event` objects (via `construct_from`) rather than `SimpleNamespace` mocks, so the tests would fail under the pre-fix code and would catch any future reintroduction of `.get()` on a `StripeObject`.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The fix is targeted and correct — all .get() calls on StripeObject are replaced with getattr(), and the new regression tests use real stripe.Event objects to guard against the breakage being reintroduced.

Two spots in worker.py (lines 457 and 472) switch the guard to getattr() but still read the actual value via subscript access (sub_meta["regionId"] / meta["regionId"]). StripeObject v15 still implements __getitem__, so this works today, but it is inconsistent with the stated migration approach and worth tidying up before shipping.

app/core/worker.py — the two regionId value-reads at the newly-fixed call sites.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/webhooks.py | Replaces event.get("id")/event.get("type") with getattr() equivalents — directly fixing the v15 AttributeError regression. Change is minimal and correct. |
| app/core/worker.py | Replaces metadata.get() / sub_meta.get() / meta.get() calls with getattr() correctly, but lines 457 and 472 still use subscript access (sub_meta["regionId"] / meta["regionId"]) to read the actual value after the getattr guard — inconsistent with the fix's approach. |
| tests/test_webhooks.py | New regression test suite using real stripe.Event objects (not SimpleNamespace mocks) to reproduce the v15 breakage; covers idempotency, duplicate delivery, and a guard test for the dict-subclass contract. |
| tests/test_private_ai.py | Trivial whitespace-only change (blank line added between imports and db.add call); no logic change. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Stripe
    participant WebhookHandler as POST /billing/events
    participant DB
    participant Worker as handle_stripe_event_background

    Stripe->>WebhookHandler: POST /billing/events (raw payload + sig)
    WebhookHandler->>WebhookHandler: decode_stripe_event(payload, sig, secret)
    Note over WebhookHandler: getattr(event, "id", None)<br/>getattr(event, "type", "unknown")<br/>[was: event.get() — AttributeError in v15]
    WebhookHandler->>DB: INSERT DBStripeProcessedEvent(event_id, event_type)
    alt duplicate event
        DB-->>WebhookHandler: IntegrityError
        WebhookHandler-->>Stripe: 200 "already processed"
    else new event
        DB-->>WebhookHandler: OK
        WebhookHandler->>Worker: add_task(handle_stripe_event_background, event)
        Note over Worker: getattr(metadata, "ai_budget_increase")<br/>getattr(sub_meta, "regionId")<br/>[was: .get() — AttributeError in v15]
        WebhookHandler-->>Stripe: 200 "processing started"
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Stripe
    participant WebhookHandler as POST /billing/events
    participant DB
    participant Worker as handle_stripe_event_background

    Stripe->>WebhookHandler: POST /billing/events (raw payload + sig)
    WebhookHandler->>WebhookHandler: decode_stripe_event(payload, sig, secret)
    Note over WebhookHandler: getattr(event, "id", None)<br/>getattr(event, "type", "unknown")<br/>[was: event.get() — AttributeError in v15]
    WebhookHandler->>DB: INSERT DBStripeProcessedEvent(event_id, event_type)
    alt duplicate event
        DB-->>WebhookHandler: IntegrityError
        WebhookHandler-->>Stripe: 200 "already processed"
    else new event
        DB-->>WebhookHandler: OK
        WebhookHandler->>Worker: add_task(handle_stripe_event_background, event)
        Note over Worker: getattr(metadata, "ai_budget_increase")<br/>getattr(sub_meta, "regionId")<br/>[was: .get() — AttributeError in v15]
        WebhookHandler-->>Stripe: 200 "processing started"
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(webhooks): replace event.get() with ..."](https://github.com/amazeeio/amazee.ai/commit/f2796c2034481efc6778cd7c3c87a4f733877a31) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38668606)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->