### PR TITLE
Hotfix/AI Stripe SDK main II

### DIFF
--- a/app/api/webhooks.py
+++ b/app/api/webhooks.py
@@ -62,8 +62,12 @@ async def handle_events(
         # the background task. If a duplicate webhook arrives concurrently,
         # the UniqueViolation on stripe_event_id means the event is already
         # being processed — return 200 immediately (Stripe doesn't retry on 200).
-        event_id = event.get("id")
-        event_type = event.get("type", "unknown")
+        #
+        # NOTE: use getattr(), not event.get(). Since stripe-python v15,
+        # StripeObject no longer subclasses dict, so event.get("id") raises
+        # AttributeError("get"). The worker already uses attribute access.
+        event_id = getattr(event, "id", None)
+        event_type = getattr(event, "type", "unknown")
         if event_id:
             try:
                 db.add(

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -469,7 +469,7 @@ async def _run_cycle_from_stripe_event(
             sub = stripe_sdk.Subscription.retrieve(subscription_id)
             meta = getattr(sub, "metadata", {}) or {}
             if getattr(meta, "regionId", None):
-                region_id = int(meta["regionId"])
+                region_id = int(getattr(meta, "regionId", None))
         except Exception as exc:
             logger.warning(
                 "Failed to retrieve subscription %s: %s", subscription_id, exc

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -437,7 +437,7 @@ async def _run_cycle_from_stripe_event(
     # then try Stripe API, then fall back to DBTeamRegion
     region_id: int | None = None
     subscription_id = getattr(event_object, "subscription", None)
-    sub_meta: dict = {}
+    sub_meta: object = {}
 
     # Check parent.subscription_details on the invoice object
     if hasattr(event_object, "parent"):
@@ -450,16 +450,18 @@ async def _run_cycle_from_stripe_event(
                 "Invoice parent.subscription_details not available; continuing with fallback region resolution"
             )
 
-    # NOTE: getattr() not .get() — stripe-python v15 StripeObject no
-    # longer subclasses dict, so sub_meta.get() raises AttributeError.
-    if getattr(sub_meta, "regionId", None):
+    # NOTE: getattr() not .get() — stripe-python v15 StripeObject no longer
+    # subclasses dict, so sub_meta.get() raises AttributeError. Test fixtures
+    # and prod both supply StripeObject metadata here.
+    _sub_region_id = getattr(sub_meta, "regionId", None)
+    if _sub_region_id:
         try:
-            region_id = int(sub_meta["regionId"])
+            region_id = int(_sub_region_id)
         except (TypeError, ValueError) as exc:
             logger.warning(
                 "Invalid regionId in subscription metadata for customer_id=%s: %r (%s)",
                 customer_id,
-                getattr(sub_meta, "regionId", None),
+                _sub_region_id,
                 exc,
             )
 
@@ -468,8 +470,9 @@ async def _run_cycle_from_stripe_event(
         try:
             sub = stripe_sdk.Subscription.retrieve(subscription_id)
             meta = getattr(sub, "metadata", {}) or {}
-            if getattr(meta, "regionId", None):
-                region_id = int(getattr(meta, "regionId", None))
+            _meta_region_id = getattr(meta, "regionId", None)
+            if _meta_region_id:
+                region_id = int(_meta_region_id)
         except Exception as exc:
             logger.warning(
                 "Failed to retrieve subscription %s: %s", subscription_id, exc

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -437,7 +437,7 @@ async def _run_cycle_from_stripe_event(
     # then try Stripe API, then fall back to DBTeamRegion
     region_id: int | None = None
     subscription_id = getattr(event_object, "subscription", None)
-    sub_meta: "stripe.StripeObject | dict" = {}
+    sub_meta: "stripe_sdk.StripeObject | dict" = {}
 
     # Check parent.subscription_details on the invoice object
     if hasattr(event_object, "parent"):

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -319,9 +319,11 @@ async def _record_periodic_payment(db: Session, event_object: any) -> Optional[i
         currency = str(raw_currency).lower() if isinstance(raw_currency, str) else "usd"
 
         # Determine payment type from metadata
+        # NOTE: getattr() not .get() — stripe-python v15 StripeObject no
+        # longer subclasses dict, so metadata.get() raises AttributeError.
         metadata = getattr(event_object, "metadata", {})
         payment_type = "subscription"
-        if metadata and metadata.get("ai_budget_increase"):
+        if metadata and getattr(metadata, "ai_budget_increase", None):
             payment_type = "topup"
 
         # Check if record already exists to avoid duplicates
@@ -448,14 +450,16 @@ async def _run_cycle_from_stripe_event(
                 "Invoice parent.subscription_details not available; continuing with fallback region resolution"
             )
 
-    if sub_meta.get("regionId"):
+    # NOTE: getattr() not .get() — stripe-python v15 StripeObject no
+    # longer subclasses dict, so sub_meta.get() raises AttributeError.
+    if getattr(sub_meta, "regionId", None):
         try:
             region_id = int(sub_meta["regionId"])
         except (TypeError, ValueError) as exc:
             logger.warning(
                 "Invalid regionId in subscription metadata for customer_id=%s: %r (%s)",
                 customer_id,
-                sub_meta.get("regionId"),
+                getattr(sub_meta, "regionId", None),
                 exc,
             )
 
@@ -464,7 +468,7 @@ async def _run_cycle_from_stripe_event(
         try:
             sub = stripe_sdk.Subscription.retrieve(subscription_id)
             meta = getattr(sub, "metadata", {}) or {}
-            if meta.get("regionId"):
+            if getattr(meta, "regionId", None):
                 region_id = int(meta["regionId"])
         except Exception as exc:
             logger.warning(
@@ -697,8 +701,9 @@ async def handle_stripe_event_background(event):
                     db, customer_id, product_id, datetime.now(UTC)
                 )
             else:
+                # getattr() not .get() — see note re: stripe-python v15.
                 metadata = getattr(event_object, "metadata", {})
-                if metadata and metadata.get("ai_budget_increase"):
+                if metadata and getattr(metadata, "ai_budget_increase", None):
                     team = (
                         db.query(DBTeam)
                         .filter(DBTeam.stripe_customer_id == customer_id)

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -437,7 +437,7 @@ async def _run_cycle_from_stripe_event(
     # then try Stripe API, then fall back to DBTeamRegion
     region_id: int | None = None
     subscription_id = getattr(event_object, "subscription", None)
-    sub_meta: object = {}
+    sub_meta: "stripe.StripeObject | dict" = {}
 
     # Check parent.subscription_details on the invoice object
     if hasattr(event_object, "parent"):

--- a/tests/test_periodic_payments.py
+++ b/tests/test_periodic_payments.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
+import stripe
 
 from app.core.config import settings
 from app.core.worker import (
@@ -19,6 +20,16 @@ from app.db.models import (
     DBTeam,
 )
 from app.schemas.models import BudgetType
+
+
+def _stripe_meta(data: dict) -> stripe.StripeObject:
+    """Build a real StripeObject metadata instead of a bare dict.
+
+    stripe-python v15 StripeObject no longer subclasses dict, so production
+    code reads metadata via getattr(). Test fixtures must supply the same
+    shape or they silently diverge from prod.
+    """
+    return stripe.StripeObject.construct_from(data, key="sk_test")
 
 
 @pytest.mark.asyncio
@@ -538,7 +549,7 @@ async def test_webhook_cycle_first_cycle_is_region_scoped(
         parent=SimpleNamespace(
             subscription_details=SimpleNamespace(
                 subscription="sub_region_scope",
-                metadata={"regionId": str(test_region.id)},
+                metadata=_stripe_meta({"regionId": str(test_region.id)}),
             )
         ),
     )
@@ -1072,7 +1083,7 @@ async def test_pool_team_invoice_paid_not_skipped(
         parent=SimpleNamespace(
             subscription_details=SimpleNamespace(
                 subscription="sub_pool_1",
-                metadata={"regionId": str(test_region.id)},
+                metadata=_stripe_meta({"regionId": str(test_region.id)}),
             )
         ),
     )

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -19,44 +19,110 @@ from app.core.limit_service import (
 )
 
 
+@patch("app.api.private_ai_keys.settings")
 @patch("httpx.AsyncClient")
 def test_create_private_ai_key(
     mock_client_class,
-    client,
-    test_token,
+    mock_settings,
+    drupal_client,
+    drupal_test_token,
     test_region,
     test_user,
-    mock_httpx_post_client,
+    db,
 ):
-    """Test creating a private AI key in a specific region"""
-    # Use the httpx POST client fixture
-    mock_client_class.return_value = mock_httpx_post_client
+    """Test that a DEFAULT user's key creation is delegated to moad.
 
-    response = client.post(
+    The moad call is mocked. A matching DBPrivateAIKey is pre-inserted to
+    simulate moad calling back via POST /internal/provision-key.
+    """
+    mock_settings.MOAD_DASHBOARD_API_URL = "http://mock-moad"
+    mock_settings.MOAD_DASHBOARD_API_TOKEN = "mock-token"
+
+    litellm_token = "test-private-key-123"
+
+    # Simulate the key that moad would create via /internal/provision-key
+    pre_created_key = DBPrivateAIKey(
+        name="Test AI Key",
+        litellm_token=litellm_token,
+        litellm_api_url="http://test-llm",
+        database_name="test-db",
+        database_host="test-host",
+        database_username="test-user",
+        database_password="test-pass",
+        region_id=test_region.id,
+        team_id=None,
+        owner_id=None,
+    )
+    db.add(pre_created_key)
+    db.commit()
+    db.refresh(pre_created_key)
+
+    # Mock the httpx call to moad returning credentials
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "llm": {"apiUrl": "http://test-llm", "token": litellm_token},
+        "vectorDb": {
+            "host": "test-host",
+            "database": "test-db",
+            "username": "test-user",
+            "password": "test-pass",
+        },
+    }
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+    mock_client_class.return_value = mock_client
+
+    response = drupal_client.post(
         "/private-ai-keys/",
-        headers={"Authorization": f"Bearer {test_token}"},
+        headers={"Authorization": f"Bearer {drupal_test_token}"},
         json={"region_id": test_region.id, "name": "Test AI Key"},
     )
 
     assert response.status_code == 200
     data = response.json()
-    assert data["region"] == test_region.name
-    assert data["region_label"] == test_region.label
-    assert data["litellm_token"] == "test-private-key-123"
-    assert data["owner_id"] == test_user.id
-    assert data["id"] != -1
+    assert data["litellm_token"] == litellm_token
+    assert data["id"] == pre_created_key.id
+
+    # Verify moad was called with the correct payload
+    call_kwargs = mock_client.post.call_args
+    assert "/api/external/provision-key" in call_kwargs[0][0]
+    assert call_kwargs[1]["json"]["email"] == test_user.email
+    assert call_kwargs[1]["json"]["appName"] == "Test AI Key"
+    assert call_kwargs[1]["json"]["regionId"] == test_region.id
 
 
-def test_create_private_ai_key_invalid_region(client, test_token):
-    """Test creating a private AI key with an invalid region ID"""
-    response = client.post(
+@patch("app.api.private_ai_keys.settings")
+@patch("httpx.AsyncClient")
+def test_create_private_ai_key_invalid_region(
+    mock_client_class, mock_settings, drupal_client, drupal_test_token, test_user, db
+):
+    """Test that a Drupal user gets 404 when moad reports region not found."""
+    mock_settings.MOAD_DASHBOARD_API_URL = "http://mock-moad"
+    mock_settings.MOAD_DASHBOARD_API_TOKEN = "mock-token"
+
+    mock_response = Mock()
+    mock_response.status_code = 404
+    mock_response.text = '{"error": "Region not found"}'
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+    mock_client_class.return_value = mock_client
+
+    response = drupal_client.post(
         "/private-ai-keys/",
-        headers={"Authorization": f"Bearer {test_token}"},
+        headers={"Authorization": f"Bearer {drupal_test_token}"},
         json={"region_id": 99999, "name": "Test Invalid Region Key"},
     )
 
     assert response.status_code == 404
-    assert "Region not found or inactive" in response.json()["detail"]
+    # Verify the 404 came from moad, not from a local DB lookup
+    mock_client.post.assert_called_once()
+    call_url = mock_client.post.call_args[0][0]
+    assert "provision-key" in call_url
 
 
 def test_list_private_ai_keys(client, test_token, test_region, db, test_user):
@@ -1424,8 +1490,27 @@ def test_create_llm_token_for_pool_team_skips_per_key_limits(
     test_team,
     mock_httpx_post_client,
 ):
-    """POOL teams should only get key expiry, without per-key budget/rate limits."""
+    """Gated POOL teams skip per-key budget/rate limits (apply_limits=False).
+    With a prior purchase the key must not be blocked."""
     test_team.budget_type = "pool"
+    test_team.require_purchase_for_requests = True
+    db.commit()
+    # Seed a purchase so the key is not blocked.
+    from app.db.models import DBPeriodicBudgetLedgerEntry
+    from datetime import UTC, datetime
+
+    db.add(
+        DBPeriodicBudgetLedgerEntry(
+            team_id=test_team.id,
+            region_id=test_region.id,
+            entry_type="topup",
+            amount_cents=1000,
+            consumed_cents=0,
+            is_active=True,
+            purchased_at=datetime.now(UTC),
+            expires_at=None,
+        )
+    )
     db.commit()
 
     mock_client_class.return_value = mock_httpx_post_client
@@ -1457,15 +1542,7 @@ def test_create_llm_token_for_pool_team_skips_per_key_limits(
     assert "budget_duration" not in call_args["json"]
     assert "max_budget" not in call_args["json"]
     assert "rpm_limit" not in call_args["json"]
-    assert call_args["json"]["blocked"] is True
-
-    key_update_calls = [
-        call
-        for call in mock_httpx_post_client.post.call_args_list
-        if str(call.args[0]).endswith("/key/update")
-    ]
-    assert len(key_update_calls) == 1
-    assert "blocked" not in key_update_calls[0].kwargs["json"]
+    assert "blocked" not in call_args["json"]
 
 
 @patch("httpx.AsyncClient")
@@ -2563,7 +2640,7 @@ def test_create_private_ai_key_cleanup_on_vector_db_failure(
     mock_create_db,
     mock_client_class,
     client,
-    test_token,
+    admin_token,
     test_region,
     mock_httpx_post_client,
 ):
@@ -2580,7 +2657,7 @@ def test_create_private_ai_key_cleanup_on_vector_db_failure(
 
     response = client.post(
         "/private-ai-keys/",
-        headers={"Authorization": f"Bearer {test_token}"},
+        headers={"Authorization": f"Bearer {admin_token}"},
         json={"region_id": test_region.id, "name": "Test AI Key"},
     )
 
@@ -2603,7 +2680,7 @@ def test_create_private_ai_key_cleanup_on_vector_db_failure(
 
     # Verify no key was stored in the database
     stored_keys = client.get(
-        "/private-ai-keys/", headers={"Authorization": f"Bearer {test_token}"}
+        "/private-ai-keys/", headers={"Authorization": f"Bearer {admin_token}"}
     ).json()
     assert len([k for k in stored_keys if k["name"] == "Test AI Key"]) == 0
 
@@ -2618,7 +2695,7 @@ def test_create_private_ai_key_cleanup_on_db_storage_failure(
     mock_create_db,
     mock_client_class,
     client,
-    test_token,
+    admin_token,
     test_region,
     mock_httpx_post_client,
 ):
@@ -2646,7 +2723,7 @@ def test_create_private_ai_key_cleanup_on_db_storage_failure(
 
     response = client.post(
         "/private-ai-keys/",
-        headers={"Authorization": f"Bearer {test_token}"},
+        headers={"Authorization": f"Bearer {admin_token}"},
         json={"region_id": test_region.id, "name": "Test AI Key"},
     )
 
@@ -2665,7 +2742,7 @@ def test_create_private_ai_key_cleanup_on_db_storage_failure(
 
     # Verify no key was stored in the database
     stored_keys = client.get(
-        "/private-ai-keys/", headers={"Authorization": f"Bearer {test_token}"}
+        "/private-ai-keys/", headers={"Authorization": f"Bearer {admin_token}"}
     ).json()
     assert len([k for k in stored_keys if k["name"] == "Test AI Key"]) == 0
 
@@ -2676,7 +2753,7 @@ def test_create_private_ai_key_cleanup_failure_handling(
     mock_create_db,
     mock_client_class,
     client,
-    test_token,
+    admin_token,
     test_region,
     mock_httpx_post_client,
 ):
@@ -2707,7 +2784,7 @@ def test_create_private_ai_key_cleanup_failure_handling(
 
     response = client.post(
         "/private-ai-keys/",
-        headers={"Authorization": f"Bearer {test_token}"},
+        headers={"Authorization": f"Bearer {admin_token}"},
         json={"region_id": test_region.id, "name": "Test AI Key"},
     )
 
@@ -2726,7 +2803,7 @@ def test_create_private_ai_key_http_exception_preservation(
     mock_create_db,
     mock_client_class,
     client,
-    test_token,
+    admin_token,
     test_region,
     mock_httpx_post_client,
 ):
@@ -2745,7 +2822,7 @@ def test_create_private_ai_key_http_exception_preservation(
 
     response = client.post(
         "/private-ai-keys/",
-        headers={"Authorization": f"Bearer {test_token}"},
+        headers={"Authorization": f"Bearer {admin_token}"},
         json={"region_id": test_region.id, "name": "Test AI Key"},
     )
 

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -19,110 +19,44 @@ from app.core.limit_service import (
 )
 
 
-@patch("app.api.private_ai_keys.settings")
 @patch("httpx.AsyncClient")
 def test_create_private_ai_key(
     mock_client_class,
-    mock_settings,
-    drupal_client,
-    drupal_test_token,
+    client,
+    test_token,
     test_region,
     test_user,
-    db,
+    mock_httpx_post_client,
 ):
-    """Test that a DEFAULT user's key creation is delegated to moad.
+    """Test creating a private AI key in a specific region"""
+    # Use the httpx POST client fixture
+    mock_client_class.return_value = mock_httpx_post_client
 
-    The moad call is mocked. A matching DBPrivateAIKey is pre-inserted to
-    simulate moad calling back via POST /internal/provision-key.
-    """
-    mock_settings.MOAD_DASHBOARD_API_URL = "http://mock-moad"
-    mock_settings.MOAD_DASHBOARD_API_TOKEN = "mock-token"
-
-    litellm_token = "test-private-key-123"
-
-    # Simulate the key that moad would create via /internal/provision-key
-    pre_created_key = DBPrivateAIKey(
-        name="Test AI Key",
-        litellm_token=litellm_token,
-        litellm_api_url="http://test-llm",
-        database_name="test-db",
-        database_host="test-host",
-        database_username="test-user",
-        database_password="test-pass",
-        region_id=test_region.id,
-        team_id=None,
-        owner_id=None,
-    )
-    db.add(pre_created_key)
-    db.commit()
-    db.refresh(pre_created_key)
-
-    # Mock the httpx call to moad returning credentials
-    mock_response = Mock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {
-        "llm": {"apiUrl": "http://test-llm", "token": litellm_token},
-        "vectorDb": {
-            "host": "test-host",
-            "database": "test-db",
-            "username": "test-user",
-            "password": "test-pass",
-        },
-    }
-    mock_client = AsyncMock()
-    mock_client.post.return_value = mock_response
-    mock_client.__aenter__.return_value = mock_client
-    mock_client.__aexit__.return_value = None
-    mock_client_class.return_value = mock_client
-
-    response = drupal_client.post(
+    response = client.post(
         "/private-ai-keys/",
-        headers={"Authorization": f"Bearer {drupal_test_token}"},
+        headers={"Authorization": f"Bearer {test_token}"},
         json={"region_id": test_region.id, "name": "Test AI Key"},
     )
 
     assert response.status_code == 200
     data = response.json()
-    assert data["litellm_token"] == litellm_token
-    assert data["id"] == pre_created_key.id
-
-    # Verify moad was called with the correct payload
-    call_kwargs = mock_client.post.call_args
-    assert "/api/external/provision-key" in call_kwargs[0][0]
-    assert call_kwargs[1]["json"]["email"] == test_user.email
-    assert call_kwargs[1]["json"]["appName"] == "Test AI Key"
-    assert call_kwargs[1]["json"]["regionId"] == test_region.id
+    assert data["region"] == test_region.name
+    assert data["region_label"] == test_region.label
+    assert data["litellm_token"] == "test-private-key-123"
+    assert data["owner_id"] == test_user.id
+    assert data["id"] != -1
 
 
-@patch("app.api.private_ai_keys.settings")
-@patch("httpx.AsyncClient")
-def test_create_private_ai_key_invalid_region(
-    mock_client_class, mock_settings, drupal_client, drupal_test_token, test_user, db
-):
-    """Test that a Drupal user gets 404 when moad reports region not found."""
-    mock_settings.MOAD_DASHBOARD_API_URL = "http://mock-moad"
-    mock_settings.MOAD_DASHBOARD_API_TOKEN = "mock-token"
-
-    mock_response = Mock()
-    mock_response.status_code = 404
-    mock_response.text = '{"error": "Region not found"}'
-    mock_client = AsyncMock()
-    mock_client.post.return_value = mock_response
-    mock_client.__aenter__.return_value = mock_client
-    mock_client.__aexit__.return_value = None
-    mock_client_class.return_value = mock_client
-
-    response = drupal_client.post(
+def test_create_private_ai_key_invalid_region(client, test_token):
+    """Test creating a private AI key with an invalid region ID"""
+    response = client.post(
         "/private-ai-keys/",
-        headers={"Authorization": f"Bearer {drupal_test_token}"},
+        headers={"Authorization": f"Bearer {test_token}"},
         json={"region_id": 99999, "name": "Test Invalid Region Key"},
     )
 
     assert response.status_code == 404
-    # Verify the 404 came from moad, not from a local DB lookup
-    mock_client.post.assert_called_once()
-    call_url = mock_client.post.call_args[0][0]
-    assert "provision-key" in call_url
+    assert "Region not found or inactive" in response.json()["detail"]
 
 
 def test_list_private_ai_keys(client, test_token, test_region, db, test_user):
@@ -1490,27 +1424,8 @@ def test_create_llm_token_for_pool_team_skips_per_key_limits(
     test_team,
     mock_httpx_post_client,
 ):
-    """Gated POOL teams skip per-key budget/rate limits (apply_limits=False).
-    With a prior purchase the key must not be blocked."""
+    """POOL teams should only get key expiry, without per-key budget/rate limits."""
     test_team.budget_type = "pool"
-    test_team.require_purchase_for_requests = True
-    db.commit()
-    # Seed a purchase so the key is not blocked.
-    from app.db.models import DBPeriodicBudgetLedgerEntry
-    from datetime import UTC, datetime
-
-    db.add(
-        DBPeriodicBudgetLedgerEntry(
-            team_id=test_team.id,
-            region_id=test_region.id,
-            entry_type="topup",
-            amount_cents=1000,
-            consumed_cents=0,
-            is_active=True,
-            purchased_at=datetime.now(UTC),
-            expires_at=None,
-        )
-    )
     db.commit()
 
     mock_client_class.return_value = mock_httpx_post_client
@@ -1542,7 +1457,15 @@ def test_create_llm_token_for_pool_team_skips_per_key_limits(
     assert "budget_duration" not in call_args["json"]
     assert "max_budget" not in call_args["json"]
     assert "rpm_limit" not in call_args["json"]
-    assert "blocked" not in call_args["json"]
+    assert call_args["json"]["blocked"] is True
+
+    key_update_calls = [
+        call
+        for call in mock_httpx_post_client.post.call_args_list
+        if str(call.args[0]).endswith("/key/update")
+    ]
+    assert len(key_update_calls) == 1
+    assert "blocked" not in key_update_calls[0].kwargs["json"]
 
 
 @patch("httpx.AsyncClient")
@@ -2640,7 +2563,7 @@ def test_create_private_ai_key_cleanup_on_vector_db_failure(
     mock_create_db,
     mock_client_class,
     client,
-    admin_token,
+    test_token,
     test_region,
     mock_httpx_post_client,
 ):
@@ -2657,7 +2580,7 @@ def test_create_private_ai_key_cleanup_on_vector_db_failure(
 
     response = client.post(
         "/private-ai-keys/",
-        headers={"Authorization": f"Bearer {admin_token}"},
+        headers={"Authorization": f"Bearer {test_token}"},
         json={"region_id": test_region.id, "name": "Test AI Key"},
     )
 
@@ -2680,7 +2603,7 @@ def test_create_private_ai_key_cleanup_on_vector_db_failure(
 
     # Verify no key was stored in the database
     stored_keys = client.get(
-        "/private-ai-keys/", headers={"Authorization": f"Bearer {admin_token}"}
+        "/private-ai-keys/", headers={"Authorization": f"Bearer {test_token}"}
     ).json()
     assert len([k for k in stored_keys if k["name"] == "Test AI Key"]) == 0
 
@@ -2695,7 +2618,7 @@ def test_create_private_ai_key_cleanup_on_db_storage_failure(
     mock_create_db,
     mock_client_class,
     client,
-    admin_token,
+    test_token,
     test_region,
     mock_httpx_post_client,
 ):
@@ -2723,7 +2646,7 @@ def test_create_private_ai_key_cleanup_on_db_storage_failure(
 
     response = client.post(
         "/private-ai-keys/",
-        headers={"Authorization": f"Bearer {admin_token}"},
+        headers={"Authorization": f"Bearer {test_token}"},
         json={"region_id": test_region.id, "name": "Test AI Key"},
     )
 
@@ -2742,7 +2665,7 @@ def test_create_private_ai_key_cleanup_on_db_storage_failure(
 
     # Verify no key was stored in the database
     stored_keys = client.get(
-        "/private-ai-keys/", headers={"Authorization": f"Bearer {admin_token}"}
+        "/private-ai-keys/", headers={"Authorization": f"Bearer {test_token}"}
     ).json()
     assert len([k for k in stored_keys if k["name"] == "Test AI Key"]) == 0
 
@@ -2753,7 +2676,7 @@ def test_create_private_ai_key_cleanup_failure_handling(
     mock_create_db,
     mock_client_class,
     client,
-    admin_token,
+    test_token,
     test_region,
     mock_httpx_post_client,
 ):
@@ -2784,7 +2707,7 @@ def test_create_private_ai_key_cleanup_failure_handling(
 
     response = client.post(
         "/private-ai-keys/",
-        headers={"Authorization": f"Bearer {admin_token}"},
+        headers={"Authorization": f"Bearer {test_token}"},
         json={"region_id": test_region.id, "name": "Test AI Key"},
     )
 
@@ -2803,7 +2726,7 @@ def test_create_private_ai_key_http_exception_preservation(
     mock_create_db,
     mock_client_class,
     client,
-    admin_token,
+    test_token,
     test_region,
     mock_httpx_post_client,
 ):
@@ -2822,7 +2745,7 @@ def test_create_private_ai_key_http_exception_preservation(
 
     response = client.post(
         "/private-ai-keys/",
-        headers={"Authorization": f"Bearer {admin_token}"},
+        headers={"Authorization": f"Bearer {test_token}"},
         json={"region_id": test_region.id, "name": "Test AI Key"},
     )
 

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,0 +1,211 @@
+"""Regression tests for the Stripe webhook endpoint (`POST /billing/events`).
+
+These guard against the stripe-python v15 breaking change where ``StripeObject``
+no longer subclasses ``dict``. Under v14.x, ``StripeObject`` inherited from
+``Dict`` so ``event.get("id")`` worked; under v15+, ``event.get("id")`` raises
+``AttributeError("get")``, which surfaced as an HTTP 500 on every webhook
+delivery from Stripe (see Stripe's migration guide):
+    https://github.com/stripe/stripe-python/wiki/Migration-guide-for-v15
+
+IMPORTANT: these tests build REAL ``stripe.Event`` objects (via
+``construct_from``), not ``SimpleNamespace`` mocks. A ``SimpleNamespace`` with
+dict ``metadata`` would let ``.get()`` succeed and silently hide the regression.
+A real ``Event`` under the pinned ``requirements.txt`` (``stripe==15.2.0``)
+exhibits the same ``StripeObject`` internals as production and therefore
+reproduces the bug. The handler must use attribute access (``getattr``).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import stripe
+from stripe import Event
+
+from app.db.models import DBStripeProcessedEvent
+
+WEBHOOK_SECRET_KEY = "stripe_webhook_secret"
+
+
+def _make_real_stripe_event(
+    event_id: str = "evt_test_regression_v15",
+    event_type: str = "invoice.paid",
+    customer_id: str = "cus_test_regression",
+    metadata: dict | None = None,
+) -> Event:
+    """Build a REAL ``stripe.Event`` (not a SimpleNamespace).
+
+    Under ``stripe >= 15`` the returned object's internals are ``StripeObject``
+    instances that do NOT support ``.get()`` — exactly matching production.
+    """
+    return Event.construct_from(
+        {
+            "id": event_id,
+            "type": event_type,
+            "data": {
+                "object": {
+                    "customer": customer_id,
+                    "metadata": metadata or {},
+                }
+            },
+        },
+        key="sk_test_regression",
+    )
+
+
+@pytest.fixture
+def webhook_secret_env(monkeypatch):
+    """Set ``WEBHOOK_SIG`` so the handler passes its secret guard.
+
+    The secret value is irrelevant here because ``decode_stripe_event`` is
+    patched in each test; we only need a non-empty value to avoid the 404
+    "not configured" branch.
+    """
+    monkeypatch.setenv("WEBHOOK_SIG", "whsec_test_regression")
+    yield
+
+
+def test_webhook_endpoint_returns_200_for_real_stripe_event(
+    client, db, webhook_secret_env
+):
+    """``POST /billing/events`` must return 200 for a real ``stripe.Event``.
+
+    Regression for the v15 break: the handler previously called
+    ``event.get("id")`` / ``event.get("type")``, which raises
+    ``AttributeError("get")`` under ``stripe >= 15`` and made Stripe see a
+    500 on every webhook delivery. The endpoint must read ``id``/``type`` via
+    attribute access (``getattr``) instead.
+    """
+    real_event = _make_real_stripe_event()
+
+    # decode_stripe_event already handles signature verification (tested
+    # elsewhere); here we feed the handler a real Event to verify the
+    # request path after verification can process a v15 StripeObject.
+    with (
+        patch("app.api.webhooks.decode_stripe_event", return_value=real_event),
+        patch(
+            "app.api.webhooks.handle_stripe_event_background", new_callable=AsyncMock
+        ) as mock_background,
+    ):
+        response = client.post(
+            "/billing/events",
+            content=b'{"id": "evt_test_regression_v15"}',
+            headers={
+                "stripe-signature": "t=1,v1=fake",
+                "content-type": "application/json",
+            },
+        )
+
+    assert response.status_code == 200, (
+        f"expected 200, got {response.status_code}: {response.text}"
+    )
+    # Background processing must be dispatched with the REAL event object.
+    mock_background.assert_awaited_once_with(real_event)
+
+
+def test_webhook_writes_idempotency_claim_from_real_stripe_event(
+    client, db, webhook_secret_env
+):
+    """The idempotency claim row must be written using the real event id.
+
+    This proves the handler extracts ``id``/``type`` from the real
+    ``stripe.Event`` (via ``getattr``) rather than crashing before the insert.
+    Under the buggy ``event.get("id")`` code this raised AttributeError -> 500
+    and no row was ever written.
+    """
+    event_id = "evt_claim_from_real_event"
+    real_event = _make_real_stripe_event(
+        event_id=event_id, event_type="customer.subscription.created"
+    )
+
+    with (
+        patch("app.api.webhooks.decode_stripe_event", return_value=real_event),
+        patch(
+            "app.api.webhooks.handle_stripe_event_background", new_callable=AsyncMock
+        ),
+    ):
+        response = client.post(
+            "/billing/events",
+            content=b'{"id": "evt_claim_from_real_event"}',
+            headers={
+                "stripe-signature": "t=1,v1=fake",
+                "content-type": "application/json",
+            },
+        )
+
+    assert response.status_code == 200, response.text
+
+    claim = (
+        db.query(DBStripeProcessedEvent)
+        .filter(DBStripeProcessedEvent.stripe_event_id == event_id)
+        .first()
+    )
+    assert claim is not None, "idempotency claim row was not written"
+    assert claim.event_type == "customer.subscription.created"
+
+
+def test_webhook_duplicate_real_event_returns_200_not_500(
+    client, db, webhook_secret_env
+):
+    """A duplicate real event hits the idempotency guard and returns 200.
+
+    This exercises the ``IntegrityError`` branch — which the buggy code never
+    reached (it 500'd before the insert). With the fix, the first delivery
+    writes the claim row and a second delivery returns 200 cleanly.
+    """
+    event_id = "evt_duplicate_real_event"
+    real_event = _make_real_stripe_event(event_id=event_id)
+
+    with (
+        patch("app.api.webhooks.decode_stripe_event", return_value=real_event),
+        patch(
+            "app.api.webhooks.handle_stripe_event_background", new_callable=AsyncMock
+        ),
+    ):
+        first = client.post(
+            "/billing/events",
+            content=b'{"id": "evt_duplicate_real_event"}',
+            headers={"stripe-signature": "t=1,v1=fake"},
+        )
+        second = client.post(
+            "/billing/events",
+            content=b'{"id": "evt_duplicate_real_event"}',
+            headers={"stripe-signature": "t=1,v1=fake"},
+        )
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    # Exactly one claim row, despite two deliveries.
+    claims = (
+        db.query(DBStripeProcessedEvent)
+        .filter(DBStripeProcessedEvent.stripe_event_id == event_id)
+        .all()
+    )
+    assert len(claims) == 1
+
+
+def test_real_stripe_metadata_is_not_dict_like():
+    """Guard test: documents the v15 contract that makes ``.get()`` unsafe.
+
+    A real Stripe ``metadata`` object (``StripeObject``) must NOT be a ``dict``
+    subclass under the pinned SDK. If this ever flips back (e.g. a downgrade or
+    SDK revert), ``.get()`` would silently work again and the regression tests
+    above would stop catching it — so this test makes the dependency explicit.
+
+    Under ``stripe < 15`` this test is skipped (metadata IS dict-like there).
+    """
+    if int(stripe.VERSION.split(".")[0]) < 15:
+        pytest.skip(
+            f"stripe-python {stripe.VERSION} still subclasses dict; "
+            "regression only applies to v15+"
+        )
+
+    event = _make_real_stripe_event(metadata={"regionId": "us103"})
+    metadata = event.data.object.metadata
+
+    # Under v15+ this must be a StripeObject, NOT a dict subclass.
+    assert not isinstance(metadata, dict), (
+        "stripe metadata is dict-like; the v15 .get() regression would NOT be "
+        "caught by the endpoint tests above"
+    )
+    # Attribute access is the supported path.
+    assert getattr(metadata, "regionId", None) == "us103"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,4 +1,5 @@
 import pytest
+import stripe
 from app.db.models import (
     DBProduct,
     DBTeamProduct,
@@ -176,7 +177,7 @@ async def test_handle_checkout_session_completed_calls_backfill(
     event_object = SimpleNamespace(
         customer="cus_checkout_completed",
         subscription="sub_checkout_123",
-        metadata={},
+        metadata=stripe.StripeObject.construct_from({}, key="sk_test"),
         client_reference_id=f"{test_team.id}-1",
     )
     event = SimpleNamespace(


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This hotfix migrates Stripe webhook and worker code from dict-style access (`.get("id")`) to attribute access (`getattr(obj, "id", None)`) to be compatible with stripe-python v15, where `StripeObject` no longer subclasses `dict`.

- `app/api/webhooks.py` and `app/core/worker.py` replace all `.get()` / subscript accesses on `StripeObject`-typed variables with `getattr()`, covering event id/type extraction, metadata payment-type detection, and region ID resolution.
- `tests/test_webhooks.py` (new) adds three regression tests that build real `stripe.Event` objects via `construct_from`, directly reproducing the v15 break and verifying the 200 response, idempotency-claim insert, and duplicate-delivery path.
- Test fixtures in `test_periodic_payments.py` and `test_worker.py` are updated to supply real `StripeObject` metadata instead of plain dicts, and `test_private_ai.py` is aligned to the current Drupal/moad delegation flow.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the production changes are narrowly scoped to replacing dict-style access with getattr() throughout the Stripe event handling path, directly fixing a live breakage from the stripe-python v15 upgrade.

The core webhook and worker fixes are correct and well-targeted. The new regression tests build real stripe.Event objects to prevent silent re-regression. The only rough edge is the sub_meta: object annotation in worker.py, which loses useful type information without causing any runtime issue.

app/core/worker.py — the sub_meta type annotation could be more precise; worth a quick look before the next type-checking pass.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/webhooks.py | Replaces event.get("id") / event.get("type") with getattr() — correct v15 fix, no functional regressions. |
| app/core/worker.py | All StripeObject .get() calls migrated to getattr(); sub_meta type annotation changed to object which is technically imprecise but not a runtime issue. |
| tests/test_webhooks.py | New regression test file; builds real stripe.Event objects via construct_from to reproduce the v15 break. Well-structured tests covering 200 response, idempotency claim, and duplicate delivery paths. |
| tests/test_periodic_payments.py | Adds _stripe_meta() helper and updates two fixtures to use real StripeObject metadata, ensuring tests exercise the same object shape as production. |
| tests/test_private_ai.py | Aligns tests to the moad delegation flow and seeds a purchase for the POOL-team blocked-key test; removes some response-shape assertions tied to the old direct provisioning path. |
| tests/test_worker.py | Updates the checkout-session test to supply real StripeObject metadata via construct_from instead of a bare dict. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Stripe
    participant Webhook as POST /billing/events
    participant DB
    participant Worker as handle_stripe_event_background

    Stripe->>Webhook: POST with stripe-signature
    Webhook->>Webhook: decode_stripe_event(payload, sig, secret)
    Note over Webhook: getattr(event, id) ok
    Webhook->>DB: INSERT DBStripeProcessedEvent(event_id, event_type)
    alt duplicate event
        DB-->>Webhook: IntegrityError
        Webhook-->>Stripe: 200 already processed
    else new event
        DB-->>Webhook: OK
        Webhook->>Worker: background_tasks.add_task
        Webhook-->>Stripe: 200
        Worker->>Worker: getattr metadata fields
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Stripe
    participant Webhook as POST /billing/events
    participant DB
    participant Worker as handle_stripe_event_background

    Stripe->>Webhook: POST with stripe-signature
    Webhook->>Webhook: decode_stripe_event(payload, sig, secret)
    Note over Webhook: getattr(event, id) ok
    Webhook->>DB: INSERT DBStripeProcessedEvent(event_id, event_type)
    alt duplicate event
        DB-->>Webhook: IntegrityError
        Webhook-->>Stripe: 200 already processed
    else new event
        DB-->>Webhook: OK
        Webhook->>Worker: background_tasks.add_task
        Webhook-->>Stripe: 200
        Worker->>Worker: getattr metadata fields
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(worker): update subscription me..."](https://github.com/amazeeio/amazee.ai/commit/01caf0242ea1f2485c3500126ab44448b04d0665) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38682586)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->