### PR TITLE
feat(auth): normalize email for user login and registration processes

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -61,6 +61,7 @@ from app.schemas.models import (
 
 from app.api.teams import register_team
 from app.api.users import _create_user_in_db, get_user_by_email
+from app.core.email import normalize_email_for_lookup
 
 auth_logger = logging.getLogger(__name__)
 
@@ -198,7 +199,10 @@ async def login(
         )
 
     auth_logger.info(f"Login attempt for user: {login_data.username}")
-    user = get_user_by_email(db, login_data.username)
+    # Collapse plus-tags (e.g. "user+p12@") to the canonical base email so
+    # login always resolves to the single identity for the human.
+    login_username = normalize_email_for_lookup(login_data.username)
+    user = get_user_by_email(db, login_username)
     if not user or not verify_password(login_data.password, user.hashed_password):
         auth_logger.warning(f"Failed login attempt for user: {login_data.username}")
         raise HTTPException(
@@ -299,6 +303,8 @@ async def register(request: Request, user: UserCreate, db: Session = Depends(get
     After registration, you'll need to login to get an access token.
     """
     auth_logger.info(f"Registration attempt for user: {user.email}")
+    # Normalize plus-tags so registrations collapse to the canonical identity.
+    user.email = normalize_email_for_lookup(user.email)
     # Check if user with this email exists
     db_user = get_user_by_email(db, user.email)
     if db_user:
@@ -346,32 +352,33 @@ async def sign_in(
         )
 
     auth_logger.info(f"Sign-in attempt for user: {sign_in_data.username}")
+    # Collapse plus-tags to the canonical base email so OTP sign-in always
+    # resolves to the single identity for the human (Drupal enters "user+p12@").
+    sign_in_username = normalize_email_for_lookup(sign_in_data.username)
     # Verify the code using DynamoDB first
     dynamodb_service = DynamoDBService()
-    stored_code = dynamodb_service.read_validation_code(sign_in_data.username)
+    stored_code = dynamodb_service.read_validation_code(sign_in_username)
 
     if (
         not stored_code
         or stored_code.get("code").upper() != sign_in_data.verification_code.upper()
     ):
-        auth_logger.warning(
-            f"Invalid verification code for user: {sign_in_data.username}"
-        )
+        auth_logger.warning(f"Invalid verification code for user: {sign_in_username}")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect email or verification code",
         )
 
     # Get user from database after verifying the code
-    user = get_user_by_email(db, sign_in_data.username)
+    user = get_user_by_email(db, sign_in_username)
 
     # If user doesn't exist, create a new user and team
     if not user:
-        auth_logger.info(f"Creating new user and team for: {sign_in_data.username}")
+        auth_logger.info(f"Creating new user and team for: {sign_in_username}")
         # First create the team
         team_data = TeamCreate(
-            name=f"Team {sign_in_data.username}",
-            admin_email=sign_in_data.username,
+            name=f"Team {sign_in_username}",
+            admin_email=sign_in_username,
             phone="",  # Required by schema but not used for auto-created teams
             billing_address="",  # Required by schema but not used for auto-created teams
             budget_type=BudgetType.PERIODIC,
@@ -379,7 +386,7 @@ async def sign_in(
         team = await register_team(team_data, db)
 
         user_data = UserCreate(
-            email=sign_in_data.username,
+            email=sign_in_username,
             password=None,
             team_id=team.id,
             role=UserRole.ADMIN,
@@ -390,7 +397,7 @@ async def sign_in(
             f"Successfully created new user and team for: {sign_in_data.username}"
         )
 
-    auth_logger.info(f"Successful sign-in for user: {sign_in_data.username}")
+    auth_logger.info(f"Successful sign-in for user: {sign_in_username}")
     return create_and_set_access_token(response, user.email, user)
 
 
@@ -404,8 +411,10 @@ def generate_validation_token(email: str) -> str:
     Returns:
         str: The generated validation token (8 characters, alphanumeric, uppercase)
     """
-    # Ensure email is lowercased for consistency
-    email = email.lower()
+    # Normalize plus-tags to the canonical base email so the code is stored
+    # under the same key regardless of which tag variant the user typed. This
+    # must match the read path in /auth/sign-in (which also normalizes).
+    email = normalize_email_for_lookup(email)
 
     # Generate an 8-character alphanumeric code in uppercase
     code = "".join(

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
+from sqlalchemy import func
 from typing import List, Optional
 from fastapi import status
 import logging
@@ -1174,6 +1175,19 @@ async def _delegate_to_moad(
     # return it instead of provisioning a new one. This matches the
     # "one key per Drupal site per region" invariant and prevents key
     # proliferation when Drupal retries the provisioning call.
+    #
+    # SECURITY: the lookup is scoped to keys this user may legitimately own:
+    #   - keys directly owned by the user (owner_id), OR
+    #   - keys whose team was provisioned for this human. moad tags team
+    #     admin_email as "base+team-<tag>@domain"; the base (plus-tag
+    #     stripped) must match the requesting user's base email. This
+    #     prevents a user from guessing another tenant's key name and being
+    #     pinned into that tenant's team.
+    team_base = func.regexp_replace(
+        func.lower(DBTeam.admin_email), r"\+[^@]*@", "@"
+    )
+    current_base = normalize_email_for_lookup(current_user.email).lower()
+
     existing_key = (
         db.query(DBPrivateAIKey)
         .filter(
@@ -1182,6 +1196,10 @@ async def _delegate_to_moad(
         )
         .outerjoin(DBTeam, DBPrivateAIKey.team_id == DBTeam.id)
         .filter((DBPrivateAIKey.team_id.is_(None)) | (DBTeam.deleted_at.is_(None)))
+        .filter(
+            (DBPrivateAIKey.owner_id == current_user.id)
+            | (team_base == current_base)
+        )
         .order_by(DBPrivateAIKey.created_at.desc())
         .first()
     )

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -1183,9 +1183,7 @@ async def _delegate_to_moad(
     #     stripped) must match the requesting user's base email. This
     #     prevents a user from guessing another tenant's key name and being
     #     pinned into that tenant's team.
-    team_base = func.regexp_replace(
-        func.lower(DBTeam.admin_email), r"\+[^@]*@", "@"
-    )
+    team_base = func.regexp_replace(func.lower(DBTeam.admin_email), r"\+[^@]*@", "@")
     current_base = normalize_email_for_lookup(current_user.email).lower()
 
     existing_key = (
@@ -1197,8 +1195,7 @@ async def _delegate_to_moad(
         .outerjoin(DBTeam, DBPrivateAIKey.team_id == DBTeam.id)
         .filter((DBPrivateAIKey.team_id.is_(None)) | (DBTeam.deleted_at.is_(None)))
         .filter(
-            (DBPrivateAIKey.owner_id == current_user.id)
-            | (team_base == current_base)
+            (DBPrivateAIKey.owner_id == current_user.id) | (team_base == current_base)
         )
         .order_by(DBPrivateAIKey.created_at.desc())
         .first()

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -27,6 +27,7 @@ from app.db.models import (
     DBTeam,
     DBSpendCap,
 )
+from app.core.email import normalize_email_for_lookup
 from app.services.litellm import LiteLLMService
 from app.core.security import (
     get_current_user_from_auth,
@@ -1169,8 +1170,37 @@ async def _delegate_to_moad(
             detail="Key provisioning service is not configured.",
         )
 
+    # Idempotency: if the user already has a key for this name + region,
+    # return it instead of provisioning a new one. This matches the
+    # "one key per Drupal site per region" invariant and prevents key
+    # proliferation when Drupal retries the provisioning call.
+    existing_key = (
+        db.query(DBPrivateAIKey)
+        .filter(
+            DBPrivateAIKey.name == private_ai_key.name,
+            DBPrivateAIKey.region_id == private_ai_key.region_id,
+        )
+        .outerjoin(DBTeam, DBPrivateAIKey.team_id == DBTeam.id)
+        .filter((DBPrivateAIKey.team_id.is_(None)) | (DBTeam.deleted_at.is_(None)))
+        .order_by(DBPrivateAIKey.created_at.desc())
+        .first()
+    )
+    if existing_key is not None:
+        logger.info(
+            "[drupal-attribution] reusing existing key %s for %s + region %s",
+            existing_key.id,
+            current_user.email,
+            private_ai_key.region_id,
+        )
+        # Ensure the user is pinned to the key's team (see note below).
+        _pin_user_to_key_team(current_user, existing_key, db)
+        return PrivateAIKey.model_validate(existing_key.to_dict())
+
+    # Send the base email (plus-tags stripped) so moad resolves the real
+    # Keycloak/MOAD identity instead of creating a new tagged surrogate.
+    base_email = normalize_email_for_lookup(current_user.email)
     payload = {
-        "email": current_user.email,
+        "email": base_email,
         "appName": private_ai_key.name,
         "regionId": private_ai_key.region_id,
     }
@@ -1242,4 +1272,34 @@ async def _delegate_to_moad(
             detail="Key provisioning failed: key not found after creation.",
         )
 
+    # Pin the Drupal user to the key's team. moad creates the key under a
+    # team (8748 in the example) that is distinct from the user's auto-team
+    # (8746). Without this, list_private_ai_keys — which scopes by
+    # user.team_id — would never see the key (the original "key never
+    # returned" bug). Once pinned, GET /private-ai-keys and GET /auth/me
+    # both resolve to the team that actually owns the key.
+    _pin_user_to_key_team(current_user, db_key, db)
+
     return PrivateAIKey.model_validate(db_key.to_dict())
+
+
+def _pin_user_to_key_team(
+    current_user: DBUser, db_key: DBPrivateAIKey, db: Session
+) -> None:
+    """
+    Pin ``current_user`` to the team that owns ``db_key``.
+
+    Idempotent: no-op when the user is already on the key's team. Skipped
+    for keys without a team (team_id is None) since there is nothing to pin.
+    """
+    if db_key.team_id is None or current_user.team_id == db_key.team_id:
+        return
+    logger.info(
+        "[drupal-attribution] pinning user %s to team %s (was %s)",
+        current_user.id,
+        db_key.team_id,
+        current_user.team_id,
+    )
+    current_user.team_id = db_key.team_id
+    db.commit()
+    db.refresh(current_user)

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -69,10 +69,37 @@ def get_user_by_email(db: Session, email: str) -> Optional[DBUser]:
     Plus-tags (e.g. "user+p12@") are stripped to the canonical base email so
     that all tag variants resolve to the single identity for the human. This
     prevents identity fragmentation across Drupal, moad, and the amazee.ai API.
+
+    Backward compatibility: if no user matches the normalized form, fall back
+    to an exact (case-insensitive) match on the raw input. This keeps legacy
+    users whose stored email still contains a plus-tag (created before
+    normalization was enforced) login-able until their row is migrated to the
+    base form. The normalized match is preferred when both exist so new,
+    canonical identities always win over stale tagged duplicates.
     """
     normalized = normalize_email_for_lookup(email)
+    raw = email.lower()
+
+    # Fast path: the two queries collapse to one when the input is already
+    # normalized (no plus-tag), which is the common case.
+    if normalized == raw:
+        return (
+            db.query(DBUser)
+            .filter(func.lower(DBUser.email) == normalized)
+            .first()
+        )
+
+    # Plus-tag input: try the normalized identity first, then fall back to the
+    # exact tagged form for legacy rows.
+    normalized_user = (
+        db.query(DBUser)
+        .filter(func.lower(DBUser.email) == normalized)
+        .first()
+    )
+    if normalized_user is not None:
+        return normalized_user
     return (
-        db.query(DBUser).filter(func.lower(DBUser.email) == normalized.lower()).first()
+        db.query(DBUser).filter(func.lower(DBUser.email) == raw).first()
     )
 
 

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -83,24 +83,16 @@ def get_user_by_email(db: Session, email: str) -> Optional[DBUser]:
     # Fast path: the two queries collapse to one when the input is already
     # normalized (no plus-tag), which is the common case.
     if normalized == raw:
-        return (
-            db.query(DBUser)
-            .filter(func.lower(DBUser.email) == normalized)
-            .first()
-        )
+        return db.query(DBUser).filter(func.lower(DBUser.email) == normalized).first()
 
     # Plus-tag input: try the normalized identity first, then fall back to the
     # exact tagged form for legacy rows.
     normalized_user = (
-        db.query(DBUser)
-        .filter(func.lower(DBUser.email) == normalized)
-        .first()
+        db.query(DBUser).filter(func.lower(DBUser.email) == normalized).first()
     )
     if normalized_user is not None:
         return normalized_user
-    return (
-        db.query(DBUser).filter(func.lower(DBUser.email) == raw).first()
-    )
+    return db.query(DBUser).filter(func.lower(DBUser.email) == raw).first()
 
 
 router = APIRouter(tags=["users"])

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -64,9 +64,16 @@ _USER_SPEND_SEMAPHORE = asyncio.Semaphore(10)
 
 def get_user_by_email(db: Session, email: str) -> Optional[DBUser]:
     """
-    Get a user by email (case-insensitive).
+    Get a user by email (case-insensitive, plus-tag insensitive).
+
+    Plus-tags (e.g. "user+p12@") are stripped to the canonical base email so
+    that all tag variants resolve to the single identity for the human. This
+    prevents identity fragmentation across Drupal, moad, and the amazee.ai API.
     """
-    return db.query(DBUser).filter(func.lower(DBUser.email) == email.lower()).first()
+    normalized = normalize_email_for_lookup(email)
+    return (
+        db.query(DBUser).filter(func.lower(DBUser.email) == normalized.lower()).first()
+    )
 
 
 router = APIRouter(tags=["users"])

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -73,7 +73,12 @@ async def get_current_user(
     except JWTError:
         raise credentials_exception
 
-    email: str = payload.get("sub")
+    raw_email: str = payload.get("sub")
+    # Normalize plus-tags so a token minted for "user+p12@" still resolves
+    # to the single canonical "user@" identity (see app/core/email.py).
+    from app.core.email import normalize_email_for_lookup
+
+    email = normalize_email_for_lookup(raw_email) if raw_email else raw_email
     user = (
         db.query(DBUser)
         .filter(func.lower(DBUser.email) == email.lower())

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -7,6 +7,7 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 import logging
 
 from app.core.config import settings
+from app.core.email import normalize_email_for_lookup
 from app.db.database import get_db
 from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import func, inspect as sa_inspect
@@ -76,8 +77,6 @@ async def get_current_user(
     raw_email: str = payload.get("sub")
     # Normalize plus-tags so a token minted for "user+p12@" still resolves
     # to the single canonical "user@" identity (see app/core/email.py).
-    from app.core.email import normalize_email_for_lookup
-
     email = normalize_email_for_lookup(raw_email) if raw_email else raw_email
     user = (
         db.query(DBUser)

--- a/tests/test_drupal_attribution.py
+++ b/tests/test_drupal_attribution.py
@@ -295,3 +295,106 @@ def test_delegation_pins_user_to_key_team(
     # The user is now pinned to the key's team.
     db.refresh(user)
     assert user.team_id == moad_team.id
+
+
+# ---------------------------------------------------------------------------
+# 6. Security: a guessed name from a different tenant is NOT reused
+# ---------------------------------------------------------------------------
+
+
+@patch("app.api.private_ai_keys.settings")
+@patch("httpx.AsyncClient")
+def test_idempotency_does_not_leak_cross_tenant_key(
+    mock_client_cls, mock_settings, drupal_client, db, test_region
+):
+    """A user requesting a name that matches ANOTHER tenant's key must not
+    receive that key or be pinned to that tenant's team.
+
+    Regression test for the cross-tenant leak: the idempotency lookup must be
+    scoped to the requesting user's own teams, not a global name+region match.
+    """
+    mock_settings.MOAD_DASHBOARD_API_URL = "http://mock-moad"
+    mock_settings.MOAD_DASHBOARD_API_TOKEN = "mock-token"
+
+    # Victim tenant: a different human with their own team + key.
+    victim_team = DBTeam(
+        name="victim-team",
+        admin_email="victim+team-abc@example.com",
+        is_active=True,
+    )
+    db.add(victim_team)
+    db.commit()
+    db.refresh(victim_team)
+    victim_key = DBPrivateAIKey(
+        name="secret-key",  # the name the attacker will guess
+        litellm_token="victim-secret-token",
+        litellm_api_url="http://victim-llm",
+        database_name="db",
+        database_host="host",
+        database_username="u",
+        database_password="p",
+        region_id=test_region.id,
+        team_id=victim_team.id,
+    )
+    db.add(victim_key)
+    db.commit()
+
+    # Attacker: a different user, not a member of victim_team.
+    attacker = _make_user(db, email="attacker@example.com")
+    attacker_token = _login(drupal_client, attacker)
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    # moad returns a fresh token that resolves to NO local key — the handler
+    # will 502, but that's fine: we only assert moad was called (no reuse).
+    mock_response.json.return_value = {"llm": {"token": "attacker-fresh-token"}}
+    mock_http = AsyncMock()
+    mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+    mock_http.__aexit__ = AsyncMock(return_value=False)
+    mock_http.post = AsyncMock(return_value=mock_response)
+    mock_client_cls.return_value = mock_http
+
+    # Attacker POSTs the victim's key NAME + same region.
+    response = drupal_client.post(
+        "/private-ai-keys",
+        json={"region_id": test_region.id, "name": "secret-key"},
+        headers={"Authorization": f"Bearer {attacker_token}"},
+    )
+
+    # The victim's key must NOT be reused: moad WAS called.
+    mock_http.post.assert_called()
+    # The attacker is NOT pinned to the victim's team.
+    db.refresh(attacker)
+    assert attacker.team_id != victim_team.id
+
+
+# ---------------------------------------------------------------------------
+# 7. Legacy compatibility: a stored +tag email is still found
+# ---------------------------------------------------------------------------
+
+
+def test_get_user_by_email_falls_back_to_tagged_row(db):
+    """A legacy user whose stored email contains a +tag is still lookup-able.
+
+    Regression test for the backward-compat break flagged in review:
+    normalization must not orphan pre-existing tagged rows.
+    """
+    from app.api.users import get_user_by_email
+
+    legacy = DBUser(
+        email="legacy+newsletter@example.com",
+        hashed_password=get_password_hash("testpassword"),
+        is_active=True,
+        is_admin=False,
+        role=UserRole.DEFAULT,
+    )
+    db.add(legacy)
+    db.commit()
+    db.refresh(legacy)
+
+    # Lookup with the exact tagged address finds the legacy row via the
+    # exact-match fallback (normalized lookup misses because no canonical
+    # base row exists yet).
+    found = get_user_by_email(db, "legacy+newsletter@example.com")
+    assert found is not None
+    assert found.id == legacy.id

--- a/tests/test_drupal_attribution.py
+++ b/tests/test_drupal_attribution.py
@@ -355,7 +355,7 @@ def test_idempotency_does_not_leak_cross_tenant_key(
     mock_client_cls.return_value = mock_http
 
     # Attacker POSTs the victim's key NAME + same region.
-    response = drupal_client.post(
+    drupal_client.post(
         "/private-ai-keys",
         json={"region_id": test_region.id, "name": "secret-key"},
         headers={"Authorization": f"Bearer {attacker_token}"},

--- a/tests/test_drupal_attribution.py
+++ b/tests/test_drupal_attribution.py
@@ -7,7 +7,7 @@ When X-Amazee-Source: frontend is present the direct creation path is used.
 
 from unittest.mock import patch, MagicMock, AsyncMock
 
-from app.db.models import DBPrivateAIKey, DBUser
+from app.db.models import DBPrivateAIKey, DBUser, DBTeam
 from app.core.security import get_password_hash
 from app.core.roles import UserRole
 
@@ -65,8 +65,12 @@ def test_no_header_delegates_to_moad(
     token = _login(drupal_client, user)
 
     litellm_token = "drupal-key-001"
+    # Use a distinct name from the POSTed key ("test-key") so the idempotency
+    # check (which matches on name + region) does not short-circuit and the
+    # full delegation path is exercised. This key is found afterwards via the
+    # litellm_token lookup that follows the moad call.
     pre_created_key = DBPrivateAIKey(
-        name="test-key",
+        name="pre-seeded-key",
         litellm_token=litellm_token,
         litellm_api_url="http://test-llm",
         database_name="db",
@@ -176,3 +180,118 @@ def test_no_header_moad_not_configured_returns_503(
     response = _post_key(drupal_client, token, test_region.id)
 
     assert response.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# 4. Idempotency: existing key for name + region is reused (no moad call)
+# ---------------------------------------------------------------------------
+
+
+@patch("app.api.private_ai_keys.settings")
+@patch("httpx.AsyncClient")
+def test_existing_key_name_region_reuses_no_moad_call(
+    mock_client_cls, mock_settings, drupal_client, db, test_region
+):
+    """A second request with the same name + region reuses the existing key.
+
+    This prevents key proliferation when Drupal retries the provisioning call.
+    moad must NOT be called on the reuse path.
+    """
+    mock_settings.MOAD_DASHBOARD_API_URL = "http://mock-moad"
+    mock_settings.MOAD_DASHBOARD_API_TOKEN = "mock-token"
+
+    user = _make_user(db)
+    token = _login(drupal_client, user)
+
+    # Pre-create a key with the SAME name + region the POST will use.
+    team = DBTeam(name="moad-team", admin_email=user.email, is_active=True)
+    db.add(team)
+    db.commit()
+    db.refresh(team)
+    existing_key = DBPrivateAIKey(
+        name="test-key",
+        litellm_token="existing-token",
+        litellm_api_url="http://test-llm",
+        database_name="db",
+        database_host="host",
+        database_username="u",
+        database_password="p",
+        region_id=test_region.id,
+        team_id=team.id,
+    )
+    db.add(existing_key)
+    db.commit()
+
+    mock_http = AsyncMock()
+    mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+    mock_http.__aexit__ = AsyncMock(return_value=False)
+    mock_http.post = AsyncMock()
+    mock_client_cls.return_value = mock_http
+
+    response = _post_key(drupal_client, token, test_region.id)
+
+    assert response.status_code == 200
+    # moad was NOT called — the existing key was reused.
+    mock_http.post.assert_not_called()
+    # The returned key is the existing one.
+    assert response.json()["litellm_token"] == "existing-token"
+
+
+# ---------------------------------------------------------------------------
+# 5. Team pinning: after delegation the user is pinned to the key's team
+# ---------------------------------------------------------------------------
+
+
+@patch("app.api.private_ai_keys.settings")
+@patch("httpx.AsyncClient")
+def test_delegation_pins_user_to_key_team(
+    mock_client_cls, mock_settings, drupal_client, db, test_region
+):
+    """After moad delegation the user's team_id is set to the key's team.
+
+    This is the core fix for the "key never returned" bug: without pinning,
+    list_private_ai_keys (scoped by user.team_id) would never see the key.
+    """
+    mock_settings.MOAD_DASHBOARD_API_URL = "http://mock-moad"
+    mock_settings.MOAD_DASHBOARD_API_TOKEN = "mock-token"
+
+    user = _make_user(db)
+    token = _login(drupal_client, user)
+
+    # The team moad will have created the key under (different from user's).
+    moad_team = DBTeam(name="moad-team", admin_email=user.email, is_active=True)
+    db.add(moad_team)
+    db.commit()
+    db.refresh(moad_team)
+
+    litellm_token = "drupal-key-002"
+    # Distinct name so idempotency doesn't short-circuit.
+    pre_created_key = DBPrivateAIKey(
+        name="pre-seeded-key-2",
+        litellm_token=litellm_token,
+        litellm_api_url="http://test-llm",
+        database_name="db",
+        database_host="host",
+        database_username="u",
+        database_password="p",
+        region_id=test_region.id,
+        team_id=moad_team.id,
+    )
+    db.add(pre_created_key)
+    db.commit()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"llm": {"token": litellm_token}}
+    mock_http = AsyncMock()
+    mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+    mock_http.__aexit__ = AsyncMock(return_value=False)
+    mock_http.post = AsyncMock(return_value=mock_response)
+    mock_client_cls.return_value = mock_http
+
+    response = _post_key(drupal_client, token, test_region.id)
+
+    assert response.status_code == 200
+    # The user is now pinned to the key's team.
+    db.refresh(user)
+    assert user.team_id == moad_team.id


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR normalizes email addresses (stripping RFC 5321 plus-tags such as `user+p12@domain` down to `user@domain`) at every authentication boundary — login, registration, OTP sign-in, JWT validation, and the moad key-provisioning delegation path. It also adds an idempotency check to `_delegate_to_moad` that reuses an existing key when the same name + region is requested again, scoped to the calling user's teams to prevent cross-tenant leakage, and introduces `_pin_user_to_key_team` to fix the "key never returned" bug.

- **Email normalization** (`app/core/email.py`, `auth.py`, `users.py`, `security.py`): plus-tags are stripped consistently at every auth entry point; `get_user_by_email` retains a backward-compat fallback that still finds legacy rows whose stored email contains a tag.
- **Idempotency + team pinning** (`private_ai_keys.py`): a new SQL query (scoped via `regexp_replace` on `DBTeam.admin_email`) prevents duplicate key provisioning on Drupal retries; after any provisioning the user is pinned to the key's owning team so `GET /private-ai-keys` returns it correctly.
- **Tests** (`test_drupal_attribution.py`): four new integration tests cover reuse, team pinning, cross-tenant isolation, and legacy tagged-row backward compatibility.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; normalization is consistent across all auth paths and the idempotency security boundary is well-tested.

The inline import inside `get_current_user` and the partial normalization in `send_validation_code` are the only items worth addressing, and neither causes incorrect behavior today. The cross-tenant idempotency scoping, the backward-compat fallback in `get_user_by_email`, and the team-pinning logic are all sound and covered by the new tests.

`app/core/security.py` for the inline import, and `app/api/auth.py` (`send_validation_code`) for consistent normalization.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/core/email.py | New module with `normalize_email_for_lookup`: strips plus-tags and lowercases. Simple and correct, but no guard for `None` input (relies on all callers passing a valid string). |
| app/api/auth.py | Normalization applied consistently at login, register, sign-in, and `generate_validation_token`. `send_validation_code` still only lowercases before calling generate (functional but slightly inconsistent; `generate_validation_token` normalizes internally so it still works correctly). |
| app/api/users.py | `get_user_by_email` updated with plus-tag-aware lookup: normalized match preferred, legacy tagged-row fallback for backward compat. Two DB queries on the tagged-input path is acceptable given the migration context. |
| app/core/security.py | `get_current_user` now normalizes the JWT `sub` claim before the DB lookup. The `normalize_email_for_lookup` import is placed inline inside the function body instead of at the module level, which runs on every authenticated request. |
| app/api/private_ai_keys.py | Adds idempotency check (name+region, scoped to caller's teams via SQL regexp_replace) and `_pin_user_to_key_team`. Security boundary is sound; base email is sent to moad instead of tagged variant. |
| tests/test_drupal_attribution.py | Adds four new integration tests covering idempotency reuse, team pinning, cross-tenant isolation, and legacy tagged-row backward compat. Good coverage of the security boundary. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant D as Drupal Client
    participant A as API (auth.py)
    participant Email as normalize_email_for_lookup
    participant DB as Database
    participant Dyn as DynamoDB
    participant MOAD as moad service

    note over D,MOAD: OTP / sign-in flow (Drupal)
    D->>A: POST /auth/request-token
    A->>Email: normalize(email)
    Email-->>A: base_email
    A->>Dyn: store_code(base_email, code)
    A->>D: code emailed

    D->>A: POST /auth/sign-in
    A->>Email: normalize(username)
    Email-->>A: base_email
    A->>Dyn: read_code(base_email)
    Dyn-->>A: stored code
    A->>DB: get_user_by_email(base_email)
    DB-->>A: user
    A->>D: access_token

    note over D,MOAD: Key provisioning
    D->>A: POST /private-ai-keys
    A->>Email: normalize(current_user.email)
    Email-->>A: base_email
    A->>DB: query existing key (name+region scoped to user/team)
    alt key already exists
        DB-->>A: existing_key
        A->>DB: pin user to key team
        A->>D: return existing key
    else no existing key
        A->>MOAD: provision-key (base_email)
        MOAD-->>A: litellm_token
        A->>DB: lookup key by token
        A->>DB: pin user to key team
        A->>D: return new key
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant D as Drupal Client
    participant A as API (auth.py)
    participant Email as normalize_email_for_lookup
    participant DB as Database
    participant Dyn as DynamoDB
    participant MOAD as moad service

    note over D,MOAD: OTP / sign-in flow (Drupal)
    D->>A: POST /auth/request-token
    A->>Email: normalize(email)
    Email-->>A: base_email
    A->>Dyn: store_code(base_email, code)
    A->>D: code emailed

    D->>A: POST /auth/sign-in
    A->>Email: normalize(username)
    Email-->>A: base_email
    A->>Dyn: read_code(base_email)
    Dyn-->>A: stored code
    A->>DB: get_user_by_email(base_email)
    DB-->>A: user
    A->>D: access_token

    note over D,MOAD: Key provisioning
    D->>A: POST /private-ai-keys
    A->>Email: normalize(current_user.email)
    Email-->>A: base_email
    A->>DB: query existing key (name+region scoped to user/team)
    alt key already exists
        DB-->>A: existing_key
        A->>DB: pin user to key team
        A->>D: return existing key
    else no existing key
        A->>MOAD: provision-key (base_email)
        MOAD-->>A: litellm_token
        A->>DB: lookup key by token
        A->>DB: pin user to key team
        A->>D: return new key
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `app/core/security.py`, line 9-10 ([link](https://github.com/amazeeio/amazee.ai/blob/a02791c8a7c6fed997d23878cc0ebd2594353e34/app/core/security.py#L9-L10)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The corresponding module-level import should be added alongside the other `app.core.*` imports at the top of the file.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


2. `app/api/auth.py`, line 442-443 ([link](https://github.com/amazeeio/amazee.ai/blob/a02791c8a7c6fed997d23878cc0ebd2594353e34/app/api/auth.py#L442-L443)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`send_validation_code` doesn't normalize the email before the `get_user_by_email` call**

   `email = email.lower()` is applied before passing to `get_user_by_email`, but the plus-tag is NOT stripped at this point. This is functionally correct today because `get_user_by_email` normalizes internally, but the email variable used for the SES send and for `auth_logger.info` is still the tagged form (e.g. `user+p12@domain`). For consistency with the rest of the auth flow, consider applying `normalize_email_for_lookup` here instead of a bare `.lower()`, so the function works on the canonical identity from the start.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["style: Clean up code formatting in priva..."](https://github.com/amazeeio/amazee.ai/commit/a02791c8a7c6fed997d23878cc0ebd2594353e34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39008117)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->