### PR TITLE
refactor(api): improve key provisioning logic for team and region mat…

### DIFF
--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -1184,15 +1184,35 @@ async def _delegate_to_moad(
     # (current_user.team_id), cross-tenant leakage is impossible by
     # construction — there is no global name+region match to exploit.
     existing_key = None
+    base_email = normalize_email_for_lookup(current_user.email).lower()
+
     if current_user.team_id is not None:
         existing_key = (
             db.query(DBPrivateAIKey)
+            .join(DBTeam, DBPrivateAIKey.team_id == DBTeam.id)
             .filter(
                 DBPrivateAIKey.region_id == private_ai_key.region_id,
                 DBPrivateAIKey.team_id == current_user.team_id,
+                DBTeam.deleted_at.is_(None),
             )
-            .outerjoin(DBTeam, DBPrivateAIKey.team_id == DBTeam.id)
-            .filter((DBPrivateAIKey.team_id.is_(None)) | (DBTeam.deleted_at.is_(None)))
+            .order_by(DBPrivateAIKey.created_at.desc())
+            .first()
+        )
+
+    # Fallback for retries before pinning: look up the key under any team whose
+    # admin_email matches this user (including moad’s +tagged surrogate teams).
+    if existing_key is None:
+        local, domain = base_email.split("@", 1)
+        tag_pattern = f"{local}+%@{domain}"
+        existing_key = (
+            db.query(DBPrivateAIKey)
+            .join(DBTeam, DBPrivateAIKey.team_id == DBTeam.id)
+            .filter(
+                DBPrivateAIKey.region_id == private_ai_key.region_id,
+                DBTeam.deleted_at.is_(None),
+                (DBTeam.admin_email.ilike(base_email))
+                | (DBTeam.admin_email.ilike(tag_pattern)),
+            )
             .order_by(DBPrivateAIKey.created_at.desc())
             .first()
         )

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -1199,9 +1199,32 @@ async def _delegate_to_moad(
             .first()
         )
 
-    # Fallback for retries before pinning: look up the key under any team whose
-    # admin_email matches this user (including moad’s +tagged surrogate teams).
-    if existing_key is None:
+    # Fallback: the team-scoped lookup above missed a reusable key. Look up
+    # any key under a team whose admin_email belongs to this same human —
+    # either the exact base email or moad’s +tagged surrogate variants
+    # (e.g. "base+team-abc@domain").
+    #
+    # This covers two cases:
+    #   1. Retry before pinning completed: moad already created the key under a
+    #      fresh team, but current_user.team_id still points at the stale
+    #      auto-team, so the team-scoped query missed it.
+    #   2. Region switch: the user was previously pinned to team T1 (region 1)
+    #      and is now requesting region 2, for which moad has already created
+    #      team T2. The team-scoped query (T1 + region 2) correctly misses;
+    #      this fallback finds the T2 key and re-pins the user to T2.
+    #
+    # The re-pinning in case 2 is intentional: the design is one key / one
+    # region at a time per user (scalar team_id models the user’s current
+    # region). Without this fallback, moad would be re-invoked and would mint
+    # a duplicate key (its provision-key endpoint is deliberately
+    # non-idempotent).
+    #
+    # SECURITY: admin_email matching is scoped to this human’s identity (base
+    # form + moad tag variants), so cross-tenant collision is impossible.
+    # Guard on "@" so a malformed stored email (no @, bypassing validators)
+    # skips this branch and degrades to moad delegation instead of crashing on
+    # the unpack below.
+    if existing_key is None and "@" in base_email:
         local, domain = base_email.split("@", 1)
         tag_pattern = f"{local}+%@{domain}"
         existing_key = (

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -1,6 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
-from sqlalchemy import func
 from typing import List, Optional
 from fastapi import status
 import logging
@@ -1171,35 +1170,32 @@ async def _delegate_to_moad(
             detail="Key provisioning service is not configured.",
         )
 
-    # Idempotency: if the user already has a key for this name + region,
+    # Idempotency: if the user's team already has a key for this region,
     # return it instead of provisioning a new one. This matches the
-    # "one key per Drupal site per region" invariant and prevents key
+    # "one key per team per region" invariant and prevents key
     # proliferation when Drupal retries the provisioning call.
     #
-    # SECURITY: the lookup is scoped to keys this user may legitimately own:
-    #   - keys directly owned by the user (owner_id), OR
-    #   - keys whose team was provisioned for this human. moad tags team
-    #     admin_email as "base+team-<tag>@domain"; the base (plus-tag
-    #     stripped) must match the requesting user's base email. This
-    #     prevents a user from guessing another tenant's key name and being
-    #     pinned into that tenant's team.
-    team_base = func.regexp_replace(func.lower(DBTeam.admin_email), r"\+[^@]*@", "@")
-    current_base = normalize_email_for_lookup(current_user.email).lower()
-
-    existing_key = (
-        db.query(DBPrivateAIKey)
-        .filter(
-            DBPrivateAIKey.name == private_ai_key.name,
-            DBPrivateAIKey.region_id == private_ai_key.region_id,
+    # The match is intentionally name-agnostic: moad stores the key name as
+    # "<appName> - <date>" (it stamps a date suffix), while Drupal sends the
+    # bare appName — so a name-based match would never fire. Matching on
+    # team + region is both more robust and the true invariant.
+    #
+    # SECURITY: because we only ever look at the requesting user's OWN team
+    # (current_user.team_id), cross-tenant leakage is impossible by
+    # construction — there is no global name+region match to exploit.
+    existing_key = None
+    if current_user.team_id is not None:
+        existing_key = (
+            db.query(DBPrivateAIKey)
+            .filter(
+                DBPrivateAIKey.region_id == private_ai_key.region_id,
+                DBPrivateAIKey.team_id == current_user.team_id,
+            )
+            .outerjoin(DBTeam, DBPrivateAIKey.team_id == DBTeam.id)
+            .filter((DBPrivateAIKey.team_id.is_(None)) | (DBTeam.deleted_at.is_(None)))
+            .order_by(DBPrivateAIKey.created_at.desc())
+            .first()
         )
-        .outerjoin(DBTeam, DBPrivateAIKey.team_id == DBTeam.id)
-        .filter((DBPrivateAIKey.team_id.is_(None)) | (DBTeam.deleted_at.is_(None)))
-        .filter(
-            (DBPrivateAIKey.owner_id == current_user.id) | (team_base == current_base)
-        )
-        .order_by(DBPrivateAIKey.created_at.desc())
-        .first()
-    )
     if existing_key is not None:
         logger.info(
             "[drupal-attribution] reusing existing key %s for %s + region %s",

--- a/scripts/restore_database.py
+++ b/scripts/restore_database.py
@@ -320,12 +320,7 @@ def detect_database_name(dump_dir, config):
             if re.match(r"^;\s+dbname:", stripped):
                 return stripped.split(":", 1)[1].strip()
     except Exception as e:
-        print(
-            sanitize(
-                f"  Warning: Could not detect source database name from backup: {e}",
-                config,
-            )
-        )
+        print(sanitize(f"  Warning: Could not detect source database name from backup: {e}", config))
     return None
 
 
@@ -333,9 +328,7 @@ def recreate_target_db(config):
     """Drop and recreate the target database to ensure a clean restore without constraint errors."""
     db_name = config["database"]
     if not validate_db_name(db_name):
-        raise SystemExit(
-            "Error: Database name is invalid. Only alphanumeric characters and underscores are allowed."
-        )
+        raise SystemExit("Error: Database name is invalid. Only alphanumeric characters and underscores are allowed.")
 
     print("  Recreating target database...")
 
@@ -352,7 +345,9 @@ def recreate_target_db(config):
     try:
         run_pg_tool(terminate_cmd, config, check=False)
     except subprocess.CalledProcessError:
-        warning_msg = "  Warning: Could not terminate all active connections for database (continuing)."
+        warning_msg = (
+            "  Warning: Could not terminate all active connections for database (continuing)."
+        )
         print(warning_msg)
 
     # 2. Drop database if exists
@@ -366,9 +361,7 @@ def recreate_target_db(config):
     try:
         run_pg_tool(drop_cmd, config)
     except subprocess.CalledProcessError as e:
-        raise SystemExit(
-            sanitize(f"  Failed to drop target database: {e.stderr or e}", config)
-        )
+        raise SystemExit(sanitize(f"  Failed to drop target database: {e.stderr or e}", config))
 
     # 3. Create database
     create_cmd = [
@@ -381,12 +374,7 @@ def recreate_target_db(config):
     try:
         run_pg_tool(create_cmd, config)
     except subprocess.CalledProcessError as e:
-        raise SystemExit(
-            sanitize(
-                f"  Failed to create target database '{db_name}': {e.stderr or e}",
-                config,
-            )
-        )
+        raise SystemExit(sanitize(f"  Failed to create target database '{db_name}': {e.stderr or e}", config))
 
 
 def apply_restore(config, dump_dir, restore_mode="target"):
@@ -554,9 +542,7 @@ def main():
     config = get_db_config()
     target_db = config["database"]
     if not validate_db_name(target_db):
-        print(
-            "Error: Target database name is invalid. Only alphanumeric characters and underscores are allowed."
-        )
+        print("Error: Target database name is invalid. Only alphanumeric characters and underscores are allowed.")
         sys.exit(1)
 
     display_host = _presence(config.get("host"))
@@ -597,16 +583,10 @@ def main():
         restore_mode = args.restore_mode
         if not args.yes:
             if source_db and source_db != target_db:
-                print(
-                    "\nWARNING: The backup source database name differs from your locally-configured target database."
-                )
+                print("\nWARNING: The backup source database name differs from your locally-configured target database.")
                 print("How would you like to restore this database?")
-                print(
-                    "  1) Restore directly into the configured target database (Recommended for local dev - no .env changes needed)"
-                )
-                print(
-                    "  2) Recreate and restore using the backup's original database name (Requires updating DATABASE_URL in .env)"
-                )
+                print("  1) Restore directly into the configured target database (Recommended for local dev - no .env changes needed)")
+                print("  2) Recreate and restore using the backup's original database name (Requires updating DATABASE_URL in .env)")
                 while True:
                     choice = input("\nSelect option [1 or 2]: ").strip()
                     if choice == "1":
@@ -618,19 +598,13 @@ def main():
                     else:
                         print("Invalid choice. Please enter 1 or 2.")
             else:
-                print(
-                    "\nWARNING: This will DROP the existing database and restore from backup."
-                )
+                print("\nWARNING: This will DROP the existing database and restore from backup.")
                 if not args.no_backup:
-                    print(
-                        "A safety backup of the current database will be created first."
-                    )
+                    print("A safety backup of the current database will be created first.")
                 else:
                     print("No safety backup will be created (--no-backup specified).")
                 response = (
-                    input("\nAre you sure you want to proceed? [yes/no]: ")
-                    .strip()
-                    .lower()
+                    input("\nAre you sure you want to proceed? [yes/no]: ").strip().lower()
                 )
                 if response not in ("yes", "y"):
                     print("Aborted.")
@@ -638,28 +612,20 @@ def main():
         else:
             # Non-interactive mode
             if restore_mode == "as-is":
-                print(
-                    "  Non-interactive: Restoring as-is into configured target database"
-                )
+                print("  Non-interactive: Restoring as-is into configured target database")
             else:
                 print("  Non-interactive: Restoring into target database")
 
         # Validate source_db ONLY if we are actually using it in as-is mode
         if restore_mode == "as-is" and source_db:
             if not validate_db_name(source_db):
-                print(
-                    "Error: Detected source database name is invalid for 'as-is' restore."
-                )
-                print(
-                    "Only alphanumeric characters and underscores are allowed for database names."
-                )
+                print("Error: Detected source database name is invalid for 'as-is' restore.")
+                print("Only alphanumeric characters and underscores are allowed for database names.")
                 sys.exit(1)
 
         # Step 2: Backup current database (unless skipped)
         if not args.no_backup:
-            active_db = (
-                source_db if (restore_mode == "as-is" and source_db) else target_db
-            )
+            active_db = source_db if (restore_mode == "as-is" and source_db) else target_db
             backup_msg = "\n[2/3] Backing up current database before restore..."
             print(backup_msg)
             backup_dir = args.backup_dir or os.path.dirname(
@@ -697,7 +663,7 @@ def main():
                 db_exists = False
                 try:
                     res = run_pg_tool(check_cmd, config)
-                    db_exists = res.stdout.strip() == "1"
+                    db_exists = (res.stdout.strip() == "1")
                 except Exception:
                     print(
                         "  Warning: Could not verify whether the target database exists. Assuming it does not exist and skipping safety backup.",
@@ -733,9 +699,7 @@ def main():
         print("\nRestore complete!")
 
         if restore_mode == "as-is" and source_db and source_db != target_db:
-            print(
-                "\nIMPORTANT: To connect your application to this database, update DATABASE_URL in your .env file."
-            )
+            print("\nIMPORTANT: To connect your application to this database, update DATABASE_URL in your .env file.")
 
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)

--- a/scripts/restore_database.py
+++ b/scripts/restore_database.py
@@ -320,7 +320,12 @@ def detect_database_name(dump_dir, config):
             if re.match(r"^;\s+dbname:", stripped):
                 return stripped.split(":", 1)[1].strip()
     except Exception as e:
-        print(sanitize(f"  Warning: Could not detect source database name from backup: {e}", config))
+        print(
+            sanitize(
+                f"  Warning: Could not detect source database name from backup: {e}",
+                config,
+            )
+        )
     return None
 
 
@@ -328,7 +333,9 @@ def recreate_target_db(config):
     """Drop and recreate the target database to ensure a clean restore without constraint errors."""
     db_name = config["database"]
     if not validate_db_name(db_name):
-        raise SystemExit("Error: Database name is invalid. Only alphanumeric characters and underscores are allowed.")
+        raise SystemExit(
+            "Error: Database name is invalid. Only alphanumeric characters and underscores are allowed."
+        )
 
     print("  Recreating target database...")
 
@@ -345,9 +352,7 @@ def recreate_target_db(config):
     try:
         run_pg_tool(terminate_cmd, config, check=False)
     except subprocess.CalledProcessError:
-        warning_msg = (
-            "  Warning: Could not terminate all active connections for database (continuing)."
-        )
+        warning_msg = "  Warning: Could not terminate all active connections for database (continuing)."
         print(warning_msg)
 
     # 2. Drop database if exists
@@ -361,7 +366,9 @@ def recreate_target_db(config):
     try:
         run_pg_tool(drop_cmd, config)
     except subprocess.CalledProcessError as e:
-        raise SystemExit(sanitize(f"  Failed to drop target database: {e.stderr or e}", config))
+        raise SystemExit(
+            sanitize(f"  Failed to drop target database: {e.stderr or e}", config)
+        )
 
     # 3. Create database
     create_cmd = [
@@ -374,7 +381,12 @@ def recreate_target_db(config):
     try:
         run_pg_tool(create_cmd, config)
     except subprocess.CalledProcessError as e:
-        raise SystemExit(sanitize(f"  Failed to create target database '{db_name}': {e.stderr or e}", config))
+        raise SystemExit(
+            sanitize(
+                f"  Failed to create target database '{db_name}': {e.stderr or e}",
+                config,
+            )
+        )
 
 
 def apply_restore(config, dump_dir, restore_mode="target"):
@@ -542,7 +554,9 @@ def main():
     config = get_db_config()
     target_db = config["database"]
     if not validate_db_name(target_db):
-        print("Error: Target database name is invalid. Only alphanumeric characters and underscores are allowed.")
+        print(
+            "Error: Target database name is invalid. Only alphanumeric characters and underscores are allowed."
+        )
         sys.exit(1)
 
     display_host = _presence(config.get("host"))
@@ -583,10 +597,16 @@ def main():
         restore_mode = args.restore_mode
         if not args.yes:
             if source_db and source_db != target_db:
-                print("\nWARNING: The backup source database name differs from your locally-configured target database.")
+                print(
+                    "\nWARNING: The backup source database name differs from your locally-configured target database."
+                )
                 print("How would you like to restore this database?")
-                print("  1) Restore directly into the configured target database (Recommended for local dev - no .env changes needed)")
-                print("  2) Recreate and restore using the backup's original database name (Requires updating DATABASE_URL in .env)")
+                print(
+                    "  1) Restore directly into the configured target database (Recommended for local dev - no .env changes needed)"
+                )
+                print(
+                    "  2) Recreate and restore using the backup's original database name (Requires updating DATABASE_URL in .env)"
+                )
                 while True:
                     choice = input("\nSelect option [1 or 2]: ").strip()
                     if choice == "1":
@@ -598,13 +618,19 @@ def main():
                     else:
                         print("Invalid choice. Please enter 1 or 2.")
             else:
-                print("\nWARNING: This will DROP the existing database and restore from backup.")
+                print(
+                    "\nWARNING: This will DROP the existing database and restore from backup."
+                )
                 if not args.no_backup:
-                    print("A safety backup of the current database will be created first.")
+                    print(
+                        "A safety backup of the current database will be created first."
+                    )
                 else:
                     print("No safety backup will be created (--no-backup specified).")
                 response = (
-                    input("\nAre you sure you want to proceed? [yes/no]: ").strip().lower()
+                    input("\nAre you sure you want to proceed? [yes/no]: ")
+                    .strip()
+                    .lower()
                 )
                 if response not in ("yes", "y"):
                     print("Aborted.")
@@ -612,20 +638,28 @@ def main():
         else:
             # Non-interactive mode
             if restore_mode == "as-is":
-                print("  Non-interactive: Restoring as-is into configured target database")
+                print(
+                    "  Non-interactive: Restoring as-is into configured target database"
+                )
             else:
                 print("  Non-interactive: Restoring into target database")
 
         # Validate source_db ONLY if we are actually using it in as-is mode
         if restore_mode == "as-is" and source_db:
             if not validate_db_name(source_db):
-                print("Error: Detected source database name is invalid for 'as-is' restore.")
-                print("Only alphanumeric characters and underscores are allowed for database names.")
+                print(
+                    "Error: Detected source database name is invalid for 'as-is' restore."
+                )
+                print(
+                    "Only alphanumeric characters and underscores are allowed for database names."
+                )
                 sys.exit(1)
 
         # Step 2: Backup current database (unless skipped)
         if not args.no_backup:
-            active_db = source_db if (restore_mode == "as-is" and source_db) else target_db
+            active_db = (
+                source_db if (restore_mode == "as-is" and source_db) else target_db
+            )
             backup_msg = "\n[2/3] Backing up current database before restore..."
             print(backup_msg)
             backup_dir = args.backup_dir or os.path.dirname(
@@ -663,7 +697,7 @@ def main():
                 db_exists = False
                 try:
                     res = run_pg_tool(check_cmd, config)
-                    db_exists = (res.stdout.strip() == "1")
+                    db_exists = res.stdout.strip() == "1"
                 except Exception:
                     print(
                         "  Warning: Could not verify whether the target database exists. Assuming it does not exist and skipping safety backup.",
@@ -699,7 +733,9 @@ def main():
         print("\nRestore complete!")
 
         if restore_mode == "as-is" and source_db and source_db != target_db:
-            print("\nIMPORTANT: To connect your application to this database, update DATABASE_URL in your .env file.")
+            print(
+                "\nIMPORTANT: To connect your application to this database, update DATABASE_URL in your .env file."
+            )
 
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)

--- a/tests/test_drupal_attribution.py
+++ b/tests/test_drupal_attribution.py
@@ -206,7 +206,9 @@ def test_existing_key_team_region_reuses_no_moad_call(
     token = _login(drupal_client, user)
 
     # Simulate a PRIOR successful provision: a team exists, has a key for
-    # this region, and the user is already pinned to it.
+    # this region, and the user is already pinned to it. The user has a
+    # team role (ADMIN), matching what /auth/sign-in creates in production —
+    # a system role (USER) + non-null team_id would be rejected by RBAC.
     team = DBTeam(name="moad-team", admin_email=user.email, is_active=True)
     db.add(team)
     db.commit()
@@ -223,9 +225,10 @@ def test_existing_key_team_region_reuses_no_moad_call(
         team_id=team.id,
     )
     db.add(existing_key)
-    # Pin the user to the team — this is what _pin_user_to_key_team does
-    # after the first provision.
+    # Pin the user to the team with a team role — mirrors the post-provision
+    # state (sign-in creates ADMIN role; _pin_user_to_key_team sets team_id).
     user.team_id = team.id
+    user.role = UserRole.ADMIN
     db.commit()
 
     mock_http = AsyncMock()

--- a/tests/test_drupal_attribution.py
+++ b/tests/test_drupal_attribution.py
@@ -189,13 +189,15 @@ def test_no_header_moad_not_configured_returns_503(
 
 @patch("app.api.private_ai_keys.settings")
 @patch("httpx.AsyncClient")
-def test_existing_key_name_region_reuses_no_moad_call(
+def test_existing_key_team_region_reuses_no_moad_call(
     mock_client_cls, mock_settings, drupal_client, db, test_region
 ):
-    """A second request with the same name + region reuses the existing key.
+    """A request whose user's team already has a key for the region reuses it.
 
-    This prevents key proliferation when Drupal retries the provisioning call.
-    moad must NOT be called on the reuse path.
+    This prevents key proliferation when Drupal retries the provisioning call
+    (or the same user re-logs-in). moad must NOT be called on the reuse path.
+    The match is team + region (name-agnostic): moad stamps a date suffix on
+    the stored name, so a name-based match would never fire.
     """
     mock_settings.MOAD_DASHBOARD_API_URL = "http://mock-moad"
     mock_settings.MOAD_DASHBOARD_API_TOKEN = "mock-token"
@@ -203,13 +205,14 @@ def test_existing_key_name_region_reuses_no_moad_call(
     user = _make_user(db)
     token = _login(drupal_client, user)
 
-    # Pre-create a key with the SAME name + region the POST will use.
+    # Simulate a PRIOR successful provision: a team exists, has a key for
+    # this region, and the user is already pinned to it.
     team = DBTeam(name="moad-team", admin_email=user.email, is_active=True)
     db.add(team)
     db.commit()
     db.refresh(team)
     existing_key = DBPrivateAIKey(
-        name="test-key",
+        name="test-key - 2026-01-01",  # moad stamps a date suffix
         litellm_token="existing-token",
         litellm_api_url="http://test-llm",
         database_name="db",
@@ -220,6 +223,9 @@ def test_existing_key_name_region_reuses_no_moad_call(
         team_id=team.id,
     )
     db.add(existing_key)
+    # Pin the user to the team — this is what _pin_user_to_key_team does
+    # after the first provision.
+    user.team_id = team.id
     db.commit()
 
     mock_http = AsyncMock()
@@ -307,11 +313,12 @@ def test_delegation_pins_user_to_key_team(
 def test_idempotency_does_not_leak_cross_tenant_key(
     mock_client_cls, mock_settings, drupal_client, db, test_region
 ):
-    """A user requesting a name that matches ANOTHER tenant's key must not
-    receive that key or be pinned to that tenant's team.
+    """A user from a different team can never receive another tenant's key.
 
-    Regression test for the cross-tenant leak: the idempotency lookup must be
-    scoped to the requesting user's own teams, not a global name+region match.
+    The idempotency lookup is scoped to the requesting user's OWN team
+    (current_user.team_id), so cross-tenant leakage is impossible by
+    construction — there is no global match to exploit, regardless of the
+    name the attacker guesses.
     """
     mock_settings.MOAD_DASHBOARD_API_URL = "http://mock-moad"
     mock_settings.MOAD_DASHBOARD_API_TOKEN = "mock-token"

--- a/tests/test_restore_database.py
+++ b/tests/test_restore_database.py
@@ -1,6 +1,11 @@
 import os
 from unittest.mock import patch, MagicMock
-from scripts.restore_database import validate_db_name, get_db_config, detect_database_name
+from scripts.restore_database import (
+    validate_db_name,
+    get_db_config,
+    detect_database_name,
+)
+
 
 def test_validate_db_name():
     assert validate_db_name("my_db") is True
@@ -10,6 +15,7 @@ def test_validate_db_name():
     assert validate_db_name("db; drop database") is False
     assert validate_db_name("") is False
     assert validate_db_name("../etc/passwd") is False
+
 
 @patch.dict(os.environ, {"DATABASE_URL": "postgres://user:pass@host:5432/my_db"})
 def test_get_db_config_strips_password():
@@ -22,10 +28,11 @@ def test_get_db_config_strips_password():
     assert config["host"] == "host"
     assert config["port"] == 5432
 
+
 @patch("scripts.restore_database.run_pg_tool")
 def test_detect_database_name(mock_run_pg_tool):
     config = {"url": "postgres://host/db"}
-    
+
     # Test different whitespace styles in TOC headers
     headers = [
         ";     dbname: my_detected_db",
@@ -33,11 +40,11 @@ def test_detect_database_name(mock_run_pg_tool):
         ";\tdbname: my_detected_db",
         ";      dbname: my_detected_db",
     ]
-    
+
     for header in headers:
         mock_res = MagicMock()
         mock_res.stdout = f"{header}\n; other fields"
         mock_run_pg_tool.return_value = mock_res
-        
+
         detected = detect_database_name("/mock/dump", config)
         assert detected == "my_detected_db", f"Failed for header: {header}"


### PR DESCRIPTION
…ching

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Replaces the name+region idempotency lookup with a two-phase team+region strategy: first match the requesting user's own `team_id` (primary), then fall back to an email-pattern match for retry/region-switch scenarios. The `func.regexp_replace` SQL expression is removed in favour of application-level email normalisation, and a `"@"` guard prevents a crash on malformed stored emails.

- **Primary lookup** (lines 1189-1200): queries `(team_id, region_id)` when `current_user.team_id` is set — cross-tenant leakage is structurally impossible here.
- **Email-pattern fallback** (lines 1227-1241): matches `DBTeam.admin_email` against the user's base email and its moad plus-tag variants; handles the \"retry before pinning\" and \"region switch\" cases; fires only when the primary query finds nothing.
- **Test updates**: the idempotency fixture now pins the user to a team with an ADMIN role (reflecting the real post-provision state), and the cross-tenant security test's docstring is refreshed.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the core provisioning logic is well-guarded and the security boundary (cross-tenant isolation) is intact by construction.

The two-phase lookup is clearly reasoned, each branch is scoped to the requesting user's own identity, and previously flagged crash/re-pinning issues are addressed. The only remaining gaps are stale test comments and a missing test for the fallback path — neither affects production behaviour.

tests/test_drupal_attribution.py has stale comments describing the old name+region matching strategy, and the fallback branch in app/api/private_ai_keys.py has no dedicated test.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/private_ai_keys.py | Rewrites idempotency lookup from name+region to team+region (primary) with an email-pattern fallback for the retry-before-pinning and region-switch cases; removes the `func` import; the fallback logic is well-commented but has no dedicated test. |
| tests/test_drupal_attribution.py | Updates idempotency test to reflect team+region matching; adds team pinning to the fixture; stale "name + region" references remain in comments and section header; the fallback path is untested. |
| tests/test_restore_database.py | Formatting-only changes: multi-line import, blank lines between tests, trailing whitespace removal; no logic changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[POST /private-ai-keys Drupal path] --> B{moad configured?}
    B -- No --> C[503 Service Unavailable]
    B -- Yes --> D{current_user.team_id not None?}
    D -- Yes --> E[Primary query: team_id + region_id]
    E --> F{key found?}
    F -- Yes --> G[existing_key = result]
    F -- No --> H[existing_key = None]
    D -- No --> H
    H --> I{at sign in base_email?}
    I -- No --> J[Skip fallback - degrade to moad]
    I -- Yes --> K[Fallback: admin_email matches base or plus-tag pattern for region]
    K --> L{key found?}
    L -- Yes --> M[existing_key = result]
    L -- No --> J
    G --> N[_pin_user_to_key_team]
    M --> N
    N --> O[Return existing key]
    J --> P[Delegate to moad provision-key]
    P --> Q[moad returns litellm_token]
    Q --> R[Lookup key by litellm_token in local DB]
    R --> S[_pin_user_to_key_team]
    S --> T[Return key]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[POST /private-ai-keys Drupal path] --> B{moad configured?}
    B -- No --> C[503 Service Unavailable]
    B -- Yes --> D{current_user.team_id not None?}
    D -- Yes --> E[Primary query: team_id + region_id]
    E --> F{key found?}
    F -- Yes --> G[existing_key = result]
    F -- No --> H[existing_key = None]
    D -- No --> H
    H --> I{at sign in base_email?}
    I -- No --> J[Skip fallback - degrade to moad]
    I -- Yes --> K[Fallback: admin_email matches base or plus-tag pattern for region]
    K --> L{key found?}
    L -- Yes --> M[existing_key = result]
    L -- No --> J
    G --> N[_pin_user_to_key_team]
    M --> N
    N --> O[Return existing key]
    J --> P[Delegate to moad provision-key]
    P --> Q[moad returns litellm_token]
    Q --> R[Lookup key by litellm_token in local DB]
    R --> S[_pin_user_to_key_team]
    S --> T[Return key]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(private\_ai\_keys): Update comments f..."](https://github.com/amazeeio/amazee.ai/commit/830fa21ff67b1abd174c9eee48f6842bfb665fdd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39062672)</sub>

<!-- /greptile_comment -->