### PR TITLE
fix(api/users): ensure case-insensitive email check for user creation

### DIFF
--- a/app/api/users.py
+++ b/app/api/users.py
@@ -781,8 +781,14 @@ async def create_user(
     """
     Create a new user. Accessible by admin users or team admins for their own team.
     """
-    # Check if email already exists
-    db_user = get_user_by_email(db, user.email)
+    # Check if email already exists. Use an exact (case-insensitive) match here
+    # rather than the normalizing get_user_by_email(), because tagged emails such as
+    # "user+team_id@domain" (created by moad's provision-key flow) are intentionally
+    # distinct identities scoped to a specific Applications workspace team.  Normalizing
+    # would strip the tag and find the base user, incorrectly blocking creation.
+    db_user = (
+        db.query(DBUser).filter(func.lower(DBUser.email) == user.email.lower()).first()
+    )
     if db_user:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Email already registered"


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a regression in `create_user` where calling `get_user_by_email()` (which strips plus-tags before matching) incorrectly blocked creation of intentionally tagged-email identities like `user+team_id@domain` when the base `user@domain` already exists. The fix replaces that call with a direct `func.lower(DBUser.email) == user.email.lower()` query that enforces case-insensitivity without normalizing plus-tags.

- The new duplicate check is correctly scoped: exact case-insensitive match prevents true duplicates while allowing tagged variants to coexist as distinct DB rows.
- The comment in the code clearly documents the rationale and the boundary between \"normalized lookup\" and \"exact tagged identity.\"
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is narrowly scoped and solves a real blocking problem for moad-provisioned tagged users.

The duplicate-check logic is correct and well-commented. The one open question is whether moad-provisioned tagged users ever need to authenticate independently via `get_user_by_email`-backed flows (JWT refresh, login), since that helper still normalizes plus-tags and would silently return the base user instead of the tagged identity. This is a design-level concern rather than a defect in the PR itself.

app/api/users.py — the fix is sound, but reviewers should confirm whether tagged-email users require independent JWT sessions; if so, `get_user_by_email` callers in `auth.py` may also need adjustment.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/users.py | Replaces `get_user_by_email()` duplicate check with a direct case-insensitive exact-match query in `create_user`, allowing moad-provisioned tagged-email users to coexist alongside their base identity; logic is correct for the stated goal. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant create_user
    participant DB
    participant _create_user_in_db

    Client->>create_user: "POST /users {email: "alice+team123@example.com"}"

    note over create_user: NEW: exact case-insensitive check
    create_user->>DB: "SELECT WHERE lower(email) == "alice+team123@example.com""
    DB-->>create_user: None (not found)

    note over create_user: OLD: get_user_by_email normalised "alice+team123" to "alice"
    note over create_user: OLD: found "alice@example.com" - HTTP 400 blocked

    create_user->>_create_user_in_db: create user with email as-is
    _create_user_in_db->>DB: "INSERT "alice+team123@example.com""
    DB-->>_create_user_in_db: new DBUser row
    _create_user_in_db-->>create_user: DBUser
    create_user-->>Client: 201 Created
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant create_user
    participant DB
    participant _create_user_in_db

    Client->>create_user: "POST /users {email: "alice+team123@example.com"}"

    note over create_user: NEW: exact case-insensitive check
    create_user->>DB: "SELECT WHERE lower(email) == "alice+team123@example.com""
    DB-->>create_user: None (not found)

    note over create_user: OLD: get_user_by_email normalised "alice+team123" to "alice"
    note over create_user: OLD: found "alice@example.com" - HTTP 400 blocked

    create_user->>_create_user_in_db: create user with email as-is
    _create_user_in_db->>DB: "INSERT "alice+team123@example.com""
    DB-->>_create_user_in_db: new DBUser row
    _create_user_in_db-->>create_user: DBUser
    create_user-->>Client: 201 Created
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api/users): ensure case-insensitive ..."](https://github.com/amazeeio/amazee.ai/commit/098bf2bfa54a56a4301b3c45cc8aba7a2d66f600) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39238540)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->