### PR TITLE
feat(private_ai_keys): enhance key reuse logic with idempotent retry …

### DIFF
--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -1244,8 +1244,8 @@ async def _delegate_to_moad(
         # the same key (names match).  If the name differs the user is
         # explicitly requesting a NEW key — bypass idempotency and fall through
         # to moad so a fresh key is provisioned.
-        requested_name = (private_ai_key.name or "").strip()
-        existing_name = (existing_key.name or "").strip()
+        requested_name = (private_ai_key.name or "").strip().lower()
+        existing_name = (existing_key.name or "").strip().lower()
         is_retry = (not requested_name) or (requested_name == existing_name)
 
         if is_retry:

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -1240,15 +1240,31 @@ async def _delegate_to_moad(
             .first()
         )
     if existing_key is not None:
-        logger.info(
-            "[drupal-attribution] reusing existing key %s for %s + region %s",
-            existing_key.id,
-            current_user.email,
-            private_ai_key.region_id,
-        )
-        # Ensure the user is pinned to the key's team (see note below).
-        _pin_user_to_key_team(current_user, existing_key, db)
-        return PrivateAIKey.model_validate(existing_key.to_dict())
+        # Only treat this as an idempotent retry if the caller is asking for
+        # the same key (names match).  If the name differs the user is
+        # explicitly requesting a NEW key — bypass idempotency and fall through
+        # to moad so a fresh key is provisioned.
+        requested_name = (private_ai_key.name or "").strip()
+        existing_name = (existing_key.name or "").strip()
+        is_retry = (not requested_name) or (requested_name == existing_name)
+
+        if is_retry:
+            logger.info(
+                "[drupal-attribution] reusing existing key %s for %s + region %s (idempotent retry)",
+                existing_key.id,
+                current_user.email,
+                private_ai_key.region_id,
+            )
+            # Ensure the user is pinned to the key's team (see note below).
+            _pin_user_to_key_team(current_user, existing_key, db)
+            return PrivateAIKey.model_validate(existing_key.to_dict())
+        else:
+            logger.info(
+                "[drupal-attribution] user %s requested new key '%s' (existing: '%s') — bypassing idempotency",
+                current_user.email,
+                requested_name,
+                existing_name,
+            )
 
     # Send the base email (plus-tags stripped) so moad resolves the real
     # Keycloak/MOAD identity instead of creating a new tagged surrogate.

--- a/scripts/restore_database.py
+++ b/scripts/restore_database.py
@@ -320,7 +320,12 @@ def detect_database_name(dump_dir, config):
             if re.match(r"^;\s+dbname:", stripped):
                 return stripped.split(":", 1)[1].strip()
     except Exception as e:
-        print(sanitize(f"  Warning: Could not detect source database name from backup: {e}", config))
+        print(
+            sanitize(
+                f"  Warning: Could not detect source database name from backup: {e}",
+                config,
+            )
+        )
     return None
 
 
@@ -328,7 +333,9 @@ def recreate_target_db(config):
     """Drop and recreate the target database to ensure a clean restore without constraint errors."""
     db_name = config["database"]
     if not validate_db_name(db_name):
-        raise SystemExit("Error: Database name is invalid. Only alphanumeric characters and underscores are allowed.")
+        raise SystemExit(
+            "Error: Database name is invalid. Only alphanumeric characters and underscores are allowed."
+        )
 
     print("  Recreating target database...")
 
@@ -345,9 +352,7 @@ def recreate_target_db(config):
     try:
         run_pg_tool(terminate_cmd, config, check=False)
     except subprocess.CalledProcessError:
-        warning_msg = (
-            "  Warning: Could not terminate all active connections for database (continuing)."
-        )
+        warning_msg = "  Warning: Could not terminate all active connections for database (continuing)."
         print(warning_msg)
 
     # 2. Drop database if exists
@@ -361,7 +366,9 @@ def recreate_target_db(config):
     try:
         run_pg_tool(drop_cmd, config)
     except subprocess.CalledProcessError as e:
-        raise SystemExit(sanitize(f"  Failed to drop target database: {e.stderr or e}", config))
+        raise SystemExit(
+            sanitize(f"  Failed to drop target database: {e.stderr or e}", config)
+        )
 
     # 3. Create database
     create_cmd = [
@@ -374,7 +381,12 @@ def recreate_target_db(config):
     try:
         run_pg_tool(create_cmd, config)
     except subprocess.CalledProcessError as e:
-        raise SystemExit(sanitize(f"  Failed to create target database '{db_name}': {e.stderr or e}", config))
+        raise SystemExit(
+            sanitize(
+                f"  Failed to create target database '{db_name}': {e.stderr or e}",
+                config,
+            )
+        )
 
 
 def apply_restore(config, dump_dir, restore_mode="target"):
@@ -542,7 +554,9 @@ def main():
     config = get_db_config()
     target_db = config["database"]
     if not validate_db_name(target_db):
-        print("Error: Target database name is invalid. Only alphanumeric characters and underscores are allowed.")
+        print(
+            "Error: Target database name is invalid. Only alphanumeric characters and underscores are allowed."
+        )
         sys.exit(1)
 
     display_host = _presence(config.get("host"))
@@ -583,10 +597,16 @@ def main():
         restore_mode = args.restore_mode
         if not args.yes:
             if source_db and source_db != target_db:
-                print("\nWARNING: The backup source database name differs from your locally-configured target database.")
+                print(
+                    "\nWARNING: The backup source database name differs from your locally-configured target database."
+                )
                 print("How would you like to restore this database?")
-                print("  1) Restore directly into the configured target database (Recommended for local dev - no .env changes needed)")
-                print("  2) Recreate and restore using the backup's original database name (Requires updating DATABASE_URL in .env)")
+                print(
+                    "  1) Restore directly into the configured target database (Recommended for local dev - no .env changes needed)"
+                )
+                print(
+                    "  2) Recreate and restore using the backup's original database name (Requires updating DATABASE_URL in .env)"
+                )
                 while True:
                     choice = input("\nSelect option [1 or 2]: ").strip()
                     if choice == "1":
@@ -598,13 +618,19 @@ def main():
                     else:
                         print("Invalid choice. Please enter 1 or 2.")
             else:
-                print("\nWARNING: This will DROP the existing database and restore from backup.")
+                print(
+                    "\nWARNING: This will DROP the existing database and restore from backup."
+                )
                 if not args.no_backup:
-                    print("A safety backup of the current database will be created first.")
+                    print(
+                        "A safety backup of the current database will be created first."
+                    )
                 else:
                     print("No safety backup will be created (--no-backup specified).")
                 response = (
-                    input("\nAre you sure you want to proceed? [yes/no]: ").strip().lower()
+                    input("\nAre you sure you want to proceed? [yes/no]: ")
+                    .strip()
+                    .lower()
                 )
                 if response not in ("yes", "y"):
                     print("Aborted.")
@@ -612,20 +638,28 @@ def main():
         else:
             # Non-interactive mode
             if restore_mode == "as-is":
-                print("  Non-interactive: Restoring as-is into configured target database")
+                print(
+                    "  Non-interactive: Restoring as-is into configured target database"
+                )
             else:
                 print("  Non-interactive: Restoring into target database")
 
         # Validate source_db ONLY if we are actually using it in as-is mode
         if restore_mode == "as-is" and source_db:
             if not validate_db_name(source_db):
-                print("Error: Detected source database name is invalid for 'as-is' restore.")
-                print("Only alphanumeric characters and underscores are allowed for database names.")
+                print(
+                    "Error: Detected source database name is invalid for 'as-is' restore."
+                )
+                print(
+                    "Only alphanumeric characters and underscores are allowed for database names."
+                )
                 sys.exit(1)
 
         # Step 2: Backup current database (unless skipped)
         if not args.no_backup:
-            active_db = source_db if (restore_mode == "as-is" and source_db) else target_db
+            active_db = (
+                source_db if (restore_mode == "as-is" and source_db) else target_db
+            )
             backup_msg = "\n[2/3] Backing up current database before restore..."
             print(backup_msg)
             backup_dir = args.backup_dir or os.path.dirname(
@@ -663,7 +697,7 @@ def main():
                 db_exists = False
                 try:
                     res = run_pg_tool(check_cmd, config)
-                    db_exists = (res.stdout.strip() == "1")
+                    db_exists = res.stdout.strip() == "1"
                 except Exception:
                     print(
                         "  Warning: Could not verify whether the target database exists. Assuming it does not exist and skipping safety backup.",
@@ -699,7 +733,9 @@ def main():
         print("\nRestore complete!")
 
         if restore_mode == "as-is" and source_db and source_db != target_db:
-            print("\nIMPORTANT: To connect your application to this database, update DATABASE_URL in your .env file.")
+            print(
+                "\nIMPORTANT: To connect your application to this database, update DATABASE_URL in your .env file."
+            )
 
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)

--- a/tests/test_drupal_attribution.py
+++ b/tests/test_drupal_attribution.py
@@ -214,7 +214,7 @@ def test_existing_key_team_region_reuses_no_moad_call(
     db.commit()
     db.refresh(team)
     existing_key = DBPrivateAIKey(
-        name="test-key - 2026-01-01",  # moad stamps a date suffix
+        name="test-key",  # matches what _post_key sends; moad no longer stamps a date suffix
         litellm_token="existing-token",
         litellm_api_url="http://test-llm",
         database_name="db",


### PR DESCRIPTION
…check

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refines the Drupal-attribution idempotency check in `_delegate_to_moad` so that an existing key is only reused when the caller sends the same name (case-insensitive match, via `.lower()`); a different name bypasses idempotency and lets moad provision a new key. The `restore_database.py` changes are a formatting-only clean-up with no functional impact.

- **`private_ai_keys.py`**: Introduces `is_retry` flag derived from a case-insensitive name comparison; an empty requested name always signals a retry, preserving backward-compatible behavior for callers that omit the name field.
- **`test_drupal_attribution.py`**: Updates the idempotency test fixture name from `\"test-key - 2026-01-01\"` to `\"test-key\"` to match the posted payload, exercising the new name-match path; the test docstring still describes the old name-agnostic logic and should be updated.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with awareness that provisioning a new key with a different name leaves the prior key active and unrevoked.

The name-matching logic works correctly for the retry path and `.lower()` normalization prevents case-drift duplicates. When idempotency is bypassed (names differ), however, the previously found existing key remains live with a working litellm_token because no deactivation is performed before moad provisions a replacement.

app/api/private_ai_keys.py — specifically the fallthrough path at line 1261 where the old key is left active after moad provisions a replacement.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/private_ai_keys.py | Adds name-based idempotency check: requests with a matching name (case-insensitive) reuse the existing key; a differing name falls through to moad for fresh provisioning. The old key is not deactivated when idempotency is bypassed (pre-existing concern noted in earlier review threads). |
| tests/test_drupal_attribution.py | Updates the idempotency test fixture name from "test-key - 2026-01-01" to "test-key" to match the posted key name; the docstring still describes the old "name-agnostic" behaviour, which is now stale and misleading. |
| scripts/restore_database.py | Pure formatting changes: long lines reformatted to fit within 88 chars and one redundant set of parentheses removed around a boolean comparison. No functional changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[POST /private-ai-keys\nDrupal path] --> B{existing_key\nfound?}
    B -- No --> G[Call moad\nprovision-key]
    B -- Yes --> C{requested_name\nempty?}
    C -- Yes --> D[is_retry = True\nIdempotent reuse]
    C -- No --> E{names match?\ncase-insensitive}
    E -- Yes --> D
    E -- No --> F[is_retry = False\nBypass idempotency]
    D --> H[Return existing_key\npin user to team]
    F --> G
    G --> I[Look up new key\nby litellm_token]
    I --> J[Pin user to\nnew key's team]
    J --> K[Return new key]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[POST /private-ai-keys\nDrupal path] --> B{existing_key\nfound?}
    B -- No --> G[Call moad\nprovision-key]
    B -- Yes --> C{requested_name\nempty?}
    C -- Yes --> D[is_retry = True\nIdempotent reuse]
    C -- No --> E{names match?\ncase-insensitive}
    E -- Yes --> D
    E -- No --> F[is_retry = False\nBypass idempotency]
    D --> H[Return existing_key\npin user to team]
    F --> G
    G --> I[Look up new key\nby litellm_token]
    I --> J[Pin user to\nnew key's team]
    J --> K[Return new key]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["test: Update test key name to reflect ch..."](https://github.com/amazeeio/amazee.ai/commit/c9131f32ff2c124a881d28765cc9aafad44c915f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39297776)</sub>

<!-- /greptile_comment -->