### PR TITLE
feat(limits): skip default budget for purchase-gated pool teams on legacy endpoints

### DIFF
--- a/app/core/limit_service.py
+++ b/app/core/limit_service.py
@@ -142,8 +142,15 @@ class LimitService:
         # Build effective limits: TEAM -> SYSTEM inheritance (no user limits in team view)
         effective_limits = {}
 
-        # Start with system defaults
+        # Start with system defaults.
+        # POOL team budgets are purchase-driven and should not inherit or
+        # materialize a default TEAM.BUDGET row from system policy.
         for limit in system_limits:
+            if (
+                limit.resource == ResourceType.BUDGET
+                and team.requires_pool_purchase_gate
+            ):
+                continue
             effective_limits[limit.resource] = limit
 
         # Override with team limits

--- a/tests/limits/test_budget_limits.py
+++ b/tests/limits/test_budget_limits.py
@@ -298,6 +298,7 @@ def test_system_default_budget_update_skips_pool_team_defaults(db, test_team):
     """
     pool_team = test_team
     pool_team.budget_type = "pool"
+    pool_team.require_purchase_for_requests = True
     db.add(pool_team)
 
     from app.db.models import DBTeam
@@ -353,6 +354,48 @@ def test_system_default_budget_update_skips_pool_team_defaults(db, test_team):
     )
     assert pool_budget.max_value == 0.0
     assert periodic_budget.max_value == 123.0
+
+
+def test_get_team_limits_skips_default_budget_for_purchase_gated_pool_teams(
+    db, test_team
+):
+    """
+    GIVEN: A purchase-gated POOL team with no explicit team budget row
+    WHEN: get_team_limits is called
+    THEN: The inherited system BUDGET limit is not returned or materialized
+    """
+    test_team.budget_type = "pool"
+    test_team.require_purchase_for_requests = True
+    db.add(test_team)
+    db.commit()
+
+    limit_service = LimitService(db)
+    limit_service.set_limit(
+        owner_type=OwnerType.SYSTEM,
+        owner_id=0,
+        resource_type=ResourceType.BUDGET,
+        limit_type=LimitType.DATA_PLANE,
+        unit=UnitType.DOLLAR,
+        max_value=27.0,
+        limited_by=LimitSource.DEFAULT,
+    )
+
+    team_limits = limit_service.get_team_limits(test_team)
+
+    assert not any(limit.resource == ResourceType.BUDGET for limit in team_limits)
+
+    from app.db.models import DBLimitedResource
+
+    persisted_budget_limit = (
+        db.query(DBLimitedResource)
+        .filter(
+            DBLimitedResource.owner_type == OwnerType.TEAM,
+            DBLimitedResource.owner_id == test_team.id,
+            DBLimitedResource.resource == ResourceType.BUDGET,
+        )
+        .first()
+    )
+    assert persisted_budget_limit is None
 
 
 def test_set_team_limits_uses_dedicated_region_default_overrides(db, test_team):


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents the `get_team_limits` code path from inheriting and immediately persisting a system-default `BUDGET` row for purchase-gated POOL teams. Before this change, any call to `get_team_limits` on such a team (e.g. via `get_token_restrictions` on a legacy endpoint) would write a `TEAM.BUDGET = $27` row, which could clobber the purchase-driven budget on the next billing cycle.

- **`app/core/limit_service.py`**: Adds a guard in `get_team_limits` that skips the system default `BUDGET` limit when `team.requires_pool_purchase_gate` is True, preventing inadvertent materialization of a default budget row. Explicit team-level budget rows (from purchases) are still returned correctly via the override loop.
- **`tests/limits/test_budget_limits.py`**: Adds `require_purchase_for_requests = True` to an existing test for explicitness (the column defaults to `True`, so behaviour was unchanged), and adds a new integration test verifying that no budget is returned or persisted for a gated POOL team when only a system default exists.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a small, targeted guard that mirrors identical guards already present in three other methods of the same class.

The new guard in `get_team_limits` is the last unguarded code path that could persist a default BUDGET row for purchase-gated POOL teams. The fix is consistent with the existing pattern in `set_team_limits`, `_get_team_default_limit_for_resource`, and `_should_skip_system_default_update_for_team`. Explicit team budget rows (from purchases) are still returned correctly via the override loop. The new test verifies both the return value and the absence of a persisted DB row, covering the concrete regression the PR aims to prevent.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/core/limit_service.py | Adds a targeted guard in `get_team_limits` to skip the system default BUDGET limit for purchase-gated POOL teams, consistent with identical guards already present in `set_team_limits`, `_get_team_default_limit_for_resource`, and `_should_skip_system_default_update_for_team`. |
| tests/limits/test_budget_limits.py | Adds `require_purchase_for_requests = True` to an existing test for clarity (was already the column default), and introduces a well-structured new test that verifies both the absence of a BUDGET in the returned list and the absence of a persisted DB row. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["get_team_limits(team)"] --> B["Query system limits"]
    B --> C["Loop over system limits"]
    C --> D{"limit.resource == BUDGET\nAND team.requires_pool_purchase_gate?"}
    D -- Yes --> E["skip / continue\n(no materialization)"]
    D -- No --> F["effective_limits[resource] = limit"]
    F --> G["Loop over team limits\n(explicit rows)"]
    E --> G
    G --> H["Override effective_limits\nwith team rows"]
    H --> I{"limit.owner_type == SYSTEM?"}
    I -- Yes --> J["set_limit(TEAM, ...)\npersist inherited row"]
    I -- No --> K["Return existing row as-is"]
    J --> L["Return limit_schemas"]
    K --> L

    style E fill:#f96,color:#000
    style D fill:#ffd,color:#000
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["get_team_limits(team)"] --> B["Query system limits"]
    B --> C["Loop over system limits"]
    C --> D{"limit.resource == BUDGET\nAND team.requires_pool_purchase_gate?"}
    D -- Yes --> E["skip / continue\n(no materialization)"]
    D -- No --> F["effective_limits[resource] = limit"]
    F --> G["Loop over team limits\n(explicit rows)"]
    E --> G
    G --> H["Override effective_limits\nwith team rows"]
    H --> I{"limit.owner_type == SYSTEM?"}
    I -- Yes --> J["set_limit(TEAM, ...)\npersist inherited row"]
    I -- No --> K["Return existing row as-is"]
    J --> L["Return limit_schemas"]
    K --> L

    style E fill:#f96,color:#000
    style D fill:#ffd,color:#000
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(limits): skip default budget for pu..."](https://github.com/amazeeio/amazee.ai/commit/307fe630ab1235b0d1c93d2263cdd56d9e6f1572) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39611093)</sub>

<!-- /greptile_comment -->