### PR TITLE
feat(webhooks): implement MOAD webhook classification and processing …

### DIFF
--- a/app/api/webhooks.py
+++ b/app/api/webhooks.py
@@ -17,6 +17,7 @@ from app.core.worker import handle_stripe_event_background
 from app.db.database import get_db
 from app.db.models import DBStripeProcessedEvent, DBSystemSecret
 from app.services.stripe import decode_stripe_event
+from app.services.stripe_webhook_classification import is_moad_webhook
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["billing"])
@@ -57,6 +58,17 @@ async def handle_events(
         signature = request.headers.get("stripe-signature")
 
         event = decode_stripe_event(payload, signature, webhook_secret)
+
+        if is_moad_webhook(event):
+            logger.info(
+                "Skipping legacy webhook processing for MOAD-owned Stripe event: event_type=%s event_id=%s",
+                getattr(event, "type", "unknown"),
+                getattr(event, "id", None),
+            )
+            return Response(
+                status_code=status.HTTP_200_OK,
+                content="Webhook acknowledged by legacy endpoint",
+            )
 
         # Claim-row idempotency: insert the event ID before dispatching
         # the background task. If a duplicate webhook arrives concurrently,

--- a/app/api/webhooks.py
+++ b/app/api/webhooks.py
@@ -10,6 +10,7 @@ from fastapi import (
     Response,
     status,
 )
+from starlette.concurrency import run_in_threadpool
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -59,7 +60,7 @@ async def handle_events(
 
         event = decode_stripe_event(payload, signature, webhook_secret)
 
-        if is_moad_webhook(event):
+        if await run_in_threadpool(is_moad_webhook, event):
             logger.info(
                 "Skipping legacy webhook processing for MOAD-owned Stripe event: event_type=%s event_id=%s",
                 getattr(event, "type", "unknown"),

--- a/app/services/stripe_webhook_classification.py
+++ b/app/services/stripe_webhook_classification.py
@@ -29,18 +29,25 @@ def _get_event_object(event: Any):
     return getattr(data, "object", None)
 
 
+def _coerce_subscription_id(subscription_ref: Any) -> str | None:
+    if not subscription_ref:
+        return None
+    if isinstance(subscription_ref, str):
+        return subscription_ref
+    return getattr(subscription_ref, "id", None)
+
+
 def _get_subscription_id_from_invoice(event_object: Any) -> str | None:
-    subscription_id = getattr(event_object, "subscription", None)
+    subscription_id = _coerce_subscription_id(
+        getattr(event_object, "subscription", None)
+    )
     if subscription_id:
-        # Unwrap expanded Subscription objects — retrieve() expects a plain string ID
-        if not isinstance(subscription_id, str):
-            subscription_id = getattr(subscription_id, "id", None)
-        return subscription_id or None
+        return subscription_id
 
     if hasattr(event_object, "parent"):
         try:
             details = event_object.parent.subscription_details
-            return getattr(details, "subscription", None)
+            return _coerce_subscription_id(getattr(details, "subscription", None))
         except AttributeError:
             return None
     return None

--- a/app/services/stripe_webhook_classification.py
+++ b/app/services/stripe_webhook_classification.py
@@ -1,0 +1,94 @@
+import logging
+from typing import Any
+
+from app.services.stripe import stripe_sdk
+
+logger = logging.getLogger(__name__)
+
+
+NEW_WEBHOOK_MARKER_KEYS = (
+    "ai_subscription",
+    "ai_budget_increase",
+    "workspaceId",
+    "teamId",
+    "regionId",
+    "webhook_owner",
+)
+
+
+def _marker_value(metadata: Any, key: str):
+    return getattr(metadata, key, None) if metadata else None
+
+
+def _looks_like_new_metadata(metadata: Any) -> bool:
+    if not metadata:
+        return False
+    if _marker_value(metadata, "ai_subscription") == "true":
+        return True
+    if _marker_value(metadata, "ai_budget_increase"):
+        return True
+    if _marker_value(metadata, "workspaceId"):
+        return True
+    return bool(
+        _marker_value(metadata, "teamId") and _marker_value(metadata, "regionId")
+    )
+
+
+def _get_event_object(event: Any):
+    data = getattr(event, "data", None)
+    return getattr(data, "object", None)
+
+
+def _get_subscription_id_from_invoice(event_object: Any) -> str | None:
+    subscription_id = getattr(event_object, "subscription", None)
+    if subscription_id:
+        return subscription_id
+
+    if hasattr(event_object, "parent"):
+        try:
+            details = event_object.parent.subscription_details
+            return getattr(details, "subscription", None)
+        except AttributeError:
+            return None
+    return None
+
+
+def _get_inline_invoice_metadata(event_object: Any):
+    if hasattr(event_object, "parent"):
+        try:
+            details = event_object.parent.subscription_details
+            return getattr(details, "metadata", None)
+        except AttributeError:
+            return None
+    return None
+
+
+def is_moad_webhook(event: Any) -> bool:
+    """Return True when a verified Stripe event belongs to the MOAD/new flow."""
+    event_type = getattr(event, "type", "unknown")
+    event_object = _get_event_object(event)
+    if not event_object:
+        return False
+
+    inline_metadatas = [
+        getattr(event_object, "metadata", None),
+        _get_inline_invoice_metadata(event_object),
+    ]
+    if any(_looks_like_new_metadata(metadata) for metadata in inline_metadatas):
+        return True
+
+    if event_type.startswith("invoice."):
+        subscription_id = _get_subscription_id_from_invoice(event_object)
+        if not subscription_id:
+            return False
+        try:
+            subscription = stripe_sdk.Subscription.retrieve(subscription_id)
+            return _looks_like_new_metadata(getattr(subscription, "metadata", None))
+        except Exception as exc:
+            logger.warning(
+                "Failed to retrieve subscription metadata while classifying webhook %s for subscription %s: %s",
+                event_type,
+                subscription_id,
+                exc,
+            )
+    return False

--- a/app/services/stripe_webhook_classification.py
+++ b/app/services/stripe_webhook_classification.py
@@ -32,7 +32,10 @@ def _get_event_object(event: Any):
 def _get_subscription_id_from_invoice(event_object: Any) -> str | None:
     subscription_id = getattr(event_object, "subscription", None)
     if subscription_id:
-        return subscription_id
+        # Unwrap expanded Subscription objects — retrieve() expects a plain string ID
+        if not isinstance(subscription_id, str):
+            subscription_id = getattr(subscription_id, "id", None)
+        return subscription_id or None
 
     if hasattr(event_object, "parent"):
         try:

--- a/app/services/stripe_webhook_classification.py
+++ b/app/services/stripe_webhook_classification.py
@@ -6,16 +6,6 @@ from app.services.stripe import stripe_sdk
 logger = logging.getLogger(__name__)
 
 
-NEW_WEBHOOK_MARKER_KEYS = (
-    "ai_subscription",
-    "ai_budget_increase",
-    "workspaceId",
-    "teamId",
-    "regionId",
-    "webhook_owner",
-)
-
-
 def _marker_value(metadata: Any, key: str):
     return getattr(metadata, key, None) if metadata else None
 
@@ -91,4 +81,5 @@ def is_moad_webhook(event: Any) -> bool:
                 subscription_id,
                 exc,
             )
+            raise
     return False

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -22,6 +22,7 @@ import stripe
 from stripe import Event
 
 from app.db.models import DBStripeProcessedEvent
+from app.services.stripe_webhook_classification import is_moad_webhook
 
 WEBHOOK_SECRET_KEY = "stripe_webhook_secret"
 
@@ -181,6 +182,101 @@ def test_webhook_duplicate_real_event_returns_200_not_500(
         .all()
     )
     assert len(claims) == 1
+
+
+def test_webhook_skips_moad_checkout_session_events(client, db, webhook_secret_env):
+    """MOAD checkout/session budget webhooks must be ACKed but not processed here."""
+    event_id = "evt_moad_checkout_session"
+    real_event = _make_real_stripe_event(
+        event_id=event_id,
+        event_type="checkout.session.completed",
+        metadata={
+            "teamId": "42",
+            "regionId": "7",
+            "ai_budget_increase": "5000",
+        },
+    )
+
+    with (
+        patch("app.api.webhooks.decode_stripe_event", return_value=real_event),
+        patch(
+            "app.api.webhooks.handle_stripe_event_background", new_callable=AsyncMock
+        ) as mock_background,
+    ):
+        response = client.post(
+            "/billing/events",
+            content=b'{"id": "evt_moad_checkout_session"}',
+            headers={"stripe-signature": "t=1,v1=fake"},
+        )
+
+    assert response.status_code == 200, response.text
+    mock_background.assert_not_awaited()
+    claim = (
+        db.query(DBStripeProcessedEvent)
+        .filter(DBStripeProcessedEvent.stripe_event_id == event_id)
+        .first()
+    )
+    assert claim is None, "MOAD-owned events should not create legacy claims"
+
+
+@patch("app.services.stripe_webhook_classification.stripe_sdk.Subscription.retrieve")
+def test_webhook_skips_moad_invoice_events_via_subscription_metadata(
+    mock_retrieve, client, db, webhook_secret_env
+):
+    """MOAD invoice webhooks may only expose markers on the subscription."""
+    event_id = "evt_moad_invoice_paid"
+    real_event = _make_real_stripe_event(event_id=event_id, event_type="invoice.paid")
+    real_event.data.object.subscription = "sub_moad_123"
+    mock_retrieve.return_value = stripe.Subscription.construct_from(
+        {
+            "id": "sub_moad_123",
+            "metadata": {
+                "ai_subscription": "true",
+                "teamId": "42",
+                "regionId": "7",
+                "workspaceId": "ws_abc",
+            },
+        },
+        key="sk_test_regression",
+    )
+
+    with (
+        patch("app.api.webhooks.decode_stripe_event", return_value=real_event),
+        patch(
+            "app.api.webhooks.handle_stripe_event_background", new_callable=AsyncMock
+        ) as mock_background,
+    ):
+        response = client.post(
+            "/billing/events",
+            content=b'{"id": "evt_moad_invoice_paid"}',
+            headers={"stripe-signature": "t=1,v1=fake"},
+        )
+
+    assert response.status_code == 200, response.text
+    mock_background.assert_not_awaited()
+    claim = (
+        db.query(DBStripeProcessedEvent)
+        .filter(DBStripeProcessedEvent.stripe_event_id == event_id)
+        .first()
+    )
+    assert claim is None, "MOAD-owned invoice events should not create legacy claims"
+
+
+@patch("app.services.stripe_webhook_classification.stripe_sdk.Subscription.retrieve")
+def test_is_moad_webhook_returns_false_for_legacy_invoice_without_markers(
+    mock_retrieve,
+):
+    """Legacy invoice events must keep flowing through the legacy worker."""
+    event = _make_real_stripe_event(
+        event_id="evt_legacy_invoice", event_type="invoice.paid"
+    )
+    event.data.object.subscription = "sub_legacy_123"
+    mock_retrieve.return_value = stripe.Subscription.construct_from(
+        {"id": "sub_legacy_123", "metadata": {}},
+        key="sk_test_regression",
+    )
+
+    assert is_moad_webhook(event) is False
 
 
 def test_real_stripe_metadata_is_not_dict_like():

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -263,6 +263,37 @@ def test_webhook_skips_moad_invoice_events_via_subscription_metadata(
 
 
 @patch("app.services.stripe_webhook_classification.stripe_sdk.Subscription.retrieve")
+def test_webhook_returns_500_when_invoice_ownership_cannot_be_determined(
+    mock_retrieve, client, db, webhook_secret_env
+):
+    event_id = "evt_invoice_ownership_unknown"
+    real_event = _make_real_stripe_event(event_id=event_id, event_type="invoice.paid")
+    real_event.data.object.subscription = "sub_unknown_123"
+    mock_retrieve.side_effect = Exception("stripe unavailable")
+
+    with (
+        patch("app.api.webhooks.decode_stripe_event", return_value=real_event),
+        patch(
+            "app.api.webhooks.handle_stripe_event_background", new_callable=AsyncMock
+        ) as mock_background,
+    ):
+        response = client.post(
+            "/billing/events",
+            content=b'{"id": "evt_invoice_ownership_unknown"}',
+            headers={"stripe-signature": "t=1,v1=fake"},
+        )
+
+    assert response.status_code == 500, response.text
+    mock_background.assert_not_awaited()
+    claim = (
+        db.query(DBStripeProcessedEvent)
+        .filter(DBStripeProcessedEvent.stripe_event_id == event_id)
+        .first()
+    )
+    assert claim is None, "ownership-unknown invoice events should not create claims"
+
+
+@patch("app.services.stripe_webhook_classification.stripe_sdk.Subscription.retrieve")
 def test_is_moad_webhook_returns_false_for_legacy_invoice_without_markers(
     mock_retrieve,
 ):
@@ -277,6 +308,55 @@ def test_is_moad_webhook_returns_false_for_legacy_invoice_without_markers(
     )
 
     assert is_moad_webhook(event) is False
+
+
+@patch("app.services.stripe_webhook_classification.stripe_sdk.Subscription.retrieve")
+def test_is_moad_webhook_reads_subscription_from_invoice_parent_details(
+    mock_retrieve,
+):
+    event = _make_real_stripe_event(
+        event_id="evt_parent_subscription", event_type="invoice.paid"
+    )
+    event.data.object.parent = stripe.StripeObject.construct_from(
+        {
+            "subscription_details": {
+                "subscription": "sub_parent_123",
+            }
+        },
+        key="sk_test_regression",
+    )
+    mock_retrieve.return_value = stripe.Subscription.construct_from(
+        {"id": "sub_parent_123", "metadata": {"ai_subscription": "true"}},
+        key="sk_test_regression",
+    )
+
+    assert is_moad_webhook(event) is True
+    mock_retrieve.assert_called_once_with("sub_parent_123")
+
+
+@patch("app.services.stripe_webhook_classification.stripe_sdk.Subscription.retrieve")
+def test_is_moad_webhook_reads_inline_metadata_from_invoice_parent_details(
+    mock_retrieve,
+):
+    event = _make_real_stripe_event(
+        event_id="evt_parent_inline_metadata",
+        event_type="invoice.paid",
+    )
+    event.data.object.parent = stripe.StripeObject.construct_from(
+        {
+            "subscription_details": {
+                "metadata": {
+                    "ai_budget_increase": "5000",
+                    "teamId": "42",
+                    "regionId": "7",
+                }
+            }
+        },
+        key="sk_test_regression",
+    )
+
+    assert is_moad_webhook(event) is True
+    mock_retrieve.assert_not_called()
 
 
 def test_real_stripe_metadata_is_not_dict_like():

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -335,6 +335,32 @@ def test_is_moad_webhook_reads_subscription_from_invoice_parent_details(
 
 
 @patch("app.services.stripe_webhook_classification.stripe_sdk.Subscription.retrieve")
+def test_is_moad_webhook_unwraps_expanded_subscription_from_invoice_parent_details(
+    mock_retrieve,
+):
+    event = _make_real_stripe_event(
+        event_id="evt_parent_subscription_expanded", event_type="invoice.paid"
+    )
+    event.data.object.parent = stripe.StripeObject.construct_from(
+        {
+            "subscription_details": {
+                "subscription": {
+                    "id": "sub_parent_expanded_123",
+                }
+            }
+        },
+        key="sk_test_regression",
+    )
+    mock_retrieve.return_value = stripe.Subscription.construct_from(
+        {"id": "sub_parent_expanded_123", "metadata": {"ai_subscription": "true"}},
+        key="sk_test_regression",
+    )
+
+    assert is_moad_webhook(event) is True
+    mock_retrieve.assert_called_once_with("sub_parent_expanded_123")
+
+
+@patch("app.services.stripe_webhook_classification.stripe_sdk.Subscription.retrieve")
 def test_is_moad_webhook_reads_inline_metadata_from_invoice_parent_details(
     mock_retrieve,
 ):


### PR DESCRIPTION
…skip

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR inserts a MOAD-ownership classification gate into the legacy Stripe webhook handler so that events belonging to the new MOAD billing flow are acknowledged (HTTP 200) without being claimed or dispatched to the legacy background processor.

- **`stripe_webhook_classification.py`** — new module; checks inline metadata on the event object and (for `invoice.*` events only) fetches the linked subscription from the Stripe API when no inline markers are present. `_coerce_subscription_id` correctly unwraps already-expanded subscription objects to avoid redundant API calls.
- **`app/api/webhooks.py`** — adds a single early-return gate using `run_in_threadpool` to keep the async handler from blocking on the synchronous Stripe SDK call.
- **`tests/test_webhooks.py`** — covers all classification branches with real `stripe.Event` StripeObjects, including the explicit design choice to return 500 (and trigger Stripe's retry) when the Stripe API is unreachable during classification.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with awareness that legacy invoice events now require a live Stripe API call when inline metadata is absent; a Stripe outage or rate-limit at classification time will cause those events to 500 and rely on Stripe's retry budget.

The classification module unconditionally re-raises any Stripe SDK exception encountered while fetching subscription metadata for invoice.* events (line 94 of stripe_webhook_classification.py). This introduces a new runtime dependency on Stripe API availability for the entire legacy invoice pipeline — prior to this PR, invoice.* processing had no such dependency. The test suite documents this as an intentional design choice (asserting 500 when the API is unavailable), but it means a transient Stripe rate-limit or outage will block all invoice events that lack inline metadata until the API recovers or Stripe's retry budget runs out. The rest of the change — the routing gate, the _coerce_subscription_id unwrapping, and the threadpool dispatch — is clean and well-tested.

app/services/stripe_webhook_classification.py — specifically the exception re-raise in the Stripe API fetch path for invoice classification.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/services/stripe_webhook_classification.py | New classification module; correctly coerces expanded subscription objects via `_coerce_subscription_id`, but unconditionally re-raises Stripe API errors for invoice events, making legacy invoice processing dependent on Stripe API availability at classification time. |
| app/api/webhooks.py | Adds early MOAD routing gate before idempotency/background-task logic; correctly uses `run_in_threadpool` to avoid blocking the async event loop for the sync classification call. |
| tests/test_webhooks.py | Comprehensive test suite using real stripe.Event StripeObjects; covers inline metadata, subscription-level metadata via API, parent subscription_details path, expanded subscription unwrapping, and explicit 500 assertion when the Stripe API is unreachable during classification. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[POST /billing/events] --> B[decode_stripe_event]
    B --> C{run_in_threadpool\nis_moad_webhook}
    C --> D{event_object\nexists?}
    D -- No --> E[return False]
    D -- Yes --> F{inline metadata\nhas MOAD markers?}
    F -- Yes --> G[return True]
    F -- No --> H{event_type\nstarts with invoice.?}
    H -- No --> I[return False]
    H -- Yes --> J{subscription_id\nfound?}
    J -- No --> K[return False]
    J -- Yes --> L[stripe_sdk.Subscription.retrieve]
    L -- Success --> M{subscription metadata\nhas MOAD markers?}
    M -- Yes --> N[return True]
    M -- No --> O[return False]
    L -- Exception --> P[log warning + re-raise]
    P --> Q[outer handler catches\nreturns HTTP 500]
    G --> R{is_moad_webhook = True?}
    N --> R
    O --> S{is_moad_webhook = False?}
    E --> S
    I --> S
    K --> S
    R -- Yes --> T[ACK 200\nno legacy claim\nno background task]
    S -- No --> U[write idempotency claim\ndispatch background task\nreturn 200]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[POST /billing/events] --> B[decode_stripe_event]
    B --> C{run_in_threadpool\nis_moad_webhook}
    C --> D{event_object\nexists?}
    D -- No --> E[return False]
    D -- Yes --> F{inline metadata\nhas MOAD markers?}
    F -- Yes --> G[return True]
    F -- No --> H{event_type\nstarts with invoice.?}
    H -- No --> I[return False]
    H -- Yes --> J{subscription_id\nfound?}
    J -- No --> K[return False]
    J -- Yes --> L[stripe_sdk.Subscription.retrieve]
    L -- Success --> M{subscription metadata\nhas MOAD markers?}
    M -- Yes --> N[return True]
    M -- No --> O[return False]
    L -- Exception --> P[log warning + re-raise]
    P --> Q[outer handler catches\nreturns HTTP 500]
    G --> R{is_moad_webhook = True?}
    N --> R
    O --> S{is_moad_webhook = False?}
    E --> S
    I --> S
    K --> S
    R -- Yes --> T[ACK 200\nno legacy claim\nno background task]
    S -- No --> U[write idempotency claim\ndispatch background task\nreturn 200]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["feat: Add subscription ID coercion for i..."](https://github.com/amazeeio/amazee.ai/commit/631bcf1a8ad7709f6ab6ddcd931f8138d8da5a3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39762913)</sub>

<!-- /greptile_comment -->