### PR TITLE
feat(webhooks): add legacy drain mode for Stripe webhook processing

### DIFF
--- a/app/api/webhooks.py
+++ b/app/api/webhooks.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["billing"])
 
 BILLING_WEBHOOK_KEY = "stripe_webhook_secret"
+LEGACY_STRIPE_DRAIN_MODE_ENV = "LEGACY_STRIPE_DRAIN_MODE"
 
 
 @router.post("/events")
@@ -36,6 +37,19 @@ async def handle_events(
     background task so Stripe receives a fast 200 response.
     """
     try:
+        # Temporary post-migration safety valve: once PROD billing has moved to
+        # MOAD's /cycle flow, the legacy amazee.ai webhook should acknowledge
+        # any late/retried Stripe deliveries without mutating legacy billing
+        # state. This buys time for manual subscription cancellation in Stripe.
+        if os.getenv(LEGACY_STRIPE_DRAIN_MODE_ENV):
+            logger.warning(
+                "Stripe webhook drain mode enabled; acknowledging event without processing"
+            )
+            return Response(
+                status_code=status.HTTP_200_OK,
+                content="Webhook acknowledged by drain mode",
+            )
+
         # Resolve webhook secret: env var takes precedence, then DB
         if os.getenv("WEBHOOK_SIG"):
             webhook_secret = os.getenv("WEBHOOK_SIG")

--- a/app/api/webhooks.py
+++ b/app/api/webhooks.py
@@ -41,7 +41,7 @@ async def handle_events(
         # MOAD's /cycle flow, the legacy amazee.ai webhook should acknowledge
         # any late/retried Stripe deliveries without mutating legacy billing
         # state. This buys time for manual subscription cancellation in Stripe.
-        if os.getenv(LEGACY_STRIPE_DRAIN_MODE_ENV):
+        if os.getenv(LEGACY_STRIPE_DRAIN_MODE_ENV, "").lower() in ("1", "true", "yes"):
             logger.warning(
                 "Stripe webhook drain mode enabled; acknowledging event without processing"
             )

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -64,6 +64,36 @@ def webhook_secret_env(monkeypatch):
     yield
 
 
+def test_webhook_drain_mode_returns_200_and_skips_processing(client, db, monkeypatch):
+    monkeypatch.setenv("LEGACY_STRIPE_DRAIN_MODE", "true")
+
+    with (
+        patch("app.api.webhooks.decode_stripe_event") as mock_decode,
+        patch(
+            "app.api.webhooks.handle_stripe_event_background", new_callable=AsyncMock
+        ) as mock_background,
+    ):
+        response = client.post(
+            "/billing/events",
+            content=b'{"id": "evt_drain_mode"}',
+            headers={
+                "stripe-signature": "t=1,v1=fake",
+                "content-type": "application/json",
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    mock_decode.assert_not_called()
+    mock_background.assert_not_awaited()
+
+    claim = (
+        db.query(DBStripeProcessedEvent)
+        .filter(DBStripeProcessedEvent.stripe_event_id == "evt_drain_mode")
+        .first()
+    )
+    assert claim is None
+
+
 def test_webhook_endpoint_returns_200_for_real_stripe_event(
     client, db, webhook_secret_env
 ):

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -64,8 +64,9 @@ def webhook_secret_env(monkeypatch):
     yield
 
 
-def test_webhook_drain_mode_returns_200_and_skips_processing(client, db, monkeypatch):
-    monkeypatch.setenv("LEGACY_STRIPE_DRAIN_MODE", "true")
+@pytest.mark.parametrize("drain_value", ["true", "1", "yes", "True", "YES"])
+def test_webhook_drain_mode_returns_200_and_skips_processing(client, db, monkeypatch, drain_value):
+    monkeypatch.setenv("LEGACY_STRIPE_DRAIN_MODE", drain_value)
 
     with (
         patch("app.api.webhooks.decode_stripe_event") as mock_decode,


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Introduces a temporary "drain mode" for the legacy Stripe webhook endpoint: when `LEGACY_STRIPE_DRAIN_MODE` is set to a truthy value (`1`, `true`, `yes`), the handler returns 200 immediately without signature verification, DB writes, or background processing — giving operators a safe window to let Stripe retries exhaust themselves during a billing migration.

- The env-var guard uses `.lower() in (\"1\", \"true\", \"yes\")`, correctly avoiding the bare-truthiness bug where `\"false\"` or `\"0\"` would silently activate drain mode.
- A parametrized test covers all five accepted truthy variants and asserts that `decode_stripe_event`, the background worker, and the idempotency table are all bypassed.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a narrow, well-commented early-return with no mutations to existing logic and correct env-var parsing.

The drain mode path is isolated to a single early-return before any existing code runs. The env-var check uses an explicit allowlist (.lower() in ("1", "true", "yes")), the feature is clearly documented as temporary, and the test suite covers all accepted truthy values while verifying no side effects occur.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/webhooks.py | Adds a drain-mode early-return at the top of the handler using a strict `.lower() in ("1", "true", "yes")` guard — correctly avoids the bare-truthiness `"false"` pitfall raised in prior review threads. |
| tests/test_webhooks.py | Adds a parametrized drain-mode test covering all five accepted truthy values; verifies `decode_stripe_event` is not called, no background task is awaited, and no idempotency row is written. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Stripe
    participant Webhook as POST /billing/events
    participant DB
    participant BG as BackgroundTask

    Stripe->>Webhook: POST (stripe-signature + payload)

    alt "LEGACY_STRIPE_DRAIN_MODE = "1"/"true"/"yes""
        Webhook-->>Stripe: 200 "Webhook acknowledged by drain mode"
        Note over Webhook: No signature check, no DB write, no processing
    else Normal mode
        Webhook->>Webhook: Resolve webhook secret (env or DB)
        Webhook->>Webhook: decode_stripe_event (verify signature)
        Webhook->>DB: INSERT idempotency claim row
        alt Duplicate event
            Webhook-->>Stripe: 200 "Webhook already processed"
        else New event
            Webhook->>BG: add_task(handle_stripe_event_background, event)
            Webhook-->>Stripe: 200 "Webhook received and processing started"
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Stripe
    participant Webhook as POST /billing/events
    participant DB
    participant BG as BackgroundTask

    Stripe->>Webhook: POST (stripe-signature + payload)

    alt "LEGACY_STRIPE_DRAIN_MODE = "1"/"true"/"yes""
        Webhook-->>Stripe: 200 "Webhook acknowledged by drain mode"
        Note over Webhook: No signature check, no DB write, no processing
    else Normal mode
        Webhook->>Webhook: Resolve webhook secret (env or DB)
        Webhook->>Webhook: decode_stripe_event (verify signature)
        Webhook->>DB: INSERT idempotency claim row
        alt Duplicate event
            Webhook-->>Stripe: 200 "Webhook already processed"
        else New event
            Webhook->>BG: add_task(handle_stripe_event_background, event)
            Webhook-->>Stripe: 200 "Webhook received and processing started"
        end
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Update tests/test\_webhooks.py"](https://github.com/amazeeio/amazee.ai/commit/d94634aca0755797011cc35638c35185c8357c98) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40046430)</sub>

<!-- /greptile_comment -->