### PR TITLE
fix(frontend): explicitly pass NEXT_PUBLIC_NEW_DASHBOARD_URL as Docke…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,8 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+      args:
+        NEXT_PUBLIC_NEW_DASHBOARD_URL: ${NEXT_PUBLIC_NEW_DASHBOARD_URL:-}
     ports:
       - "3000:3000"
     command:


### PR DESCRIPTION
Without an explicit args declaration in docker-compose.yml, Lagoon does not pass the build-scope variable as --build-arg, so the value is not baked into the Next.js build and the dashboard URL link never renders on prod.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an explicit `args` declaration in `docker-compose.yml` for the `frontend` service so that `NEXT_PUBLIC_NEW_DASHBOARD_URL` is forwarded as a `--build-arg` during the Docker build. Without it, Lagoon never passed the variable to the Next.js build step, so the dashboard URL was never baked into the static output.

- The Dockerfile already declares `ARG NEXT_PUBLIC_NEW_DASHBOARD_URL` in both build stages and assigns it as an `ENV`, so the production image path is now complete.
- The `environment` block of the `frontend` service does not include this variable, meaning local development (which runs `npm run dev` with a volume mount) will not benefit from the fix and the dashboard URL will still be absent unless it is also added at runtime.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge — it correctly wires the build arg so Lagoon can pass the value into the Next.js production build.

The one-liner fix addresses the root cause described in the PR: without the explicit `args` declaration Lagoon never forwarded the variable, so the dashboard URL was absent in production. The Dockerfile already handles the arg correctly in both stages, so the production path is complete. The only gap is that local dev mode (which uses `npm run dev` with a volume mount) still won't see the variable because it is not in the `environment` block — but this is a non-blocking quality improvement and does not affect the Lagoon deployment being fixed.

No files require special attention beyond the single `docker-compose.yml` change.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docker-compose.yml | Adds explicit `args` block to the frontend build section so Lagoon passes `NEXT_PUBLIC_NEW_DASHBOARD_URL` as a `--build-arg`, allowing Next.js to bake it into the static output. The `environment` section does not include this variable, so local dev mode (which uses `npm run dev` with a volume mount) won't have it available at runtime. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Lagoon
    participant DockerCompose as docker-compose.yml
    participant Dockerfile as frontend/Dockerfile
    participant NextBuild as Next.js Build
    participant StaticOutput as Static Output

    Lagoon->>DockerCompose: Read build config
    DockerCompose->>Dockerfile: "docker build --build-arg NEXT_PUBLIC_NEW_DASHBOARD_URL=value"
    Note over DockerCompose,Dockerfile: Previously: arg not declared → not passed → empty
    Dockerfile->>NextBuild: ENV NEXT_PUBLIC_NEW_DASHBOARD_URL set in builder stage
    NextBuild->>StaticOutput: Variable baked into static JS bundle
    StaticOutput->>Lagoon: Image with dashboard URL embedded
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Lagoon
    participant DockerCompose as docker-compose.yml
    participant Dockerfile as frontend/Dockerfile
    participant NextBuild as Next.js Build
    participant StaticOutput as Static Output

    Lagoon->>DockerCompose: Read build config
    DockerCompose->>Dockerfile: "docker build --build-arg NEXT_PUBLIC_NEW_DASHBOARD_URL=value"
    Note over DockerCompose,Dockerfile: Previously: arg not declared → not passed → empty
    Dockerfile->>NextBuild: ENV NEXT_PUBLIC_NEW_DASHBOARD_URL set in builder stage
    NextBuild->>StaticOutput: Variable baked into static JS bundle
    StaticOutput->>Lagoon: Image with dashboard URL embedded
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `docker-compose.yml`, line 72-74 ([link](https://github.com/amazeeio/amazee.ai/blob/1a9c99337f8746f0467c5c380637f7e340259c13/docker-compose.yml#L72-L74)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`NEXT_PUBLIC_NEW_DASHBOARD_URL` missing from runtime environment for local dev**

   The new `build.args` entry correctly bakes the URL into the Docker image during `docker build`, which fixes the Lagoon production path. However, the `frontend` service is started with `npm run dev` and a volume mount (`./frontend:/app`), so the pre-built image content is bypassed entirely. In dev mode Next.js resolves `NEXT_PUBLIC_*` variables from the container's runtime environment, not from the build-time baked values. Because `NEXT_PUBLIC_NEW_DASHBOARD_URL` is absent from the `environment` block, developers running `docker-compose up` locally will still see the dashboard URL missing.


2. `docker-compose.yml`, line 72-73 ([link](https://github.com/amazeeio/amazee.ai/blob/1a9c99337f8746f0467c5c380637f7e340259c13/docker-compose.yml#L72-L73)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Adding `NEXT_PUBLIC_NEW_DASHBOARD_URL` to the `environment` block ensures the dev server also receives the value at runtime, mirroring the production behaviour.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(frontend): explicitly pass NEXT\_PUBL..."](https://github.com/amazeeio/amazee.ai/commit/1a9c99337f8746f0467c5c380637f7e340259c13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40769084)</sub>

<!-- /greptile_comment -->