### PR TITLE
fix: set default URL for NEW_DASHBOARD_URL if not defined

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,7 +2,7 @@ import { ArrowRight } from "lucide-react";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
 
-const NEW_DASHBOARD_URL = process.env.NEXT_PUBLIC_NEW_DASHBOARD_URL;
+const NEW_DASHBOARD_URL = process.env.NEXT_PUBLIC_NEW_DASHBOARD_URL || "https://my.amazee.io";
 
 export default function Home() {
   return (


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a hardcoded fallback value `"https://my.amazee.io"` to `NEW_DASHBOARD_URL` so that the redirect button is always rendered when the `NEXT_PUBLIC_NEW_DASHBOARD_URL` environment variable is not set.

- The env-var read now uses `||` to fall back to the hardcoded URL, making the \"New dashboard URL is not configured.\" error branch on line 66–69 unreachable dead code.
- The hardcoded URL is burned into the source; a future URL change would require a code edit and redeployment rather than an env-var update.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a one-line fallback that ensures the redirect button always renders.

The fix works correctly: the fallback URL is non-empty so the button always displays. The only leftover issue is that the conditional error-message branch in the JSX is now dead code and can be cleaned up.

frontend/src/app/page.tsx — the ternary guarding the button render can be simplified now that the URL always has a value.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/app/page.tsx | Adds a hardcoded default URL fallback; the existing "not configured" error branch becomes unreachable dead code. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Browser loads page.tsx] --> B{NEXT_PUBLIC_NEW_DASHBOARD_URL set?}
    B -- Yes --> C[Use env var value]
    B -- No --> D[Use hardcoded fallback\nhttps://my.amazee.io]
    C --> E[NEW_DASHBOARD_URL is truthy]
    D --> E
    E --> F{NEW_DASHBOARD_URL truthy?}
    F -- Always true --> G[Render redirect Button]
    F -. Never .-> H[Render error message\n'New dashboard URL is not configured.']
    style H stroke-dasharray: 5 5, color:#999
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Browser loads page.tsx] --> B{NEXT_PUBLIC_NEW_DASHBOARD_URL set?}
    B -- Yes --> C[Use env var value]
    B -- No --> D[Use hardcoded fallback\nhttps://my.amazee.io]
    C --> E[NEW_DASHBOARD_URL is truthy]
    D --> E
    E --> F{NEW_DASHBOARD_URL truthy?}
    F -- Always true --> G[Render redirect Button]
    F -. Never .-> H[Render error message\n'New dashboard URL is not configured.']
    style H stroke-dasharray: 5 5, color:#999
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `frontend/src/app/page.tsx`, line 59-70 ([link](https://github.com/amazeeio/amazee.ai/blob/f25e87649a1b0579aed7cff585d152120e14d47f/frontend/src/app/page.tsx#L59-L70)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Dead code — error branch is now unreachable**

   Since `NEW_DASHBOARD_URL` is now always a non-empty string (it falls back to `"https://my.amazee.io"`), the `else` branch on lines 66–69 that renders "New dashboard URL is not configured." can never be reached. Consider removing the conditional and rendering the `<Button>` unconditionally, or keeping the guard only if an empty-string env value should still be treated as "not configured" (in which case the `||` fallback already covers that and the branch can simply be dropped).

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix: set default URL for NEW\_DASHBOARD\_U..."](https://github.com/amazeeio/amazee.ai/commit/f25e87649a1b0579aed7cff585d152120e14d47f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40778482)</sub>

<!-- /greptile_comment -->