### PR TITLE
fix: don't leak individually-owned keys to other team members

### DIFF
--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -671,10 +671,16 @@ async def list_private_ai_keys(
                     # If force_user_keys is enabled, users can only see their own keys
                     query = query.filter(DBPrivateAIKey.owner_id == current_user.id)
                 else:
-                    # Otherwise, can see their own keys and team-owned keys
+                    # Otherwise, can see their own keys and team-owned keys.
+                    # "Team-owned" means owner_id is NULL — individually-owned
+                    # keys are only attributed to a team_id for billing/limits
+                    # and must not leak to the rest of the team.
                     query = query.filter(
                         (DBPrivateAIKey.owner_id == current_user.id)
-                        | (DBPrivateAIKey.team_id == current_user.team_id)
+                        | (
+                            (DBPrivateAIKey.team_id == current_user.team_id)
+                            & (DBPrivateAIKey.owner_id.is_(None))
+                        )
                     )
         else:
             # Regular users can only see their own keys
@@ -770,10 +776,16 @@ async def list_private_ai_keys_by_region(
                     # If force_user_keys is enabled, users can only see their own keys
                     query = query.filter(DBPrivateAIKey.owner_id == current_user.id)
                 else:
-                    # Otherwise, can see their own keys and team-owned keys
+                    # Otherwise, can see their own keys and team-owned keys.
+                    # "Team-owned" means owner_id is NULL — individually-owned
+                    # keys are only attributed to a team_id for billing/limits
+                    # and must not leak to the rest of the team.
                     query = query.filter(
                         (DBPrivateAIKey.owner_id == current_user.id)
-                        | (DBPrivateAIKey.team_id == current_user.team_id)
+                        | (
+                            (DBPrivateAIKey.team_id == current_user.team_id)
+                            & (DBPrivateAIKey.owner_id.is_(None))
+                        )
                     )
         else:
             # Regular users can only see their own keys

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -598,15 +598,20 @@ async def list_private_ai_keys(
     owner_id: Optional[int] = None,
     team_id: Optional[int] = None,
     search: Optional[str] = None,
+    show_all: bool = False,
     current_user=Depends(get_current_user_from_auth),
     db: Session = Depends(get_db),
 ):
     """
     List private AI keys.
     If user is admin:
-        - Returns all keys if no owner_id or team_id is provided
         - Returns keys for specific owner if owner_id is provided
         - Returns keys for specific team if team_id is provided
+        - Returns every key in the system if show_all=true is passed
+        - Otherwise (no params), returns only the admin's own keys — the
+          same safe default as any other caller. This avoids handing back
+          every secret in the database to any admin-scoped integration
+          (e.g. a management token) that calls this endpoint with no filters.
     If user is team admin:
         - Returns keys owned by users in their team AND keys owned by their team
     If user is not admin:
@@ -643,6 +648,10 @@ async def list_private_ai_keys(
                 (DBPrivateAIKey.owner_id.in_(team_user_ids))
                 | (DBPrivateAIKey.team_id == team_id)
             )
+        elif not show_all:
+            # Safe default: no filters and no explicit opt-in means "my own
+            # keys", not "every key in the system".
+            query = query.filter(DBPrivateAIKey.owner_id == current_user.id)
     else:
         # Check if user is a team admin
         if current_user.team_id is not None:
@@ -695,6 +704,7 @@ async def list_private_ai_keys_by_region(
     region_id: int,
     team_id: Optional[int] = None,
     user_id: Optional[int] = None,
+    show_all: bool = False,
     current_user=Depends(get_current_user_from_auth),
     db: Session = Depends(get_db),
 ):
@@ -712,6 +722,9 @@ async def list_private_ai_keys_by_region(
       parameter silently ignored. May be combined with `team_id` to further scope
       results to keys owned by that user within a particular team.
       Returns an empty list when the specified user does not exist.
+    - **show_all**: System admin only. Without it (and without team_id/user_id),
+      an admin caller gets only their own keys in this region rather than every
+      key in the region.
     """
     query = db.query(DBPrivateAIKey).outerjoin(
         DBTeam, DBPrivateAIKey.team_id == DBTeam.id
@@ -748,6 +761,11 @@ async def list_private_ai_keys_by_region(
             if user is None:
                 return []
             query = query.filter(DBPrivateAIKey.owner_id == user_id)
+
+        if team_id is None and user_id is None and not show_all:
+            # Safe default: no filters and no explicit opt-in means "my own
+            # keys in this region", not "every key in the region".
+            query = query.filter(DBPrivateAIKey.owner_id == current_user.id)
     else:
         # Check if user is a team admin
         if current_user.team_id is not None:

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -2233,7 +2233,8 @@ def test_restored_team_keys_are_accessible(
 
     # Verify key is not in list
     response = client.get(
-        "/private-ai-keys", headers={"Authorization": f"Bearer {admin_token}"}
+        "/private-ai-keys?show_all=true",
+        headers={"Authorization": f"Bearer {admin_token}"},
     )
     assert response.status_code == 200
     keys = response.json()
@@ -2248,7 +2249,8 @@ def test_restored_team_keys_are_accessible(
 
     # Verify key is now in list
     response = client.get(
-        "/private-ai-keys", headers={"Authorization": f"Bearer {admin_token}"}
+        "/private-ai-keys?show_all=true",
+        headers={"Authorization": f"Bearer {admin_token}"},
     )
     assert response.status_code == 200
     keys = response.json()

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -65,7 +65,9 @@ def webhook_secret_env(monkeypatch):
 
 
 @pytest.mark.parametrize("drain_value", ["true", "1", "yes", "True", "YES"])
-def test_webhook_drain_mode_returns_200_and_skips_processing(client, db, monkeypatch, drain_value):
+def test_webhook_drain_mode_returns_200_and_skips_processing(
+    client, db, monkeypatch, drain_value
+):
     monkeypatch.setenv("LEGACY_STRIPE_DRAIN_MODE", drain_value)
 
     with (
@@ -93,7 +95,6 @@ def test_webhook_drain_mode_returns_200_and_skips_processing(client, db, monkeyp
         .first()
     )
     assert claim is None
-
 
 
 def test_webhook_endpoint_returns_200_for_real_stripe_event(


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a data-isolation bug where non-admin team members could read individually-owned keys belonging to other members on the same team. It also tightens the admin default so that calling the key-listing endpoints without explicit filters now returns only the caller's own keys rather than the entire database, with a new `show_all=true` opt-in for the previous behavior.

- **Core fix (`owner_id.is_(None)`)**: The team-scoped leg of the filter for regular (non-admin, non-team-admin) users now requires `owner_id IS NULL`, ensuring only true team-owned keys (not individually-owned keys tagged to a team for billing) are visible to other members. Applied consistently to both `list_private_ai_keys` and `list_private_ai_keys_by_region`.
- **Admin safe-default (`show_all`)**: Both list endpoints now default to `owner_id == current_user.id` for admin callers with no filters, preventing management tokens from inadvertently receiving every secret in the database. Existing tests in `test_teams.py` were updated to pass `show_all=true`.
- **Test gap**: The equivalent test in `test_team_retention.py` (`test_list_keys_excludes_soft_deleted_teams`) was not updated and now passes trivially for the wrong reason, leaving soft-deleted key exclusion untested for admin-wide queries.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The logic change in the application code is correct and the fix is applied consistently across both list endpoints. The one concern worth resolving before merging is a missed test update in test_team_retention.py.

The production code in private_ai_keys.py is solid — the owner_id.is_(None) predicate and the show_all opt-in are applied symmetrically in both list endpoints and the logic is correct. However, test_list_keys_excludes_soft_deleted_teams in test_team_retention.py was not updated alongside the analogous tests in test_teams.py, so it now passes for a reason unrelated to soft-deleted key exclusion.

tests/test_team_retention.py — the test_list_keys_excludes_soft_deleted_teams test needs show_all=true to remain meaningful after the admin default change.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/private_ai_keys.py | Fixes individually-owned key leakage to non-admin team members by requiring owner_id IS NULL for the team-owned leg of the filter; adds show_all opt-in for admin-wide listings in both list endpoints. |
| tests/test_teams.py | Correctly updated two existing admin-listing assertions to pass show_all=true, preserving their original semantics after the default behavior change. |
| tests/test_team_retention.py | test_list_keys_excludes_soft_deleted_teams was not updated to use show_all=true, so it now passes trivially (admin sees no keys at all) rather than validating soft-deleted key exclusion. |
| tests/test_webhooks.py | Trivial formatting-only changes (function signature wrap, blank-line removal) with no logic impact. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GET /private-ai-keys] --> B{is_admin?}
    B -- Yes --> C{owner_id or team_id provided?}
    C -- owner_id --> D[Filter by owner_id]
    C -- team_id --> E[Filter by team_id + team member ids]
    C -- Neither --> F{show_all=true?}
    F -- Yes --> G[Return ALL keys]
    F -- No --> H[Filter: owner_id == current_user.id NEW safe default]
    B -- No --> I{role == TEAM_ADMIN?}
    I -- Yes --> J[Keys owned by any team member OR team-owned]
    I -- No --> K{force_user_keys?}
    K -- Yes --> L[Filter: owner_id == current_user.id]
    K -- No --> M[Filter: own keys OR team_id==team AND owner_id IS NULL FIX: was missing IS NULL]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[GET /private-ai-keys] --> B{is_admin?}
    B -- Yes --> C{owner_id or team_id provided?}
    C -- owner_id --> D[Filter by owner_id]
    C -- team_id --> E[Filter by team_id + team member ids]
    C -- Neither --> F{show_all=true?}
    F -- Yes --> G[Return ALL keys]
    F -- No --> H[Filter: owner_id == current_user.id NEW safe default]
    B -- No --> I{role == TEAM_ADMIN?}
    I -- Yes --> J[Keys owned by any team member OR team-owned]
    I -- No --> K{force_user_keys?}
    K -- Yes --> L[Filter: owner_id == current_user.id]
    K -- No --> M[Filter: own keys OR team_id==team AND owner_id IS NULL FIX: was missing IS NULL]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["test: Update URL for private AI keys to ..."](https://github.com/amazeeio/amazee.ai/commit/7efdb3d719d1507233e29185b7a94c197bb4e7dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41035558)</sub>

<!-- /greptile_comment -->