### PR TITLE
refactor(api): remove show_all parameter from private AI keys endpoint

### DIFF
--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -598,7 +598,6 @@ async def list_private_ai_keys(
     owner_id: Optional[int] = None,
     team_id: Optional[int] = None,
     search: Optional[str] = None,
-    show_all: bool = False,
     current_user=Depends(get_current_user_from_auth),
     db: Session = Depends(get_db),
 ):
@@ -607,7 +606,6 @@ async def list_private_ai_keys(
     If user is admin:
         - Returns keys for specific owner if owner_id is provided
         - Returns keys for specific team if team_id is provided
-        - Returns every key in the system if show_all=true is passed
         - Otherwise (no params), returns only the admin's own keys — the
           same safe default as any other caller. This avoids handing back
           every secret in the database to any admin-scoped integration
@@ -648,9 +646,9 @@ async def list_private_ai_keys(
                 (DBPrivateAIKey.owner_id.in_(team_user_ids))
                 | (DBPrivateAIKey.team_id == team_id)
             )
-        elif not show_all:
-            # Safe default: no filters and no explicit opt-in means "my own
-            # keys", not "every key in the system".
+        else:
+            # Safe default: an admin with no filters gets only their own
+            # keys, not every key in the system.
             query = query.filter(DBPrivateAIKey.owner_id == current_user.id)
     else:
         # Check if user is a team admin
@@ -704,7 +702,6 @@ async def list_private_ai_keys_by_region(
     region_id: int,
     team_id: Optional[int] = None,
     user_id: Optional[int] = None,
-    show_all: bool = False,
     current_user=Depends(get_current_user_from_auth),
     db: Session = Depends(get_db),
 ):
@@ -722,9 +719,9 @@ async def list_private_ai_keys_by_region(
       parameter silently ignored. May be combined with `team_id` to further scope
       results to keys owned by that user within a particular team.
       Returns an empty list when the specified user does not exist.
-    - **show_all**: System admin only. Without it (and without team_id/user_id),
-      an admin caller gets only their own keys in this region rather than every
-      key in the region.
+
+    Without team_id or user_id, an admin caller gets only their own keys in
+    this region rather than every key in the region.
     """
     query = db.query(DBPrivateAIKey).outerjoin(
         DBTeam, DBPrivateAIKey.team_id == DBTeam.id
@@ -762,9 +759,9 @@ async def list_private_ai_keys_by_region(
                 return []
             query = query.filter(DBPrivateAIKey.owner_id == user_id)
 
-        if team_id is None and user_id is None and not show_all:
-            # Safe default: no filters and no explicit opt-in means "my own
-            # keys in this region", not "every key in the region".
+        if team_id is None and user_id is None:
+            # Safe default: an admin with no filters gets only their own keys
+            # in this region, not every key in the region.
             query = query.filter(DBPrivateAIKey.owner_id == current_user.id)
     else:
         # Check if user is a team admin

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -2233,7 +2233,7 @@ def test_restored_team_keys_are_accessible(
 
     # Verify key is not in list
     response = client.get(
-        "/private-ai-keys?show_all=true",
+        f"/private-ai-keys?team_id={team_id}",
         headers={"Authorization": f"Bearer {admin_token}"},
     )
     assert response.status_code == 200
@@ -2249,7 +2249,7 @@ def test_restored_team_keys_are_accessible(
 
     # Verify key is now in list
     response = client.get(
-        "/private-ai-keys?show_all=true",
+        f"/private-ai-keys?team_id={team_id}",
         headers={"Authorization": f"Bearer {admin_token}"},
     )
     assert response.status_code == 200


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes the `show_all` boolean query parameter from the two private-AI-key list endpoints (`GET /private-ai-keys` and `GET /private-ai-keys/region/{region_id}`). The conditional `elif not show_all` branches are replaced with unconditional `else`, so an admin caller that supplies no `owner_id`, `team_id`, or `user_id` filter now always receives only their own keys.

- **`app/api/private_ai_keys.py`**: `show_all` parameter dropped from both endpoint signatures; the fallback filter (`owner_id == current_user.id`) is now always applied for admin callers with no explicit scope filters, making the safe-default behaviour permanent rather than opt-out.
- **`tests/test_teams.py`**: `test_restored_team_keys_are_accessible` is updated to use `?team_id={team_id}` instead of `?show_all=true`; the soft-delete exclusion logic continues to be validated through the team-scoped admin code path.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Straightforward removal of a parameter that bypassed the safe-default scoping rule; all code paths now enforce the same behaviour unconditionally.

Both endpoints are simplified by eliminating the bypass branch entirely. Existing callers that passed show_all=true will now receive only the admin's own keys instead of all keys — this is intentional and aligns with the safe-default already documented in the code. The test update accurately reflects the new contract by switching to a team_id filter that exercises the same soft-delete exclusion logic. No new logic is introduced, no data is lost, and no existing safety check is weakened.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/private_ai_keys.py | Removes show_all query parameter from both list_private_ai_keys and list_private_ai_keys_by_region; the safe-default branch (admin sees only their own keys when no filters supplied) is now always taken, closing the bypass path. |
| tests/test_teams.py | Updates test_restored_team_keys_are_accessible to use ?team_id={team_id} instead of the removed ?show_all=true; the soft-delete exclusion logic is still fully exercised through the team-scoped filter path. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant API as list_private_ai_keys
    participant DB

    Client->>API: GET /private-ai-keys (admin, no filters)
    API->>DB: "filter owner_id == current_user.id"
    DB-->>API: admin's own keys only
    API-->>Client: 200 own keys

    Client->>API: "GET /private-ai-keys?owner_id=X (admin)"
    API->>DB: "filter owner_id == X"
    DB-->>API: keys for owner X
    API-->>Client: 200 owner X keys

    Client->>API: "GET /private-ai-keys?team_id=Y (admin)"
    API->>DB: "filter owner_id IN team_users OR team_id == Y"
    DB-->>API: team keys
    API-->>Client: 200 team Y keys

    Note over Client,API: show_all removed - passing it is now silently ignored and admin gets only their own keys
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant API as list_private_ai_keys
    participant DB

    Client->>API: GET /private-ai-keys (admin, no filters)
    API->>DB: "filter owner_id == current_user.id"
    DB-->>API: admin's own keys only
    API-->>Client: 200 own keys

    Client->>API: "GET /private-ai-keys?owner_id=X (admin)"
    API->>DB: "filter owner_id == X"
    DB-->>API: keys for owner X
    API-->>Client: 200 owner X keys

    Client->>API: "GET /private-ai-keys?team_id=Y (admin)"
    API->>DB: "filter owner_id IN team_users OR team_id == Y"
    DB-->>API: team keys
    API-->>Client: 200 team Y keys

    Note over Client,API: show_all removed - passing it is now silently ignored and admin gets only their own keys
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(api): remove show\_all parameter..."](https://github.com/amazeeio/amazee.ai/commit/daea6d5fc1b4b3d7f0cd74a58e1be0edab37b5ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41056887)</sub>

<!-- /greptile_comment -->