### PR TITLE
feat(spend): implement endpoint to retrieve key daily activity data

### DIFF
--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -1422,14 +1422,15 @@ async def get_key_daily_activity(
         if not row.get("date"):
             continue
         metrics = row.get("metrics") or {}
+        spend_val = metrics.get("spend")
         activity.append(
             KeyDailyActivityRow(
                 date=row["date"],
-                spend=metrics.get("spend") or 0.0,
-                prompt_tokens=metrics.get("prompt_tokens") or 0,
-                completion_tokens=metrics.get("completion_tokens") or 0,
-                total_tokens=metrics.get("total_tokens") or 0,
-                request_count=metrics.get("api_requests") or 0,
+                spend=spend_val if spend_val is not None else 0.0,
+                prompt_tokens=metrics.get("prompt_tokens") if metrics.get("prompt_tokens") is not None else 0,
+                completion_tokens=metrics.get("completion_tokens") if metrics.get("completion_tokens") is not None else 0,
+                total_tokens=metrics.get("total_tokens") if metrics.get("total_tokens") is not None else 0,
+                request_count=metrics.get("api_requests") if metrics.get("api_requests") is not None else 0,
             )
         )
     activity.sort(key=lambda r: r.date)

--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -39,6 +39,8 @@ from app.schemas.limits import OwnerType, ResourceType
 from app.api.users import invalidate_user_spend_cache
 from app.schemas.models import (
     BudgetType,
+    KeyDailyActivityResponse,
+    KeyDailyActivityRow,
     PrivateAIKeySpend,
     SpendBudgetUpdateRequest,
     SpendBudgetUpdateResponse,
@@ -1348,6 +1350,97 @@ async def get_key_spend_alias(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to get Private AI Key spend: {str(exc)}",
         )
+
+
+@router.get(
+    "/{region_id}/key/{key_id}/daily-activity",
+    response_model=KeyDailyActivityResponse,
+    summary="Get key daily activity by region",
+    description=(
+        "Returns per-day usage (spend, tokens and request count) for a specific "
+        "key in the specified region across the requested date range. Proxies "
+        "LiteLLM's `/user/daily/activity`, filtered to this key. Days with no "
+        "usage are omitted from the response."
+    ),
+    response_description="Per-day usage rows for the key, ordered by date.",
+)
+async def get_key_daily_activity(
+    region_id: int,
+    key_id: int,
+    start_date: date = Query(
+        ..., description="Start date (inclusive), formatted YYYY-MM-DD."
+    ),
+    end_date: date = Query(
+        ..., description="End date (inclusive), formatted YYYY-MM-DD."
+    ),
+    current_user: DBUser = Depends(get_current_user_from_auth),
+    user_role: str = Depends(get_private_ai_access),
+    db: Session = Depends(get_db),
+):
+    if start_date > end_date:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="start_date must be on or before end_date",
+        )
+
+    key = db.query(DBPrivateAIKey).filter(DBPrivateAIKey.id == key_id).first()
+    if not key:
+        raise HTTPException(status_code=404, detail="Private AI Key not found")
+    if key.region_id != region_id:
+        raise HTTPException(
+            status_code=404, detail="Private AI Key not found in region"
+        )
+
+    # Reuse authorization semantics from get_key_spend_alias.
+    if current_user.is_admin:
+        pass
+    elif user_role in [UserRole.TEAM_ADMIN, UserRole.KEY_CREATOR, UserRole.READ_ONLY]:
+        if key.team_id is not None:
+            if key.team_id != current_user.team_id:
+                raise HTTPException(status_code=404, detail="Private AI Key not found")
+        else:
+            owner = db.query(DBUser).filter(DBUser.id == key.owner_id).first()
+            if not owner or owner.team_id != current_user.team_id:
+                raise HTTPException(status_code=404, detail="Private AI Key not found")
+    else:
+        if key.owner_id != current_user.id:
+            raise HTTPException(status_code=404, detail="Private AI Key not found")
+
+    region = _get_region_or_404(db, region_id)
+    service = LiteLLMService(
+        api_url=region.litellm_api_url, api_key=region.litellm_api_key
+    )
+
+    rows = await service.get_daily_activity(
+        litellm_token=key.litellm_token,
+        start_date=start_date.isoformat(),
+        end_date=end_date.isoformat(),
+    )
+
+    activity: list[KeyDailyActivityRow] = []
+    for row in rows:
+        if not row.get("date"):
+            continue
+        metrics = row.get("metrics") or {}
+        activity.append(
+            KeyDailyActivityRow(
+                date=row["date"],
+                spend=metrics.get("spend") or 0.0,
+                prompt_tokens=metrics.get("prompt_tokens") or 0,
+                completion_tokens=metrics.get("completion_tokens") or 0,
+                total_tokens=metrics.get("total_tokens") or 0,
+                request_count=metrics.get("api_requests") or 0,
+            )
+        )
+    activity.sort(key=lambda r: r.date)
+
+    return KeyDailyActivityResponse(
+        region_id=region_id,
+        key_id=key_id,
+        start_date=start_date,
+        end_date=end_date,
+        activity=activity,
+    )
 
 
 @router.put(

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, ConfigDict, EmailStr, AfterValidator, Field
 from typing import Optional, List, ClassVar, Literal, Dict, Annotated, Any
-from datetime import datetime
+from datetime import date, datetime
 from sqlalchemy.orm import relationship
 from enum import Enum
 
@@ -569,6 +569,33 @@ class UserSpendResponse(BaseModel):
     total_tokens: Optional[int] = None
     key_count: int
     keys: List[SpendKeyItem]
+
+
+class KeyDailyActivityRow(BaseModel):
+    date: date
+    spend: float = 0.0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    request_count: int = Field(
+        default=0,
+        description="Number of API requests made with this key on this day.",
+    )
+    model_config = ConfigDict(from_attributes=True)
+
+
+class KeyDailyActivityResponse(BaseModel):
+    region_id: int
+    key_id: int
+    start_date: date
+    end_date: date
+    activity: List[KeyDailyActivityRow] = Field(
+        description=(
+            "Per-day usage rows for the key, ordered ascending by date. "
+            "Days with no usage are omitted."
+        )
+    )
+    model_config = ConfigDict(from_attributes=True)
 
 
 class SpendBudgetUpdateRequest(BaseModel):

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -285,9 +285,10 @@ class LiteLLMService:
         hashed_token = self.hash_token(litellm_token)
         results: list[dict] = []
         page = 1
+        max_pages = 100
         try:
             async with httpx.AsyncClient() as client:
-                while True:
+                while page <= max_pages:
                     response = await client.get(
                         f"{self.api_url}/user/daily/activity",
                         headers={"Authorization": f"Bearer {self.master_key}"},

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -1,3 +1,4 @@
+import hashlib
 import httpx
 from fastapi import HTTPException, status
 import logging
@@ -27,6 +28,18 @@ class LiteLLMService:
     def format_team_id(region_name: str, team_id: int) -> str:
         """Generate the correctly formatted team_id for LiteLLM"""
         return f"{region_name.replace(' ', '_')}_{team_id}"
+
+    @staticmethod
+    def hash_token(litellm_token: str) -> str:
+        """Hash a LiteLLM key the way LiteLLM stores it internally.
+
+        LiteLLM persists ``sk-`` keys as their SHA-256 hexdigest (e.g. in the
+        daily-spend tables that back ``/user/daily/activity``). Any other token
+        is stored verbatim. Mirrors LiteLLM's ``_hash_token_if_needed``.
+        """
+        if litellm_token.startswith("sk-"):
+            return hashlib.sha256(litellm_token.encode()).hexdigest()
+        return litellm_token
 
     @staticmethod
     def sanitize_alias(alias: str) -> str:
@@ -253,6 +266,62 @@ class LiteLLMService:
             raise HTTPException(
                 status_code=status_code,
                 detail=f"Failed to get LiteLLM key information: {error_msg}",
+            )
+
+    async def get_daily_activity(
+        self,
+        litellm_token: str,
+        start_date: str,
+        end_date: str,
+        page_size: int = 1000,
+    ) -> list[dict]:
+        """Fetch per-day usage for a single key from LiteLLM.
+
+        Proxies LiteLLM's ``/user/daily/activity`` endpoint, filtered to the
+        given key (via its hashed token), and paginates through every page.
+        Returns the raw ``results`` rows, each containing ``date``, ``metrics``
+        and ``breakdown``.
+        """
+        hashed_token = self.hash_token(litellm_token)
+        results: list[dict] = []
+        page = 1
+        try:
+            async with httpx.AsyncClient() as client:
+                while True:
+                    response = await client.get(
+                        f"{self.api_url}/user/daily/activity",
+                        headers={"Authorization": f"Bearer {self.master_key}"},
+                        params={
+                            "start_date": start_date,
+                            "end_date": end_date,
+                            "api_key": hashed_token,
+                            "page": page,
+                            "page_size": page_size,
+                        },
+                    )
+                    response.raise_for_status()
+                    data = response.json()
+                    results.extend(data.get("results", []))
+                    metadata = data.get("metadata") or {}
+                    if not metadata.get("has_more"):
+                        break
+                    page += 1
+            logger.info("Successfully retrieved LiteLLM daily activity")
+            return results
+        except httpx.HTTPStatusError as e:
+            error_msg = str(e)
+            logger.error(f"Error getting LiteLLM daily activity: {error_msg}")
+            status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+            if hasattr(e, "response") and e.response is not None:
+                status_code = e.response.status_code
+                try:
+                    error_details = e.response.json()
+                    error_msg = f"Status {e.response.status_code}: {error_details}"
+                except ValueError:
+                    error_msg = f"Status {e.response.status_code}: {e.response.text}"
+            raise HTTPException(
+                status_code=status_code,
+                detail=f"Failed to get LiteLLM daily activity: {error_msg}",
             )
 
     async def update_budget(

--- a/tests/test_litellm_service.py
+++ b/tests/test_litellm_service.py
@@ -931,3 +931,98 @@ def test_get_team_model_aliases_team_list_fallback_returns_none_when_not_found(
     aliases = asyncio.run(service.get_team_model_aliases("team-1"))
 
     assert aliases == {}
+
+
+def test_hash_token_hashes_sk_keys():
+    """sk- keys are SHA-256 hashed the way LiteLLM stores them."""
+    import hashlib
+
+    token = "sk-abc123"
+    expected = hashlib.sha256(token.encode()).hexdigest()
+    assert LiteLLMService.hash_token(token) == expected
+
+
+def test_hash_token_passes_through_non_sk_tokens():
+    """Tokens that are not sk- keys are returned unchanged."""
+    assert LiteLLMService.hash_token("already-hashed-token") == "already-hashed-token"
+
+
+def _daily_activity_page(results, has_more):
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "results": results,
+        "metadata": {"has_more": has_more},
+    }
+    mock_response.raise_for_status.return_value = None
+    return mock_response
+
+
+@patch("httpx.AsyncClient")
+def test_get_daily_activity_paginates_and_filters_by_hashed_key(
+    mock_client_class, test_region
+):
+    """get_daily_activity follows pagination and filters by the hashed token."""
+    page1 = _daily_activity_page(
+        [{"date": "2025-06-01", "metrics": {"spend": 1.0}}], has_more=True
+    )
+    page2 = _daily_activity_page(
+        [{"date": "2025-06-02", "metrics": {"spend": 2.0}}], has_more=False
+    )
+
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = [page1, page2]
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+    mock_client_class.return_value = mock_client
+
+    service = LiteLLMService(
+        api_url=test_region.litellm_api_url, api_key=test_region.litellm_api_key
+    )
+
+    results = asyncio.run(
+        service.get_daily_activity(
+            litellm_token="sk-abc123",
+            start_date="2025-06-01",
+            end_date="2025-06-02",
+        )
+    )
+
+    assert [r["date"] for r in results] == ["2025-06-01", "2025-06-02"]
+    assert mock_client.get.call_count == 2
+
+    import hashlib
+
+    expected_hash = hashlib.sha256(b"sk-abc123").hexdigest()
+    first_call = mock_client.get.call_args_list[0]
+    assert first_call.kwargs["params"]["api_key"] == expected_hash
+    assert first_call.kwargs["params"]["start_date"] == "2025-06-01"
+    assert first_call.kwargs["params"]["end_date"] == "2025-06-02"
+    assert first_call.kwargs["params"]["page"] == 1
+    # Second page requested when has_more is True.
+    assert mock_client.get.call_args_list[1].kwargs["params"]["page"] == 2
+
+
+@patch("httpx.AsyncClient")
+def test_get_daily_activity_failure(
+    mock_client_class, test_region, mock_httpx_failure_client
+):
+    """A LiteLLM error is surfaced as an HTTPException."""
+    mock_client_class.return_value = mock_httpx_failure_client(
+        500, "Internal Server Error"
+    )
+
+    service = LiteLLMService(
+        api_url=test_region.litellm_api_url, api_key=test_region.litellm_api_key
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(
+            service.get_daily_activity(
+                litellm_token="sk-abc123",
+                start_date="2025-06-01",
+                end_date="2025-06-02",
+            )
+        )
+
+    assert "Failed to get LiteLLM daily activity" in exc_info.value.detail

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -169,6 +169,154 @@ def test_key_spend_alias(
     assert data["total_tokens"] == 1500
 
 
+@patch("app.api.spend.LiteLLMService.get_daily_activity", new_callable=AsyncMock)
+def test_key_daily_activity(
+    mock_get_daily_activity, client, team_admin_token, test_team_user, test_region, db
+):
+    key = DBPrivateAIKey(
+        name="daily-activity-key",
+        litellm_token="sk-daily-token",
+        region_id=test_region.id,
+        owner_id=test_team_user.id,
+        team_id=test_team_user.team_id,
+    )
+    db.add(key)
+    db.commit()
+
+    # Returned out of order to verify the endpoint sorts ascending by date.
+    mock_get_daily_activity.return_value = [
+        {
+            "date": "2025-06-02",
+            "metrics": {
+                "spend": 2.5,
+                "prompt_tokens": 200,
+                "completion_tokens": 50,
+                "total_tokens": 250,
+                "api_requests": 4,
+            },
+        },
+        {
+            "date": "2025-06-01",
+            "metrics": {
+                "spend": 1.0,
+                "prompt_tokens": 100,
+                "completion_tokens": 20,
+                "total_tokens": 120,
+                "api_requests": 2,
+            },
+        },
+    ]
+
+    response = client.get(
+        f"/spend/{test_region.id}/key/{key.id}/daily-activity",
+        params={"start_date": "2025-06-01", "end_date": "2025-06-02"},
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["region_id"] == test_region.id
+    assert data["key_id"] == key.id
+    assert data["start_date"] == "2025-06-01"
+    assert data["end_date"] == "2025-06-02"
+    assert [row["date"] for row in data["activity"]] == ["2025-06-01", "2025-06-02"]
+    first = data["activity"][0]
+    assert first["spend"] == 1.0
+    assert first["prompt_tokens"] == 100
+    assert first["completion_tokens"] == 20
+    assert first["total_tokens"] == 120
+    assert first["request_count"] == 2
+
+    # Endpoint forwards the key's plaintext token and the requested range.
+    mock_get_daily_activity.assert_awaited_once()
+    kwargs = mock_get_daily_activity.await_args.kwargs
+    assert kwargs["litellm_token"] == "sk-daily-token"
+    assert kwargs["start_date"] == "2025-06-01"
+    assert kwargs["end_date"] == "2025-06-02"
+
+
+@patch("app.api.spend.LiteLLMService.get_daily_activity", new_callable=AsyncMock)
+def test_key_daily_activity_empty(
+    mock_get_daily_activity, client, team_admin_token, test_team_user, test_region, db
+):
+    key = DBPrivateAIKey(
+        name="daily-activity-empty-key",
+        litellm_token="sk-empty-token",
+        region_id=test_region.id,
+        owner_id=test_team_user.id,
+        team_id=test_team_user.team_id,
+    )
+    db.add(key)
+    db.commit()
+    mock_get_daily_activity.return_value = []
+
+    response = client.get(
+        f"/spend/{test_region.id}/key/{key.id}/daily-activity",
+        params={"start_date": "2025-06-01", "end_date": "2025-06-02"},
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code == 200
+    assert response.json()["activity"] == []
+
+
+@patch("app.api.spend.LiteLLMService.get_daily_activity", new_callable=AsyncMock)
+def test_key_daily_activity_invalid_range(
+    mock_get_daily_activity, client, team_admin_token, test_team_user, test_region, db
+):
+    key = DBPrivateAIKey(
+        name="daily-activity-range-key",
+        litellm_token="sk-range-token",
+        region_id=test_region.id,
+        owner_id=test_team_user.id,
+        team_id=test_team_user.team_id,
+    )
+    db.add(key)
+    db.commit()
+
+    response = client.get(
+        f"/spend/{test_region.id}/key/{key.id}/daily-activity",
+        params={"start_date": "2025-06-05", "end_date": "2025-06-01"},
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code == 400
+    mock_get_daily_activity.assert_not_awaited()
+
+
+@patch("app.api.spend.LiteLLMService.get_daily_activity", new_callable=AsyncMock)
+def test_key_daily_activity_key_not_found(
+    mock_get_daily_activity, client, team_admin_token, test_region
+):
+    response = client.get(
+        f"/spend/{test_region.id}/key/999999/daily-activity",
+        params={"start_date": "2025-06-01", "end_date": "2025-06-02"},
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code == 404
+    mock_get_daily_activity.assert_not_awaited()
+
+
+@patch("app.api.spend.LiteLLMService.get_daily_activity", new_callable=AsyncMock)
+def test_key_daily_activity_forbidden_other_owner(
+    mock_get_daily_activity, client, test_token, test_admin, test_region, db
+):
+    # Key owned by another user (the admin), no team; requested by test_user.
+    key = DBPrivateAIKey(
+        name="daily-activity-other-owner-key",
+        litellm_token="sk-other-token",
+        region_id=test_region.id,
+        owner_id=test_admin.id,
+    )
+    db.add(key)
+    db.commit()
+
+    response = client.get(
+        f"/spend/{test_region.id}/key/{key.id}/daily-activity",
+        params={"start_date": "2025-06-01", "end_date": "2025-06-02"},
+        headers={"Authorization": f"Bearer {test_token}"},
+    )
+    assert response.status_code == 404
+    mock_get_daily_activity.assert_not_awaited()
+
+
 @patch("app.api.spend.LiteLLMService.get_key_info", new_callable=AsyncMock)
 def test_key_spend_alias_uses_configured_cap_for_no_purchase_pool_team(
     mock_get_key_info, client, admin_token, test_team, test_region, db


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a new `GET /{region_id}/key/{key_id}/daily-activity` endpoint that returns per-day spend, token, and request-count data for a single Private AI Key by proxying LiteLLM's `/user/daily/activity` API. It also introduces a `hash_token` utility to convert plaintext `sk-` keys into the SHA-256 digests that LiteLLM stores internally.

- **New endpoint** (`app/api/spend.py`): validates date range, replicates the authorization logic from `get_key_spend_alias`, delegates to a new service method, and sorts the resulting rows ascending by date.
- **New service method** (`app/services/litellm.py`): `get_daily_activity` hashes the token, paginates through LiteLLM with a 100-page cap (`max_pages = 100`), and returns accumulated results.
- **New schemas** (`app/schemas/models.py`): `KeyDailyActivityRow` and `KeyDailyActivityResponse` with proper `is not None` guards in the endpoint rather than falsy-value `or` checks.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the new endpoint is self-contained, authorization is an exact copy of the audited pattern in get_key_spend_alias, and the two concerns raised in earlier review rounds (pagination bound and falsy-value defaults) are both addressed in this revision.

The change adds a read-only endpoint with no writes or schema migrations. Authorization logic is copied verbatim from a pre-existing, reviewed endpoint. The pagination cap (max_pages=100) is in place, the is-not-None guards are used consistently, and the hashing helper is unit-tested against the known LiteLLM convention. No logic errors or unsafe paths were found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/spend.py | Adds the new GET daily-activity endpoint; authorization mirrors get_key_spend_alias exactly; date-range validation, region check, and response assembly all look correct. |
| app/services/litellm.py | Adds hash_token static method and get_daily_activity; pagination is now bounded by max_pages=100; error handling is consistent with existing service methods. |
| app/schemas/models.py | Adds KeyDailyActivityRow and KeyDailyActivityResponse Pydantic models; field types and defaults are appropriate; from_attributes=True is unnecessary but harmless. |
| tests/test_spend.py | Good coverage: happy path, empty result, invalid date range, 404 for missing key, and forbidden access for a key owned by another user. |
| tests/test_litellm_service.py | Tests hash_token for sk- and non-sk- tokens, verifies pagination + hashed-key param forwarding, and confirms error is surfaced as HTTPException. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Endpoint as GET /spend/{region_id}/key/{key_id}/daily-activity
    participant DB
    participant LiteLLMService
    participant LiteLLM as LiteLLM /user/daily/activity

    Client->>Endpoint: start_date, end_date
    Endpoint->>Endpoint: "validate start_date <= end_date"
    Endpoint->>DB: fetch DBPrivateAIKey by key_id
    DB-->>Endpoint: key (or 404)
    Endpoint->>Endpoint: "check key.region_id == region_id"
    Endpoint->>Endpoint: authorization check (admin / team role / owner)
    Endpoint->>DB: _get_region_or_404(region_id)
    DB-->>Endpoint: region
    Endpoint->>LiteLLMService: get_daily_activity(litellm_token, start_date, end_date)
    LiteLLMService->>LiteLLMService: hash_token(litellm_token) SHA-256 if sk- prefix
    loop "paginate (page=1..max_pages=100)"
        LiteLLMService->>LiteLLM: "GET /user/daily/activity?api_key=hashed&page=N"
        LiteLLM-->>LiteLLMService: "{results, metadata.has_more}"
        LiteLLMService->>LiteLLMService: extend results
        alt "has_more == false"
            LiteLLMService-->>LiteLLMService: break
        end
    end
    LiteLLMService-->>Endpoint: list of raw daily rows
    Endpoint->>Endpoint: build KeyDailyActivityRow list (is-not-None guards)
    Endpoint->>Endpoint: sort ascending by date
    Endpoint-->>Client: KeyDailyActivityResponse
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Endpoint as GET /spend/{region_id}/key/{key_id}/daily-activity
    participant DB
    participant LiteLLMService
    participant LiteLLM as LiteLLM /user/daily/activity

    Client->>Endpoint: start_date, end_date
    Endpoint->>Endpoint: "validate start_date <= end_date"
    Endpoint->>DB: fetch DBPrivateAIKey by key_id
    DB-->>Endpoint: key (or 404)
    Endpoint->>Endpoint: "check key.region_id == region_id"
    Endpoint->>Endpoint: authorization check (admin / team role / owner)
    Endpoint->>DB: _get_region_or_404(region_id)
    DB-->>Endpoint: region
    Endpoint->>LiteLLMService: get_daily_activity(litellm_token, start_date, end_date)
    LiteLLMService->>LiteLLMService: hash_token(litellm_token) SHA-256 if sk- prefix
    loop "paginate (page=1..max_pages=100)"
        LiteLLMService->>LiteLLM: "GET /user/daily/activity?api_key=hashed&page=N"
        LiteLLM-->>LiteLLMService: "{results, metadata.has_more}"
        LiteLLMService->>LiteLLMService: extend results
        alt "has_more == false"
            LiteLLMService-->>LiteLLMService: break
        end
    end
    LiteLLMService-->>Endpoint: list of raw daily rows
    Endpoint->>Endpoint: build KeyDailyActivityRow list (is-not-None guards)
    Endpoint->>Endpoint: sort ascending by date
    Endpoint-->>Client: KeyDailyActivityResponse
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Update app/api/spend.py"](https://github.com/amazeeio/amazee.ai/commit/c48bc7c275d9c05dc770d4cae88cde863ee67547) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41578492)</sub>

<!-- /greptile_comment -->