### PR TITLE
feat(api): add endpoint to retrieve key last-used timestamp by region

### DIFF
--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -1397,6 +1397,13 @@ async def get_key_last_used(
         api_url=region.litellm_api_url, api_key=region.litellm_api_key
     )
 
+    if not key.litellm_token:
+        return KeyLastUsedResponse(
+            region_id=region_id,
+            key_id=key_id,
+            last_used_at=None,
+        )
+
     last_used_at = await service.get_key_last_used(key.litellm_token)
 
     return KeyLastUsedResponse(

--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -39,6 +39,7 @@ from app.schemas.limits import OwnerType, ResourceType
 from app.api.users import invalidate_user_spend_cache
 from app.schemas.models import (
     BudgetType,
+    KeyLastUsedResponse,
     PrivateAIKeySpend,
     SpendBudgetUpdateRequest,
     SpendBudgetUpdateResponse,
@@ -1348,6 +1349,61 @@ async def get_key_spend_alias(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to get Private AI Key spend: {str(exc)}",
         )
+
+
+@router.get(
+    "/{region_id}/key/{key_id}/last-used",
+    response_model=KeyLastUsedResponse,
+    summary="Get key last-used time by region",
+    description=(
+        "Returns the timestamp a specific key was last used in the given region, "
+        "derived from LiteLLM spend logs (the most recent request time). "
+        "`last_used_at` is null when the key has never been used."
+    ),
+    response_description="Last-used timestamp for the key.",
+)
+async def get_key_last_used(
+    region_id: int,
+    key_id: int,
+    current_user: DBUser = Depends(get_current_user_from_auth),
+    user_role: str = Depends(get_private_ai_access),
+    db: Session = Depends(get_db),
+):
+    key = db.query(DBPrivateAIKey).filter(DBPrivateAIKey.id == key_id).first()
+    if not key:
+        raise HTTPException(status_code=404, detail="Private AI Key not found")
+    if key.region_id != region_id:
+        raise HTTPException(
+            status_code=404, detail="Private AI Key not found in region"
+        )
+
+    # Reuse authorization semantics from get_key_spend_alias.
+    if current_user.is_admin:
+        pass
+    elif user_role in [UserRole.TEAM_ADMIN, UserRole.KEY_CREATOR, UserRole.READ_ONLY]:
+        if key.team_id is not None:
+            if key.team_id != current_user.team_id:
+                raise HTTPException(status_code=404, detail="Private AI Key not found")
+        else:
+            owner = db.query(DBUser).filter(DBUser.id == key.owner_id).first()
+            if not owner or owner.team_id != current_user.team_id:
+                raise HTTPException(status_code=404, detail="Private AI Key not found")
+    else:
+        if key.owner_id != current_user.id:
+            raise HTTPException(status_code=404, detail="Private AI Key not found")
+
+    region = _get_region_or_404(db, region_id)
+    service = LiteLLMService(
+        api_url=region.litellm_api_url, api_key=region.litellm_api_key
+    )
+
+    last_used_at = await service.get_key_last_used(key.litellm_token)
+
+    return KeyLastUsedResponse(
+        region_id=region_id,
+        key_id=key_id,
+        last_used_at=last_used_at,
+    )
 
 
 @router.put(

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -571,6 +571,19 @@ class UserSpendResponse(BaseModel):
     keys: List[SpendKeyItem]
 
 
+class KeyLastUsedResponse(BaseModel):
+    region_id: int
+    key_id: int
+    last_used_at: Optional[datetime] = Field(
+        default=None,
+        description=(
+            "Timestamp the key was last used, derived from LiteLLM spend logs. "
+            "Null when the key has never been used."
+        ),
+    )
+    model_config = ConfigDict(from_attributes=True)
+
+
 class SpendBudgetUpdateRequest(BaseModel):
     max_budget: Optional[float] = Field(default=None, ge=0)
 

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -1,4 +1,6 @@
+import hashlib
 import httpx
+from datetime import datetime, timedelta, timezone
 from fastapi import HTTPException, status
 import logging
 import re
@@ -27,6 +29,18 @@ class LiteLLMService:
     def format_team_id(region_name: str, team_id: int) -> str:
         """Generate the correctly formatted team_id for LiteLLM"""
         return f"{region_name.replace(' ', '_')}_{team_id}"
+
+    @staticmethod
+    def hash_token(litellm_token: str) -> str:
+        """Hash a LiteLLM key the way LiteLLM stores it internally.
+
+        LiteLLM persists ``sk-`` keys as their SHA-256 hexdigest (e.g. in the
+        ``LiteLLM_SpendLogs`` table queried by ``/spend/logs/v2``). Any other
+        token is stored verbatim. Mirrors LiteLLM's ``_hash_token_if_needed``.
+        """
+        if litellm_token.startswith("sk-"):
+            return hashlib.sha256(litellm_token.encode()).hexdigest()
+        return litellm_token
 
     @staticmethod
     def sanitize_alias(alias: str) -> str:
@@ -253,6 +267,61 @@ class LiteLLMService:
             raise HTTPException(
                 status_code=status_code,
                 detail=f"Failed to get LiteLLM key information: {error_msg}",
+            )
+
+    async def get_key_last_used(self, litellm_token: str) -> Optional[datetime]:
+        """Return the timestamp a key was last used, or ``None`` if never used.
+
+        Derives the last-used time from LiteLLM's spend logs: the most recent
+        ``startTime`` recorded for the key. Uses the paginated
+        ``/spend/logs/v2`` endpoint sorted by ``startTime`` descending with
+        ``page_size=1``, so only the single latest row is transferred
+        regardless of how many requests the key has made.
+        """
+        hashed_token = self.hash_token(litellm_token)
+        # /spend/logs/v2 requires an explicit range; use an all-encompassing
+        # window so we capture the key's very first through most-recent usage.
+        start_date = "1970-01-01 00:00:00"
+        end_date = (datetime.now(timezone.utc) + timedelta(days=1)).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"{self.api_url}/spend/logs/v2",
+                    headers={"Authorization": f"Bearer {self.master_key}"},
+                    params={
+                        "api_key": hashed_token,
+                        "start_date": start_date,
+                        "end_date": end_date,
+                        "page": 1,
+                        "page_size": 1,
+                    },
+                )
+                response.raise_for_status()
+                data = response.json()
+            rows = data.get("data") or []
+            if not rows:
+                return None
+            # Sorted startTime desc, so the first row holds max(startTime).
+            start_time = rows[0].get("startTime")
+            if not start_time:
+                return None
+            return datetime.fromisoformat(str(start_time).replace("Z", "+00:00"))
+        except httpx.HTTPStatusError as e:
+            error_msg = str(e)
+            logger.error(f"Error getting LiteLLM key last-used time: {error_msg}")
+            status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+            if hasattr(e, "response") and e.response is not None:
+                status_code = e.response.status_code
+                try:
+                    error_details = e.response.json()
+                    error_msg = f"Status {e.response.status_code}: {error_details}"
+                except ValueError:
+                    error_msg = f"Status {e.response.status_code}: {e.response.text}"
+            raise HTTPException(
+                status_code=status_code,
+                detail=f"Failed to get LiteLLM key last-used time: {error_msg}",
             )
 
     async def update_budget(

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -296,6 +296,8 @@ class LiteLLMService:
                         "end_date": end_date,
                         "page": 1,
                         "page_size": 1,
+                        "sort_by": "startTime",
+                        "sort_order": "desc",
                     },
                 )
                 response.raise_for_status()

--- a/tests/test_litellm_service.py
+++ b/tests/test_litellm_service.py
@@ -1,5 +1,7 @@
 import pytest
 import asyncio
+import hashlib
+from datetime import datetime, timezone
 from unittest.mock import patch, AsyncMock, Mock
 from fastapi import HTTPException
 from app.services.litellm import LiteLLMService
@@ -931,3 +933,100 @@ def test_get_team_model_aliases_team_list_fallback_returns_none_when_not_found(
     aliases = asyncio.run(service.get_team_model_aliases("team-1"))
 
     assert aliases == {}
+
+
+def test_hash_token_hashes_sk_keys():
+    """sk- keys are SHA-256 hashed the way LiteLLM stores them."""
+    token = "sk-abc123"
+    expected = hashlib.sha256(token.encode()).hexdigest()
+    assert LiteLLMService.hash_token(token) == expected
+
+
+def test_hash_token_passes_through_non_sk_tokens():
+    """Tokens that are not sk- keys are returned unchanged."""
+    assert LiteLLMService.hash_token("already-hashed-token") == "already-hashed-token"
+
+
+@patch("httpx.AsyncClient")
+def test_get_key_last_used_returns_latest_start_time(mock_client_class, test_region):
+    """The most recent spend log startTime is returned as a datetime."""
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "data": [{"startTime": "2025-06-15T10:30:00.123000Z"}],
+        "total": 42,
+        "page": 1,
+        "page_size": 1,
+        "total_pages": 42,
+    }
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+    mock_client_class.return_value = mock_client
+
+    service = LiteLLMService(
+        api_url=test_region.litellm_api_url, api_key=test_region.litellm_api_key
+    )
+
+    result = asyncio.run(service.get_key_last_used("sk-abc123"))
+
+    assert result == datetime(2025, 6, 15, 10, 30, 0, 123000, tzinfo=timezone.utc)
+
+    # Filters by the hashed token and requests only the single latest row.
+    call = mock_client.get.call_args
+    assert call.args[0] == f"{test_region.litellm_api_url}/spend/logs/v2"
+    params = call.kwargs["params"]
+    assert params["api_key"] == hashlib.sha256(b"sk-abc123").hexdigest()
+    assert params["page_size"] == 1
+    assert params["start_date"] == "1970-01-01 00:00:00"
+
+
+@patch("httpx.AsyncClient")
+def test_get_key_last_used_returns_none_when_never_used(mock_client_class, test_region):
+    """A key with no spend logs yields None."""
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "data": [],
+        "total": 0,
+        "page": 1,
+        "page_size": 1,
+        "total_pages": 0,
+    }
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+    mock_client_class.return_value = mock_client
+
+    service = LiteLLMService(
+        api_url=test_region.litellm_api_url, api_key=test_region.litellm_api_key
+    )
+
+    result = asyncio.run(service.get_key_last_used("sk-abc123"))
+
+    assert result is None
+
+
+@patch("httpx.AsyncClient")
+def test_get_key_last_used_failure(
+    mock_client_class, test_region, mock_httpx_failure_client
+):
+    """A LiteLLM error is surfaced as an HTTPException."""
+    mock_client_class.return_value = mock_httpx_failure_client(
+        500, "Internal Server Error"
+    )
+
+    service = LiteLLMService(
+        api_url=test_region.litellm_api_url, api_key=test_region.litellm_api_key
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(service.get_key_last_used("sk-abc123"))
+
+    assert "Failed to get LiteLLM key last-used time" in exc_info.value.detail

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -169,6 +169,94 @@ def test_key_spend_alias(
     assert data["total_tokens"] == 1500
 
 
+@patch("app.api.spend.LiteLLMService.get_key_last_used", new_callable=AsyncMock)
+def test_key_last_used(
+    mock_get_key_last_used, client, team_admin_token, test_team_user, test_region, db
+):
+    key = DBPrivateAIKey(
+        name="last-used-key",
+        litellm_token="sk-last-used-token",
+        region_id=test_region.id,
+        owner_id=test_team_user.id,
+        team_id=test_team_user.team_id,
+    )
+    db.add(key)
+    db.commit()
+
+    mock_get_key_last_used.return_value = datetime(2025, 6, 15, 10, 30, 0, tzinfo=UTC)
+
+    response = client.get(
+        f"/spend/{test_region.id}/key/{key.id}/last-used",
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["region_id"] == test_region.id
+    assert data["key_id"] == key.id
+    returned = datetime.fromisoformat(data["last_used_at"].replace("Z", "+00:00"))
+    assert returned == datetime(2025, 6, 15, 10, 30, 0, tzinfo=UTC)
+
+    mock_get_key_last_used.assert_awaited_once()
+    assert mock_get_key_last_used.await_args.args[0] == "sk-last-used-token"
+
+
+@patch("app.api.spend.LiteLLMService.get_key_last_used", new_callable=AsyncMock)
+def test_key_last_used_never_used(
+    mock_get_key_last_used, client, team_admin_token, test_team_user, test_region, db
+):
+    key = DBPrivateAIKey(
+        name="never-used-key",
+        litellm_token="sk-never-used-token",
+        region_id=test_region.id,
+        owner_id=test_team_user.id,
+        team_id=test_team_user.team_id,
+    )
+    db.add(key)
+    db.commit()
+    mock_get_key_last_used.return_value = None
+
+    response = client.get(
+        f"/spend/{test_region.id}/key/{key.id}/last-used",
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code == 200
+    assert response.json()["last_used_at"] is None
+
+
+@patch("app.api.spend.LiteLLMService.get_key_last_used", new_callable=AsyncMock)
+def test_key_last_used_key_not_found(
+    mock_get_key_last_used, client, team_admin_token, test_region
+):
+    response = client.get(
+        f"/spend/{test_region.id}/key/999999/last-used",
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code == 404
+    mock_get_key_last_used.assert_not_awaited()
+
+
+@patch("app.api.spend.LiteLLMService.get_key_last_used", new_callable=AsyncMock)
+def test_key_last_used_forbidden_other_owner(
+    mock_get_key_last_used, client, test_token, test_admin, test_region, db
+):
+    # Key owned by another user (the admin), no team; requested by test_user.
+    key = DBPrivateAIKey(
+        name="last-used-other-owner-key",
+        litellm_token="sk-other-owner-token",
+        region_id=test_region.id,
+        owner_id=test_admin.id,
+    )
+    db.add(key)
+    db.commit()
+
+    response = client.get(
+        f"/spend/{test_region.id}/key/{key.id}/last-used",
+        headers={"Authorization": f"Bearer {test_token}"},
+    )
+    assert response.status_code == 404
+    mock_get_key_last_used.assert_not_awaited()
+
+
 @patch("app.api.spend.LiteLLMService.get_key_info", new_callable=AsyncMock)
 def test_key_spend_alias_uses_configured_cap_for_no_purchase_pool_team(
     mock_get_key_info, client, admin_token, test_team, test_region, db


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `GET /{region_id}/key/{key_id}/last-used` endpoint that returns the most recent usage timestamp for a private AI key by querying LiteLLM's `/spend/logs/v2` spend-logs API. It introduces a `hash_token` static method to replicate LiteLLM's internal SHA-256 key hashing, an explicit `sort_by=startTime&sort_order=desc&page_size=1` query to efficiently retrieve only the latest entry, and a null guard for keys without a `litellm_token`.

- Adds `LiteLLMService.hash_token` and `get_key_last_used` methods with consistent exception-handling patterns, plus a `KeyLastUsedResponse` Pydantic schema.
- Reuses the same authorization logic as `get_key_spend_alias` (admin → team-member → owner) and includes tests covering happy-path, never-used, not-found, and forbidden-owner cases.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge; the new endpoint is self-contained and all previously identified edge-cases (null token, explicit sort order) are correctly handled.

Authorization logic mirrors a battle-tested sibling endpoint, the null-token guard is in place, and the LiteLLM query uses explicit sort parameters and page_size=1 for efficiency. The only concern is a minor datetime-parsing edge case (naive datetime when LiteLLM omits the timezone suffix) that would only surface if the upstream API changes its response format.

app/services/litellm.py — the datetime parsing in get_key_last_used could silently return a timezone-naive datetime if LiteLLM ever omits the Z suffix from startTime.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/spend.py | Adds GET /{region_id}/key/{key_id}/last-used endpoint with correct authorization, null-token guard, and region validation mirroring get_key_spend_alias. |
| app/services/litellm.py | Adds hash_token and get_key_last_used; datetime parsing uses .replace("Z", "+00:00") which may yield a naive datetime if LiteLLM omits the timezone suffix. |
| app/schemas/models.py | Adds KeyLastUsedResponse schema with Optional[datetime] and from_attributes=True; straightforward and correct. |
| tests/test_litellm_service.py | Adds unit tests for hash_token, get_key_last_used success/empty/error paths; covers the hashed token assertion and page_size=1 parameter. |
| tests/test_spend.py | Adds integration-style tests for the new endpoint covering happy-path, never-used, not-found, and cross-owner authorization enforcement. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant API as GET /{region_id}/key/{key_id}/last-used
    participant DB as Database
    participant LiteLLM as LiteLLM /spend/logs/v2

    Client->>API: GET request (auth token)
    API->>DB: Lookup DBPrivateAIKey by key_id
    DB-->>API: key or None
    API->>API: Check region_id match
    API->>API: Authorization check (admin / team / owner)
    API->>DB: _get_region_or_404(region_id)
    DB-->>API: DBRegion (litellm_api_url, litellm_api_key)
    alt litellm_token is None
        API-->>Client: "KeyLastUsedResponse(last_used_at=null)"
    else litellm_token exists
        API->>API: hash_token(litellm_token) → SHA-256 hex
        API->>LiteLLM: "GET /spend/logs/v2?api_key=hashed&sort_by=startTime&sort_order=desc&page_size=1"
        LiteLLM-->>API: "{data: [{startTime: "..."}]} or {data: []}"
        alt data is empty
            API-->>Client: "KeyLastUsedResponse(last_used_at=null)"
        else data has row
            API->>API: fromisoformat(startTime)
            API-->>Client: "KeyLastUsedResponse(last_used_at=datetime)"
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant API as GET /{region_id}/key/{key_id}/last-used
    participant DB as Database
    participant LiteLLM as LiteLLM /spend/logs/v2

    Client->>API: GET request (auth token)
    API->>DB: Lookup DBPrivateAIKey by key_id
    DB-->>API: key or None
    API->>API: Check region_id match
    API->>API: Authorization check (admin / team / owner)
    API->>DB: _get_region_or_404(region_id)
    DB-->>API: DBRegion (litellm_api_url, litellm_api_key)
    alt litellm_token is None
        API-->>Client: "KeyLastUsedResponse(last_used_at=null)"
    else litellm_token exists
        API->>API: hash_token(litellm_token) → SHA-256 hex
        API->>LiteLLM: "GET /spend/logs/v2?api_key=hashed&sort_by=startTime&sort_order=desc&page_size=1"
        LiteLLM-->>API: "{data: [{startTime: "..."}]} or {data: []}"
        alt data is empty
            API-->>Client: "KeyLastUsedResponse(last_used_at=null)"
        else data has row
            API->>API: fromisoformat(startTime)
            API-->>Client: "KeyLastUsedResponse(last_used_at=datetime)"
        end
    end
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Update app/api/spend.py"](https://github.com/amazeeio/amazee.ai/commit/e0dc3af241d43667a8d4e3d32abd28ed4cceaee0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41584429)</sub>

<!-- /greptile_comment -->