### PR TITLE
fix(security): gate /openapi.json behind auth instead of blocking it

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -23,7 +23,7 @@ from app.api import (
     webhooks,
 )
 from app.core.config import settings
-from app.core.security import get_current_user
+from app.core.security import get_current_user_from_auth
 from app.middleware.audit import AuditLogMiddleware
 from app.middleware.auth import AuthMiddleware
 from app.middleware.caching import CacheControlMiddleware
@@ -219,10 +219,8 @@ app.include_router(spend.router, prefix="/spend", tags=["spend"])
 
 
 @app.get("/openapi.json", include_in_schema=False)
-async def openapi_schema(user=Depends(get_current_user)):
+async def openapi_schema(user=Depends(get_current_user_from_auth)):
     """Serve the OpenAPI schema to authenticated callers only (M5)."""
-    if user is None:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
     return app.openapi()
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -23,11 +23,12 @@ from app.api import (
     webhooks,
 )
 from app.core.config import settings
+from app.core.security import get_current_user
 from app.middleware.audit import AuditLogMiddleware
 from app.middleware.auth import AuthMiddleware
 from app.middleware.caching import CacheControlMiddleware
 from app.middleware.prometheus import PrometheusMiddleware
-from fastapi import FastAPI, HTTPException, status
+from fastapi import Depends, FastAPI, HTTPException, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.openapi.docs import get_swagger_ui_html
@@ -88,9 +89,9 @@ app = FastAPI(
     version=__version__,
     docs_url=None,  # Disable default /docs endpoint
     redoc_url=None,  # Disable default /redoc endpoint
-    # Only publish the OpenAPI schema locally. In deployed envs it would let
-    # anonymous callers enumerate every endpoint, param and schema (M5).
-    openapi_url="/openapi.json" if settings.ENV_SUFFIX == "local" else None,
+    # Disable FastAPI's default unauthenticated /openapi.json route.
+    # A custom authenticated endpoint is registered below (M5).
+    openapi_url=None,
     root_path_in_servers=True,
     openapi_tags=[
         {
@@ -215,6 +216,14 @@ app.include_router(
 app.include_router(limits.router, prefix="/limits", tags=["limits"])
 app.include_router(budgets.router, prefix="/budgets", tags=["budgets"])
 app.include_router(spend.router, prefix="/spend", tags=["spend"])
+
+
+@app.get("/openapi.json", include_in_schema=False)
+async def openapi_schema(user=Depends(get_current_user)):
+    """Serve the OpenAPI schema to authenticated callers only (M5)."""
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    return app.openapi()
 
 
 @app.get("/", include_in_schema=False)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -212,18 +212,18 @@ async def test_get_current_user_from_auth_does_not_accept_local_bearer_from_cook
     assert exc_info.value.status_code == 401
 
 
-def test_docs_and_openapi_are_404_when_not_local():
-    """M5: non-local envs must not serve /openapi.json or the Swagger UI at /.
+def test_openapi_requires_auth_when_not_local():
+    """M5: /openapi.json must be auth-gated in deployed envs; Swagger UI still 404.
 
-    openapi_url is fixed when app.main builds the FastAPI app (conftest forces
-    ENV_SUFFIX=local before that import), so flipping settings.ENV_SUFFIX here
-    can't exercise it — import the app fresh in a subprocess instead.
+    Unauthenticated callers get 401 (not the schema). The Swagger UI at / stays
+    404 in non-local envs. openapi_url is fixed at import time, so we use a
+    subprocess to import the app fresh with ENV_SUFFIX=production.
     """
     code = (
         "from fastapi.testclient import TestClient\n"
         "from app.main import app\n"
         "client = TestClient(app)\n"
-        "assert client.get('/openapi.json').status_code == 404\n"
+        "assert client.get('/openapi.json').status_code == 401\n"
         "assert client.get('/').status_code == 404\n"
     )
     result = subprocess.run(


### PR DESCRIPTION
## Summary

- `/openapi.json` now requires a valid Bearer token (M5 still satisfied — anonymous callers get 401, not the schema)
- The Swagger UI at `/` remains 404 in non-local envs
- Updates the security test to assert 401 on unauthenticated access

## Motivation

Blocking the endpoint completely broke CI codegen in downstream consumers (e.g. [amazeeio/moad](https://github.com/amazeeio/moad)) that fetch the OpenAPI spec using an API key to generate typed Effect service clients. An authenticated gate preserves the security intent while restoring that workflow.

## Test plan

- [ ] `pytest tests/test_security.py` passes (subprocess test now asserts 401 for unauthenticated `/openapi.json`)
- [ ] Authenticated request (valid Bearer token) returns the schema with 200
- [ ] `/` still returns 404 in non-local envs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves `/openapi.json` from a blocked endpoint to an authenticated endpoint.

- Disables FastAPI's default OpenAPI route.
- Adds a custom `/openapi.json` handler guarded by auth.
- Keeps the Swagger UI hidden outside local environments.
- Updates the security test to expect 401 for anonymous schema access.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The changed OpenAPI route needs an auth-path fix before merging.

- Anonymous callers receive 401 as intended.
- Valid API-key callers can still receive 401 on `/openapi.json`.
- Browser sessions can fail to load the local Swagger schema because cookie auth is ignored.

app/main.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/main.py | Adds the custom authenticated OpenAPI route, but uses a narrower auth dependency than other protected routes. |
| tests/test_security.py | Updates the non-local security test for anonymous `/openapi.json` access, but does not cover authenticated API-key or cookie access. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): gate /openapi.json behind..."](https://github.com/amazeeio/amazee.ai/commit/154b3d90671a1d64e6c437b5205c5582d75cfcee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42700976)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->