### PR TITLE
590 daily activity endpoints

### DIFF
--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -479,10 +479,7 @@ async def create_llm_token(
         owner = db.query(DBUser).filter(DBUser.id == owner_id).first()
         if not owner or (
             not current_user.is_admin
-            and (
-                current_user.team_id is None
-                or owner.team_id != current_user.team_id
-            )
+            and (current_user.team_id is None or owner.team_id != current_user.team_id)
         ):
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Owner user not found"

--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -309,6 +309,33 @@ def _rows_to_daily_activity(rows: list[dict]) -> list[KeyDailyActivityRow]:
     return activity
 
 
+# Default look-back window (in days) used when a daily-activity request omits
+# start_date and/or end_date.
+DEFAULT_DAILY_ACTIVITY_WINDOW_DAYS = 30
+
+
+def _resolve_daily_activity_range(
+    start_date: date | None, end_date: date | None
+) -> tuple[date, date]:
+    """Fill in defaults for an optional daily-activity date range and validate it.
+
+    When ``end_date`` is omitted it defaults to today (UTC); when ``start_date``
+    is omitted it defaults to ``end_date`` minus
+    ``DEFAULT_DAILY_ACTIVITY_WINDOW_DAYS`` days, giving a rolling 30-day window.
+    Raises 400 if the resolved ``start_date`` is after ``end_date``.
+    """
+    if end_date is None:
+        end_date = datetime.now(UTC).date()
+    if start_date is None:
+        start_date = end_date - timedelta(days=DEFAULT_DAILY_ACTIVITY_WINDOW_DAYS)
+    if start_date > end_date:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="start_date must be on or before end_date",
+        )
+    return start_date, end_date
+
+
 def _sum_optional_token_values(
     items: list[SpendKeyItem],
 ) -> tuple[int | None, int | None, int | None]:
@@ -1459,7 +1486,9 @@ async def get_key_last_used(
     summary="Get key daily activity by region",
     description=(
         "Returns per-day usage (spend, tokens and request count) for a specific "
-        "key in the specified region across the requested date range. Proxies "
+        "key in the specified region across the requested date range. "
+        "start_date and end_date are optional and default to the last 30 days "
+        "(end_date defaults to today UTC, start_date to 30 days earlier). Proxies "
         "LiteLLM's `/user/daily/activity`, filtered to this key. Days with no "
         "usage are omitted from the response."
     ),
@@ -1468,21 +1497,25 @@ async def get_key_last_used(
 async def get_key_daily_activity(
     region_id: int,
     key_id: int,
-    start_date: date = Query(
-        ..., description="Start date (inclusive), formatted YYYY-MM-DD."
+    start_date: date | None = Query(
+        None,
+        description=(
+            "Start date (inclusive), formatted YYYY-MM-DD. "
+            "Defaults to 30 days before end_date when omitted."
+        ),
     ),
-    end_date: date = Query(
-        ..., description="End date (inclusive), formatted YYYY-MM-DD."
+    end_date: date | None = Query(
+        None,
+        description=(
+            "End date (inclusive), formatted YYYY-MM-DD. "
+            "Defaults to today (UTC) when omitted."
+        ),
     ),
     current_user: DBUser = Depends(get_current_user_from_auth),
     user_role: str = Depends(get_private_ai_access),
     db: Session = Depends(get_db),
 ):
-    if start_date > end_date:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="start_date must be on or before end_date",
-        )
+    start_date, end_date = _resolve_daily_activity_range(start_date, end_date)
 
     key = db.query(DBPrivateAIKey).filter(DBPrivateAIKey.id == key_id).first()
     if not key:
@@ -1534,7 +1567,9 @@ async def get_key_daily_activity(
     description=(
         "Returns per-day usage (spend, tokens and request count) aggregated "
         "across all of a user's keys in the specified region across the "
-        "requested date range. Proxies LiteLLM's `/user/daily/activity`, "
+        "requested date range. start_date and end_date are optional and default "
+        "to the last 30 days (end_date defaults to today UTC, start_date to 30 "
+        "days earlier). Proxies LiteLLM's `/user/daily/activity`, "
         "filtered to this user. Days with no usage are omitted.\n\n"
         "Values come from LiteLLM's pre-aggregated daily-spend tables (whole "
         "UTC days) and are independent of billing-cycle spend resets, so they "
@@ -1547,21 +1582,25 @@ async def get_key_daily_activity(
 async def get_user_daily_activity(
     region_id: int,
     user_id: int,
-    start_date: date = Query(
-        ..., description="Start date (inclusive), formatted YYYY-MM-DD."
+    start_date: date | None = Query(
+        None,
+        description=(
+            "Start date (inclusive), formatted YYYY-MM-DD. "
+            "Defaults to 30 days before end_date when omitted."
+        ),
     ),
-    end_date: date = Query(
-        ..., description="End date (inclusive), formatted YYYY-MM-DD."
+    end_date: date | None = Query(
+        None,
+        description=(
+            "End date (inclusive), formatted YYYY-MM-DD. "
+            "Defaults to today (UTC) when omitted."
+        ),
     ),
     current_user: DBUser = Depends(get_current_user_from_auth),
     user_role: str = Depends(get_private_ai_access),
     db: Session = Depends(get_db),
 ):
-    if start_date > end_date:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="start_date must be on or before end_date",
-        )
+    start_date, end_date = _resolve_daily_activity_range(start_date, end_date)
 
     target_user = db.query(DBUser).filter(DBUser.id == user_id).first()
     if not target_user:
@@ -1595,7 +1634,9 @@ async def get_user_daily_activity(
     description=(
         "Returns per-day usage (spend, tokens and request count) aggregated "
         "across all of a team's keys in the specified region across the "
-        "requested date range. Proxies LiteLLM's `/team/daily/activity`, "
+        "requested date range. start_date and end_date are optional and default "
+        "to the last 30 days (end_date defaults to today UTC, start_date to 30 "
+        "days earlier). Proxies LiteLLM's `/team/daily/activity`, "
         "filtered to this team. Days with no usage are omitted.\n\n"
         "Values come from LiteLLM's pre-aggregated daily-spend tables (whole "
         "UTC days) and are independent of billing-cycle spend resets, so they "
@@ -1608,21 +1649,25 @@ async def get_user_daily_activity(
 async def get_team_daily_activity(
     region_id: int,
     team_id: int,
-    start_date: date = Query(
-        ..., description="Start date (inclusive), formatted YYYY-MM-DD."
+    start_date: date | None = Query(
+        None,
+        description=(
+            "Start date (inclusive), formatted YYYY-MM-DD. "
+            "Defaults to 30 days before end_date when omitted."
+        ),
     ),
-    end_date: date = Query(
-        ..., description="End date (inclusive), formatted YYYY-MM-DD."
+    end_date: date | None = Query(
+        None,
+        description=(
+            "End date (inclusive), formatted YYYY-MM-DD. "
+            "Defaults to today (UTC) when omitted."
+        ),
     ),
     current_user: DBUser = Depends(get_current_user_from_auth),
     user_role: str = Depends(get_private_ai_access),
     db: Session = Depends(get_db),
 ):
-    if start_date > end_date:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="start_date must be on or before end_date",
-        )
+    start_date, end_date = _resolve_daily_activity_range(start_date, end_date)
 
     team = (
         db.query(DBTeam)

--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -52,6 +52,8 @@ from app.schemas.models import (
     TeamSpendHistoryResponse,
     TeamSpendResponse,
     PeriodicTeamBudgetView,
+    TeamDailyActivityResponse,
+    UserDailyActivityResponse,
     UserSpendResponse,
 )
 from app.services.litellm import LiteLLMService
@@ -269,6 +271,42 @@ def _extract_token_usage(data: dict) -> tuple[int | None, int | None, int | None
         _to_int_or_none(data.get("completion_tokens")),
         _to_int_or_none(data.get("total_tokens")),
     )
+
+
+def _rows_to_daily_activity(rows: list[dict]) -> list[KeyDailyActivityRow]:
+    """Map raw LiteLLM daily-activity rows to daily-activity response rows.
+
+    Each raw row carries ``date`` and a ``metrics`` block; rows without a date
+    are skipped and the result is ordered ascending by date. The ``breakdown``
+    block returned by LiteLLM (per model/provider/key) is intentionally dropped
+    to keep the response flat.
+    """
+    activity: list[KeyDailyActivityRow] = []
+    for row in rows:
+        if not row.get("date"):
+            continue
+        metrics = row.get("metrics") or {}
+        spend_val = metrics.get("spend")
+        activity.append(
+            KeyDailyActivityRow(
+                date=row["date"],
+                spend=spend_val if spend_val is not None else 0.0,
+                prompt_tokens=metrics.get("prompt_tokens")
+                if metrics.get("prompt_tokens") is not None
+                else 0,
+                completion_tokens=metrics.get("completion_tokens")
+                if metrics.get("completion_tokens") is not None
+                else 0,
+                total_tokens=metrics.get("total_tokens")
+                if metrics.get("total_tokens") is not None
+                else 0,
+                request_count=metrics.get("api_requests")
+                if metrics.get("api_requests") is not None
+                else 0,
+            )
+        )
+    activity.sort(key=lambda r: r.date)
+    return activity
 
 
 def _sum_optional_token_values(
@@ -1480,38 +1518,139 @@ async def get_key_daily_activity(
         end_date=end_date.isoformat(),
     )
 
-    activity: list[KeyDailyActivityRow] = []
-    for row in rows:
-        if not row.get("date"):
-            continue
-        metrics = row.get("metrics") or {}
-        spend_val = metrics.get("spend")
-        activity.append(
-            KeyDailyActivityRow(
-                date=row["date"],
-                spend=spend_val if spend_val is not None else 0.0,
-                prompt_tokens=metrics.get("prompt_tokens")
-                if metrics.get("prompt_tokens") is not None
-                else 0,
-                completion_tokens=metrics.get("completion_tokens")
-                if metrics.get("completion_tokens") is not None
-                else 0,
-                total_tokens=metrics.get("total_tokens")
-                if metrics.get("total_tokens") is not None
-                else 0,
-                request_count=metrics.get("api_requests")
-                if metrics.get("api_requests") is not None
-                else 0,
-            )
-        )
-    activity.sort(key=lambda r: r.date)
-
     return KeyDailyActivityResponse(
         region_id=region_id,
         key_id=key_id,
         start_date=start_date,
         end_date=end_date,
-        activity=activity,
+        activity=_rows_to_daily_activity(rows),
+    )
+
+
+@router.get(
+    "/{region_id}/user/{user_id}/daily-activity",
+    response_model=UserDailyActivityResponse,
+    summary="Get user daily activity by region",
+    description=(
+        "Returns per-day usage (spend, tokens and request count) aggregated "
+        "across all of a user's keys in the specified region across the "
+        "requested date range. Proxies LiteLLM's `/user/daily/activity`, "
+        "filtered to this user. Days with no usage are omitted.\n\n"
+        "Values come from LiteLLM's pre-aggregated daily-spend tables (whole "
+        "UTC days) and are independent of billing-cycle spend resets, so they "
+        "do NOT reconcile with the cycle-reset spend/budget figures returned by "
+        "the other spend endpoints. The current UTC day may under-report until "
+        "LiteLLM's next batch flush."
+    ),
+    response_description="Per-day usage rows for the user, ordered by date.",
+)
+async def get_user_daily_activity(
+    region_id: int,
+    user_id: int,
+    start_date: date = Query(
+        ..., description="Start date (inclusive), formatted YYYY-MM-DD."
+    ),
+    end_date: date = Query(
+        ..., description="End date (inclusive), formatted YYYY-MM-DD."
+    ),
+    current_user: DBUser = Depends(get_current_user_from_auth),
+    user_role: str = Depends(get_private_ai_access),
+    db: Session = Depends(get_db),
+):
+    if start_date > end_date:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="start_date must be on or before end_date",
+        )
+
+    target_user = db.query(DBUser).filter(DBUser.id == user_id).first()
+    if not target_user:
+        raise HTTPException(status_code=404, detail="User not found")
+    _assert_user_access(current_user, user_role, target_user)
+
+    region = _get_region_or_404(db, region_id)
+    service = LiteLLMService(
+        api_url=region.litellm_api_url, api_key=region.litellm_api_key
+    )
+
+    rows = await service.get_user_daily_activity(
+        user_id=str(user_id),
+        start_date=start_date.isoformat(),
+        end_date=end_date.isoformat(),
+    )
+
+    return UserDailyActivityResponse(
+        region_id=region_id,
+        user_id=user_id,
+        start_date=start_date,
+        end_date=end_date,
+        activity=_rows_to_daily_activity(rows),
+    )
+
+
+@router.get(
+    "/{region_id}/team/{team_id}/daily-activity",
+    response_model=TeamDailyActivityResponse,
+    summary="Get team daily activity by region",
+    description=(
+        "Returns per-day usage (spend, tokens and request count) aggregated "
+        "across all of a team's keys in the specified region across the "
+        "requested date range. Proxies LiteLLM's `/team/daily/activity`, "
+        "filtered to this team. Days with no usage are omitted.\n\n"
+        "Values come from LiteLLM's pre-aggregated daily-spend tables (whole "
+        "UTC days) and are independent of billing-cycle spend resets, so they "
+        "do NOT reconcile with the cycle-reset spend/budget figures returned by "
+        "the other spend endpoints. The current UTC day may under-report until "
+        "LiteLLM's next batch flush."
+    ),
+    response_description="Per-day usage rows for the team, ordered by date.",
+)
+async def get_team_daily_activity(
+    region_id: int,
+    team_id: int,
+    start_date: date = Query(
+        ..., description="Start date (inclusive), formatted YYYY-MM-DD."
+    ),
+    end_date: date = Query(
+        ..., description="End date (inclusive), formatted YYYY-MM-DD."
+    ),
+    current_user: DBUser = Depends(get_current_user_from_auth),
+    user_role: str = Depends(get_private_ai_access),
+    db: Session = Depends(get_db),
+):
+    if start_date > end_date:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="start_date must be on or before end_date",
+        )
+
+    team = (
+        db.query(DBTeam)
+        .filter(DBTeam.id == team_id, DBTeam.deleted_at.is_(None))
+        .first()
+    )
+    if not team:
+        raise HTTPException(status_code=404, detail="Team not found")
+    _assert_team_access(current_user, user_role, team_id)
+
+    region = _get_region_or_404(db, region_id)
+    service = LiteLLMService(
+        api_url=region.litellm_api_url, api_key=region.litellm_api_key
+    )
+    lite_team_id = LiteLLMService.format_team_id(region.name, team_id)
+
+    rows = await service.get_team_daily_activity(
+        team_id=lite_team_id,
+        start_date=start_date.isoformat(),
+        end_date=end_date.isoformat(),
+    )
+
+    return TeamDailyActivityResponse(
+        region_id=region_id,
+        team_id=team_id,
+        start_date=start_date,
+        end_date=end_date,
+        activity=_rows_to_daily_activity(rows),
     )
 
 

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -2861,7 +2861,7 @@ async def expire_trial_user_keys(db: Session, user: DBUser):
             try:
                 litellm_service = LiteLLMService(
                     api_url=key.region.litellm_api_url,
-                    api_key=key.region.litellm_api_key
+                    api_key=key.region.litellm_api_key,
                 )
                 await litellm_service.update_key_duration(key.litellm_token, "0d")
                 logger.info(f"Set duration to 0d for key {key.id}")
@@ -2886,27 +2886,37 @@ async def monitor_trial_users(db: Session):
     logger.info("Monitoring trial users")
     try:
         # Get trial team (only consider active teams)
-        trial_team = db.query(DBTeam).filter(
-            DBTeam.admin_email == settings.AI_TRIAL_TEAM_EMAIL,
-            DBTeam.is_active.is_(True)
-        ).first()
+        trial_team = (
+            db.query(DBTeam)
+            .filter(
+                DBTeam.admin_email == settings.AI_TRIAL_TEAM_EMAIL,
+                DBTeam.is_active.is_(True),
+            )
+            .first()
+        )
         if not trial_team:
             logger.info("Trial team not found, skipping")
             return
 
         # Get all active users in the trial team (excluding admin)
-        users = db.query(DBUser).filter(
-            DBUser.team_id == trial_team.id,
-            DBUser.is_active,
-            DBUser.role == "user"
-        ).all()
+        users = (
+            db.query(DBUser)
+            .filter(
+                DBUser.team_id == trial_team.id, DBUser.is_active, DBUser.role == "user"
+            )
+            .all()
+        )
 
         # Fetch all user budget limits in one query
-        user_limits = db.query(DBLimitedResource).filter(
-            DBLimitedResource.owner_type == OwnerType.USER,
-            DBLimitedResource.owner_id.in_([user.id for user in users]),
-            DBLimitedResource.resource == ResourceType.BUDGET
-        ).all()
+        user_limits = (
+            db.query(DBLimitedResource)
+            .filter(
+                DBLimitedResource.owner_type == OwnerType.USER,
+                DBLimitedResource.owner_id.in_([user.id for user in users]),
+                DBLimitedResource.resource == ResourceType.BUDGET,
+            )
+            .all()
+        )
 
         user_limit_map = {limit.owner_id: limit for limit in user_limits}
 
@@ -2916,7 +2926,9 @@ async def monitor_trial_users(db: Session):
             user_limit = user_limit_map.get(user.id)
             if user_limit and user_limit.current_value is not None:
                 if user_limit.current_value >= user_limit.max_value:
-                    logger.info(f"Trial user {user.email} (ID: {user.id}) has fully used up their budget ({user_limit.current_value} >= {user_limit.max_value}). Setting for removal.")
+                    logger.info(
+                        f"Trial user {user.email} (ID: {user.id}) has fully used up their budget ({user_limit.current_value} >= {user_limit.max_value}). Setting for removal."
+                    )
                     await deactivate_trial_user(db, user)
                     over_budget_users.append(user)
 
@@ -2933,4 +2945,3 @@ async def monitor_trial_users(db: Session):
         logger.error(f"Error in trial user monitoring: {e}")
         db.rollback()
         raise
-

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -172,12 +172,7 @@ def _host_is_blocked(host: str) -> bool:
     # metadata/loopback address would bypass the block.
     if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
         ip = ip.ipv4_mapped
-    return (
-        ip.is_loopback
-        or ip.is_link_local
-        or ip.is_multicast
-        or ip.is_unspecified
-    )
+    return ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_unspecified
 
 
 def validate_region_api_url(value: str) -> str:

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -684,6 +684,34 @@ class KeyDailyActivityResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class UserDailyActivityResponse(BaseModel):
+    region_id: int
+    user_id: int
+    start_date: date
+    end_date: date
+    activity: List[KeyDailyActivityRow] = Field(
+        description=(
+            "Per-day usage rows aggregated across all of the user's keys, "
+            "ordered ascending by date. Days with no usage are omitted."
+        )
+    )
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TeamDailyActivityResponse(BaseModel):
+    region_id: int
+    team_id: int
+    start_date: date
+    end_date: date
+    activity: List[KeyDailyActivityRow] = Field(
+        description=(
+            "Per-day usage rows aggregated across all of the team's keys, "
+            "ordered ascending by date. Days with no usage are omitted."
+        )
+    )
+    model_config = ConfigDict(from_attributes=True)
+
+
 class SpendBudgetUpdateRequest(BaseModel):
     max_budget: Optional[float] = Field(default=None, ge=0)
 

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -327,21 +327,30 @@ class LiteLLMService:
                 detail=f"Failed to get LiteLLM key last-used time: {error_msg}",
             )
 
-    async def get_daily_activity(
+    async def _fetch_daily_activity(
         self,
-        litellm_token: str,
+        endpoint: str,
+        filter_params: dict,
         start_date: str,
         end_date: str,
         page_size: int = 1000,
     ) -> list[dict]:
-        """Fetch per-day usage for a single key from LiteLLM.
+        """Paginate a LiteLLM daily-activity endpoint and return all rows.
 
-        Proxies LiteLLM's ``/user/daily/activity`` endpoint, filtered to the
-        given key (via its hashed token), and paginates through every page.
-        Returns the raw ``results`` rows, each containing ``date``, ``metrics``
-        and ``breakdown``.
+        ``endpoint`` is the path to call (e.g. ``/user/daily/activity`` or
+        ``/team/daily/activity``). ``filter_params`` carries the entity filter
+        for that endpoint (e.g. ``{"api_key": ...}``, ``{"user_id": ...}`` or
+        ``{"team_ids": ...}``). Paginates through every page and returns the raw
+        ``results`` rows, each containing ``date``, ``metrics`` and
+        ``breakdown``.
+
+        These values come from LiteLLM's pre-aggregated daily-spend tables,
+        which are keyed on whole UTC days and are independent of our
+        billing-cycle spend resets — so they are a true continuous usage history
+        and will NOT reconcile with the cycle-reset spend/budget figures
+        returned by the other spend endpoints. The current UTC day may
+        under-report until LiteLLM's next batch flush.
         """
-        hashed_token = self.hash_token(litellm_token)
         results: list[dict] = []
         page = 1
         max_pages = 100
@@ -349,14 +358,14 @@ class LiteLLMService:
             async with httpx.AsyncClient() as client:
                 while page <= max_pages:
                     response = await client.get(
-                        f"{self.api_url}/user/daily/activity",
+                        f"{self.api_url}{endpoint}",
                         headers={"Authorization": f"Bearer {self.master_key}"},
                         params={
                             "start_date": start_date,
                             "end_date": end_date,
-                            "api_key": hashed_token,
                             "page": page,
                             "page_size": page_size,
+                            **filter_params,
                         },
                     )
                     response.raise_for_status()
@@ -383,6 +392,67 @@ class LiteLLMService:
                 status_code=status_code,
                 detail=f"Failed to get LiteLLM daily activity: {error_msg}",
             )
+
+    async def get_daily_activity(
+        self,
+        litellm_token: str,
+        start_date: str,
+        end_date: str,
+        page_size: int = 1000,
+    ) -> list[dict]:
+        """Fetch per-day usage for a single key from LiteLLM.
+
+        Proxies LiteLLM's ``/user/daily/activity`` endpoint, filtered to the
+        given key (via its hashed token).
+        """
+        hashed_token = self.hash_token(litellm_token)
+        return await self._fetch_daily_activity(
+            "/user/daily/activity",
+            {"api_key": hashed_token},
+            start_date=start_date,
+            end_date=end_date,
+            page_size=page_size,
+        )
+
+    async def get_user_daily_activity(
+        self,
+        user_id: str,
+        start_date: str,
+        end_date: str,
+        page_size: int = 1000,
+    ) -> list[dict]:
+        """Fetch per-day usage for a single user from LiteLLM.
+
+        Proxies LiteLLM's ``/user/daily/activity`` endpoint, filtered to the
+        given user (aggregated across all of the user's keys).
+        """
+        return await self._fetch_daily_activity(
+            "/user/daily/activity",
+            {"user_id": str(user_id)},
+            start_date=start_date,
+            end_date=end_date,
+            page_size=page_size,
+        )
+
+    async def get_team_daily_activity(
+        self,
+        team_id: str,
+        start_date: str,
+        end_date: str,
+        page_size: int = 1000,
+    ) -> list[dict]:
+        """Fetch per-day usage for a single team from LiteLLM.
+
+        Proxies LiteLLM's ``/team/daily/activity`` endpoint, filtered to the
+        given LiteLLM ``team_id`` (aggregated across all of the team's keys).
+        """
+        return await self._fetch_daily_activity(
+            "/team/daily/activity",
+            {"team_ids": team_id},
+            start_date=start_date,
+            end_date=end_date,
+            page_size=page_size,
+        )
 
     async def update_budget(
         self,

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -428,7 +428,7 @@ class LiteLLMService:
         """
         return await self._fetch_daily_activity(
             "/user/daily/activity",
-            {"user_id": str(user_id)},
+            {"user_id": user_id},
             start_date=start_date,
             end_date=end_date,
             page_size=page_size,

--- a/scripts/trigger_trial_recon_job.py
+++ b/scripts/trigger_trial_recon_job.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 
 # Add the parent directory to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from sqlalchemy.orm import sessionmaker
 from app.db.database import engine
@@ -15,11 +15,11 @@ from app.core.locking import try_acquire_lock, release_lock
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 
 logger = logging.getLogger(__name__)
+
 
 async def trigger_trial_recon_job():
     """Manually trigger the trial recon job (monitor_trial_users)"""
@@ -47,7 +47,9 @@ async def trigger_trial_recon_job():
                 release_lock(lock_name, db)
                 logger.info("Released monitor_trial_users lock")
         else:
-            logger.warning("Another process has the monitor_trial_users lock, cannot execute job")
+            logger.warning(
+                "Another process has the monitor_trial_users lock, cannot execute job"
+            )
             return False
 
     except Exception as e:
@@ -60,6 +62,7 @@ async def trigger_trial_recon_job():
 
     return True
 
+
 def main():
     """Main function to run the script"""
     try:
@@ -70,12 +73,15 @@ def main():
             logger.info("✅ Trial recon job completed successfully")
             sys.exit(0)
         else:
-            logger.info("⚠️  Trial recon job could not be executed (lock held by another process)")
+            logger.info(
+                "⚠️  Trial recon job could not be executed (lock held by another process)"
+            )
             sys.exit(1)
 
     except Exception as e:
         logger.error(f"❌ Script failed: {str(e)}")
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_litellm_service.py
+++ b/tests/test_litellm_service.py
@@ -1111,3 +1111,70 @@ def test_get_daily_activity_failure(
         )
 
     assert "Failed to get LiteLLM daily activity" in exc_info.value.detail
+
+
+@patch("httpx.AsyncClient")
+def test_get_user_daily_activity_filters_by_user_id(mock_client_class, test_region):
+    """get_user_daily_activity hits /user/daily/activity filtered by user_id."""
+    page = _daily_activity_page(
+        [{"date": "2025-06-01", "metrics": {"spend": 1.0}}], has_more=False
+    )
+
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = [page]
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+    mock_client_class.return_value = mock_client
+
+    service = LiteLLMService(
+        api_url=test_region.litellm_api_url, api_key=test_region.litellm_api_key
+    )
+
+    results = asyncio.run(
+        service.get_user_daily_activity(
+            user_id=42,
+            start_date="2025-06-01",
+            end_date="2025-06-02",
+        )
+    )
+
+    assert [r["date"] for r in results] == ["2025-06-01"]
+    first_call = mock_client.get.call_args_list[0]
+    assert first_call.args[0].endswith("/user/daily/activity")
+    assert first_call.kwargs["params"]["user_id"] == "42"
+    assert "api_key" not in first_call.kwargs["params"]
+    assert first_call.kwargs["params"]["start_date"] == "2025-06-01"
+    assert first_call.kwargs["params"]["end_date"] == "2025-06-02"
+
+
+@patch("httpx.AsyncClient")
+def test_get_team_daily_activity_filters_by_team_ids(mock_client_class, test_region):
+    """get_team_daily_activity hits /team/daily/activity filtered by team_ids."""
+    page = _daily_activity_page(
+        [{"date": "2025-06-01", "metrics": {"spend": 3.0}}], has_more=False
+    )
+
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = [page]
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+    mock_client_class.return_value = mock_client
+
+    service = LiteLLMService(
+        api_url=test_region.litellm_api_url, api_key=test_region.litellm_api_key
+    )
+
+    results = asyncio.run(
+        service.get_team_daily_activity(
+            team_id="Test_Region_7",
+            start_date="2025-06-01",
+            end_date="2025-06-02",
+        )
+    )
+
+    assert [r["date"] for r in results] == ["2025-06-01"]
+    first_call = mock_client.get.call_args_list[0]
+    assert first_call.args[0].endswith("/team/daily/activity")
+    assert first_call.kwargs["params"]["team_ids"] == "Test_Region_7"
+    assert first_call.kwargs["params"]["start_date"] == "2025-06-01"
+    assert first_call.kwargs["params"]["end_date"] == "2025-06-02"

--- a/tests/test_litellm_service.py
+++ b/tests/test_litellm_service.py
@@ -1132,7 +1132,7 @@ def test_get_user_daily_activity_filters_by_user_id(mock_client_class, test_regi
 
     results = asyncio.run(
         service.get_user_daily_activity(
-            user_id=42,
+            user_id="42",
             start_date="2025-06-01",
             end_date="2025-06-02",
         )

--- a/tests/test_monitor_trial_users.py
+++ b/tests/test_monitor_trial_users.py
@@ -6,17 +6,17 @@ from app.db.models import DBTeam, DBUser, DBLimitedResource, DBPrivateAIKey, DBR
 from app.schemas.limits import ResourceType, OwnerType, LimitType, UnitType, LimitSource
 from app.core.config import settings
 
+
 @pytest.fixture
 def trial_team(db: Session):
     team = DBTeam(
-        name="AI Trial Team",
-        admin_email=settings.AI_TRIAL_TEAM_EMAIL,
-        is_active=True
+        name="AI Trial Team", admin_email=settings.AI_TRIAL_TEAM_EMAIL, is_active=True
     )
     db.add(team)
     db.commit()
     db.refresh(team)
     return team
+
 
 @pytest.fixture
 def trial_user(db: Session, trial_team: DBTeam):
@@ -24,12 +24,13 @@ def trial_user(db: Session, trial_team: DBTeam):
         email="trial-user@example.com",
         team_id=trial_team.id,
         is_active=True,
-        role="user"
+        role="user",
     )
     db.add(user)
     db.commit()
     db.refresh(user)
     return user
+
 
 @pytest.fixture
 def trial_region(db: Session):
@@ -37,26 +38,30 @@ def trial_region(db: Session):
         name="test-trial-region",
         litellm_api_url="http://mock-litellm",
         litellm_api_key="mock-key",
-        is_active=True
+        is_active=True,
     )
     db.add(region)
     db.commit()
     db.refresh(region)
     return region
 
+
 @pytest.fixture
-def trial_key(db: Session, trial_user: DBUser, trial_region: DBRegion, trial_team: DBTeam):
+def trial_key(
+    db: Session, trial_user: DBUser, trial_region: DBRegion, trial_team: DBTeam
+):
     key = DBPrivateAIKey(
         owner_id=trial_user.id,
         team_id=trial_team.id,
         region_id=trial_region.id,
         litellm_token="mock-token",
-        name="Trial Key"
+        name="Trial Key",
     )
     db.add(key)
     db.commit()
     db.refresh(key)
     return key
+
 
 @pytest.fixture
 def user_budget_limit(db: Session, trial_user: DBUser):
@@ -69,61 +74,66 @@ def user_budget_limit(db: Session, trial_user: DBUser):
         max_value=10.0,
         current_value=0.0,
         limited_by=LimitSource.MANUAL,
-        set_by="test"
+        set_by="test",
     )
     db.add(limit)
     db.commit()
     db.refresh(limit)
     return limit
 
+
 @pytest.fixture
 def mock_litellm():
     """Fixture to mock LiteLLMService."""
-    with patch('app.core.worker.LiteLLMService', autospec=True) as MockLiteLLM:
+    with patch("app.core.worker.LiteLLMService", autospec=True) as MockLiteLLM:
         mock_instance = MockLiteLLM.return_value
         mock_instance.update_key_duration = AsyncMock()
         yield mock_instance
 
+
 @pytest.mark.asyncio
-async def test_monitor_trial_users_no_overage(db, trial_team, trial_user, trial_key, user_budget_limit, mock_litellm):
+async def test_monitor_trial_users_no_overage(
+    db, trial_team, trial_user, trial_key, user_budget_limit, mock_litellm
+):
     """Test that users within budget are not affected."""
     # usage is 5.0, max is 10.0
     user_budget_limit.current_value = 5.0
     db.commit()
 
     await monitor_trial_users(db)
-    
+
     # Verify user is still active
     db.refresh(trial_user)
     assert trial_user.is_active is True
-    
+
     # Verify LiteLLM was not called
     assert mock_litellm.update_key_duration.call_count == 0
 
+
 @pytest.mark.asyncio
-async def test_monitor_trial_users_with_overage(db, trial_team, trial_user, trial_key, user_budget_limit, mock_litellm):
+async def test_monitor_trial_users_with_overage(
+    db, trial_team, trial_user, trial_key, user_budget_limit, mock_litellm
+):
     """Test that users over budget are disabled and keys expired."""
     # usage is 10.0, max is 10.0 (limit reached)
     user_budget_limit.current_value = 10.0
     db.commit()
 
     await monitor_trial_users(db)
-    
+
     # Verify user is deactivated
     db.refresh(trial_user)
     assert trial_user.is_active is False
-    
+
     # Verify LiteLLM called with 0d duration
     mock_litellm.update_key_duration.assert_called_once_with("mock-token", "0d")
+
 
 @pytest.mark.asyncio
 async def test_monitor_trial_users_skips_admin(db, trial_team, mock_litellm):
     """Test that admin user is skipped even if over budget."""
     admin_user = DBUser(
-        email="admin@example.com",
-        team_id=trial_team.id,
-        is_active=True,
-        role="admin"
+        email="admin@example.com", team_id=trial_team.id, is_active=True, role="admin"
     )
     db.add(admin_user)
     db.commit()
@@ -138,13 +148,13 @@ async def test_monitor_trial_users_skips_admin(db, trial_team, mock_litellm):
         max_value=10.0,
         current_value=15.0,
         limited_by=LimitSource.MANUAL,
-        set_by="test"
+        set_by="test",
     )
     db.add(limit)
     db.commit()
 
     await monitor_trial_users(db)
-    
+
     db.refresh(admin_user)
     assert admin_user.is_active is True
     assert mock_litellm.update_key_duration.call_count == 0

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -283,7 +283,9 @@ def test_update_region(client, admin_token, test_region):
     assert data["postgres_port"] == update_data["postgres_port"]
 
 
-def test_update_region_legacy_http_url_grandfathered(client, admin_token, test_region, db):
+def test_update_region_legacy_http_url_grandfathered(
+    client, admin_token, test_region, db
+):
     """
     Given a legacy region whose stored litellm_api_url is still http://
     When an admin updates unrelated fields without changing the URL

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -590,6 +590,79 @@ def test_team_daily_activity_team_not_found(
     mock_get_team_daily_activity.assert_not_awaited()
 
 
+@patch("app.api.spend.LiteLLMService.get_daily_activity", new_callable=AsyncMock)
+def test_key_daily_activity_defaults_to_last_30_days(
+    mock_get_daily_activity, client, team_admin_token, test_team_user, test_region, db
+):
+    key = DBPrivateAIKey(
+        name="daily-activity-default-key",
+        litellm_token="sk-default-token",
+        region_id=test_region.id,
+        owner_id=test_team_user.id,
+        team_id=test_team_user.team_id,
+    )
+    db.add(key)
+    db.commit()
+    mock_get_daily_activity.return_value = []
+
+    # No start_date/end_date -> defaults to the last 30 days (UTC).
+    response = client.get(
+        f"/spend/{test_region.id}/key/{key.id}/daily-activity",
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code == 200
+    today = datetime.now(UTC).date()
+    data = response.json()
+    assert data["end_date"] == today.isoformat()
+    assert data["start_date"] == (today - timedelta(days=30)).isoformat()
+
+    kwargs = mock_get_daily_activity.await_args.kwargs
+    assert kwargs["end_date"] == today.isoformat()
+    assert kwargs["start_date"] == (today - timedelta(days=30)).isoformat()
+
+
+@patch("app.api.spend.LiteLLMService.get_user_daily_activity", new_callable=AsyncMock)
+def test_user_daily_activity_defaults_to_last_30_days(
+    mock_get_user_daily_activity, client, team_admin_token, test_team_user, test_region
+):
+    mock_get_user_daily_activity.return_value = []
+
+    response = client.get(
+        f"/spend/{test_region.id}/user/{test_team_user.id}/daily-activity",
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code == 200
+    today = datetime.now(UTC).date()
+    data = response.json()
+    assert data["end_date"] == today.isoformat()
+    assert data["start_date"] == (today - timedelta(days=30)).isoformat()
+
+    kwargs = mock_get_user_daily_activity.await_args.kwargs
+    assert kwargs["end_date"] == today.isoformat()
+    assert kwargs["start_date"] == (today - timedelta(days=30)).isoformat()
+
+
+@patch("app.api.spend.LiteLLMService.get_team_daily_activity", new_callable=AsyncMock)
+def test_team_daily_activity_defaults_to_last_30_days(
+    mock_get_team_daily_activity, client, team_admin_token, test_team, test_region
+):
+    mock_get_team_daily_activity.return_value = []
+
+    response = client.get(
+        f"/spend/{test_region.id}/team/{test_team.id}/daily-activity",
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code == 200
+    today = datetime.now(UTC).date()
+    data = response.json()
+    assert data["end_date"] == today.isoformat()
+    assert data["start_date"] == (today - timedelta(days=30)).isoformat()
+
+    kwargs = mock_get_team_daily_activity.await_args.kwargs
+    assert kwargs["end_date"] == today.isoformat()
+    assert kwargs["start_date"] == (today - timedelta(days=30)).isoformat()
+
+
 @patch("app.api.spend.LiteLLMService.get_key_info", new_callable=AsyncMock)
 def test_key_spend_alias_uses_configured_cap_for_no_purchase_pool_team(
     mock_get_key_info, client, admin_token, test_team, test_region, db

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -405,6 +405,191 @@ def test_key_daily_activity_forbidden_other_owner(
     mock_get_daily_activity.assert_not_awaited()
 
 
+@patch("app.api.spend.LiteLLMService.get_user_daily_activity", new_callable=AsyncMock)
+def test_user_daily_activity(
+    mock_get_user_daily_activity,
+    client,
+    team_admin_token,
+    test_team_user,
+    test_region,
+):
+    # Returned out of order to verify the endpoint sorts ascending by date.
+    mock_get_user_daily_activity.return_value = [
+        {
+            "date": "2025-06-02",
+            "metrics": {
+                "spend": 2.5,
+                "prompt_tokens": 200,
+                "completion_tokens": 50,
+                "total_tokens": 250,
+                "api_requests": 4,
+            },
+        },
+        {
+            "date": "2025-06-01",
+            "metrics": {
+                "spend": 1.0,
+                "prompt_tokens": 100,
+                "completion_tokens": 20,
+                "total_tokens": 120,
+                "api_requests": 2,
+            },
+        },
+    ]
+
+    response = client.get(
+        f"/spend/{test_region.id}/user/{test_team_user.id}/daily-activity",
+        params={"start_date": "2025-06-01", "end_date": "2025-06-02"},
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["region_id"] == test_region.id
+    assert data["user_id"] == test_team_user.id
+    assert data["start_date"] == "2025-06-01"
+    assert data["end_date"] == "2025-06-02"
+    assert [row["date"] for row in data["activity"]] == ["2025-06-01", "2025-06-02"]
+    first = data["activity"][0]
+    assert first["spend"] == 1.0
+    assert first["prompt_tokens"] == 100
+    assert first["completion_tokens"] == 20
+    assert first["total_tokens"] == 120
+    assert first["request_count"] == 2
+
+    # Endpoint forwards the user id (as a string) and the requested range.
+    mock_get_user_daily_activity.assert_awaited_once()
+    kwargs = mock_get_user_daily_activity.await_args.kwargs
+    assert kwargs["user_id"] == str(test_team_user.id)
+    assert kwargs["start_date"] == "2025-06-01"
+    assert kwargs["end_date"] == "2025-06-02"
+
+
+@patch("app.api.spend.LiteLLMService.get_user_daily_activity", new_callable=AsyncMock)
+def test_user_daily_activity_invalid_range(
+    mock_get_user_daily_activity, client, team_admin_token, test_team_user, test_region
+):
+    response = client.get(
+        f"/spend/{test_region.id}/user/{test_team_user.id}/daily-activity",
+        params={"start_date": "2025-06-05", "end_date": "2025-06-01"},
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code == 400
+    mock_get_user_daily_activity.assert_not_awaited()
+
+
+@patch("app.api.spend.LiteLLMService.get_user_daily_activity", new_callable=AsyncMock)
+def test_user_daily_activity_user_not_found(
+    mock_get_user_daily_activity, client, team_admin_token, test_region
+):
+    response = client.get(
+        f"/spend/{test_region.id}/user/999999/daily-activity",
+        params={"start_date": "2025-06-01", "end_date": "2025-06-02"},
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code == 404
+    mock_get_user_daily_activity.assert_not_awaited()
+
+
+@patch("app.api.spend.LiteLLMService.get_user_daily_activity", new_callable=AsyncMock)
+def test_user_daily_activity_forbidden_other_user(
+    mock_get_user_daily_activity, client, test_token, test_admin, test_region
+):
+    # test_user requesting the admin's activity (different user, not same team).
+    response = client.get(
+        f"/spend/{test_region.id}/user/{test_admin.id}/daily-activity",
+        params={"start_date": "2025-06-01", "end_date": "2025-06-02"},
+        headers={"Authorization": f"Bearer {test_token}"},
+    )
+    assert response.status_code == 403
+    mock_get_user_daily_activity.assert_not_awaited()
+
+
+@patch("app.api.spend.LiteLLMService.get_team_daily_activity", new_callable=AsyncMock)
+def test_team_daily_activity(
+    mock_get_team_daily_activity,
+    client,
+    team_admin_token,
+    test_team,
+    test_region,
+):
+    # Returned out of order to verify the endpoint sorts ascending by date.
+    mock_get_team_daily_activity.return_value = [
+        {
+            "date": "2025-06-02",
+            "metrics": {
+                "spend": 5.0,
+                "prompt_tokens": 400,
+                "completion_tokens": 100,
+                "total_tokens": 500,
+                "api_requests": 8,
+            },
+        },
+        {
+            "date": "2025-06-01",
+            "metrics": {
+                "spend": 3.0,
+                "prompt_tokens": 300,
+                "completion_tokens": 60,
+                "total_tokens": 360,
+                "api_requests": 6,
+            },
+        },
+    ]
+
+    response = client.get(
+        f"/spend/{test_region.id}/team/{test_team.id}/daily-activity",
+        params={"start_date": "2025-06-01", "end_date": "2025-06-02"},
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["region_id"] == test_region.id
+    assert data["team_id"] == test_team.id
+    assert data["start_date"] == "2025-06-01"
+    assert data["end_date"] == "2025-06-02"
+    assert [row["date"] for row in data["activity"]] == ["2025-06-01", "2025-06-02"]
+    first = data["activity"][0]
+    assert first["spend"] == 3.0
+    assert first["prompt_tokens"] == 300
+    assert first["completion_tokens"] == 60
+    assert first["total_tokens"] == 360
+    assert first["request_count"] == 6
+
+    # Endpoint forwards the formatted LiteLLM team id and the requested range.
+    mock_get_team_daily_activity.assert_awaited_once()
+    kwargs = mock_get_team_daily_activity.await_args.kwargs
+    expected_team_id = f"{test_region.name.replace(' ', '_')}_{test_team.id}"
+    assert kwargs["team_id"] == expected_team_id
+    assert kwargs["start_date"] == "2025-06-01"
+    assert kwargs["end_date"] == "2025-06-02"
+
+
+@patch("app.api.spend.LiteLLMService.get_team_daily_activity", new_callable=AsyncMock)
+def test_team_daily_activity_invalid_range(
+    mock_get_team_daily_activity, client, team_admin_token, test_team, test_region
+):
+    response = client.get(
+        f"/spend/{test_region.id}/team/{test_team.id}/daily-activity",
+        params={"start_date": "2025-06-05", "end_date": "2025-06-01"},
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code == 400
+    mock_get_team_daily_activity.assert_not_awaited()
+
+
+@patch("app.api.spend.LiteLLMService.get_team_daily_activity", new_callable=AsyncMock)
+def test_team_daily_activity_team_not_found(
+    mock_get_team_daily_activity, client, team_admin_token, test_region
+):
+    response = client.get(
+        f"/spend/{test_region.id}/team/999999/daily-activity",
+        params={"start_date": "2025-06-01", "end_date": "2025-06-02"},
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code == 404
+    mock_get_team_daily_activity.assert_not_awaited()
+
+
 @patch("app.api.spend.LiteLLMService.get_key_info", new_callable=AsyncMock)
 def test_key_spend_alias_uses_configured_cap_for_no_purchase_pool_team(
     mock_get_key_info, client, admin_token, test_team, test_region, db


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces two new spend endpoints — `GET /{region_id}/user/{user_id}/daily-activity` and `GET /{region_id}/team/{team_id}/daily-activity` — by extracting a shared `_fetch_daily_activity` paginator in `LiteLLMService` and a `_rows_to_daily_activity` mapping helper in the API layer. The remaining file changes are pure Black-style formatting fixes.

- **New endpoints** delegate to `_assert_user_access` / `_assert_team_access` for access control and proxy LiteLLM's `/user/daily/activity` and `/team/daily/activity` endpoints with full pagination.
- **LiteLLM service refactor** pulls common pagination logic into `_fetch_daily_activity` and adds typed wrappers for user and team queries, keeping the existing key-level method unchanged.
- **Test coverage** includes happy path, invalid date range, 404, and a forbidden-access case for the user endpoint; the team endpoint is missing an equivalent cross-team 403 test.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after addressing the missing `is_active` filter on the user lookup in the new daily-activity endpoint.

The new user daily-activity endpoint queries `DBUser` without the `is_active` guard that every comparable user lookup in the same file applies. This means a team admin can retrieve spend history for a deactivated user, which is inconsistent with the access-control posture established elsewhere in the file. Everything else — the LiteLLM service refactor, the new schemas, the team endpoint, and all the formatting changes — looks correct and well-tested.

`app/api/spend.py` — the `get_user_daily_activity` handler needs an `is_active` filter on its `DBUser` lookup to match the pattern used by similar handlers in the same file.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/api/spend.py | Adds two new GET endpoints for user and team daily activity; extracts shared `_rows_to_daily_activity` helper from existing key-activity code. The user-lookup query is missing the `is_active` filter, inconsistent with other user queries in the same file. |
| app/services/litellm.py | Refactors `get_daily_activity` into a generic `_fetch_daily_activity` paginator and adds `get_user_daily_activity`/`get_team_daily_activity` wrappers. Redundant `str()` coercion on `user_id` inside `get_user_daily_activity` where the declared type is already `str`. |
| app/schemas/models.py | Adds `UserDailyActivityResponse` and `TeamDailyActivityResponse` Pydantic models reusing the existing `KeyDailyActivityRow` type; also minor line-length formatting fix. |
| tests/test_spend.py | Adds tests for the two new endpoints covering happy path, invalid date range, 404, and one forbidden-access scenario for user activity. Missing a corresponding forbidden-access test for the team endpoint. |
| tests/test_litellm_service.py | Adds unit tests verifying that `get_user_daily_activity` and `get_team_daily_activity` hit the correct LiteLLM endpoints with the right filter params; test for user activity passes an `int` to a `str`-typed parameter. |
| app/core/worker.py | Formatting-only changes — trailing commas added and long lines wrapped for Black compliance; no logic changes. |
| app/api/private_ai_keys.py | Single-line formatting change only — boolean expression reformatted onto one line; no logic change. |
| scripts/trigger_trial_recon_job.py | Formatting-only changes — quote style standardised and long logger calls wrapped; no logic changes. |
| tests/test_monitor_trial_users.py | Formatting-only changes — blank lines between fixtures added, trailing commas inserted, and missing newline at end of file fixed; no logic changes. |
| tests/test_region.py | Single formatting change — long function signature wrapped across three lines; no logic changes. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant SpendAPI as spend.py (API)
    participant DB as Database
    participant LiteLLMService
    participant LiteLLM as LiteLLM Proxy

    Note over Client,LiteLLM: GET /{region_id}/user/{user_id}/daily-activity
    Client->>SpendAPI: "GET /spend/{region_id}/user/{user_id}/daily-activity"
    SpendAPI->>SpendAPI: "validate start_date <= end_date"
    SpendAPI->>DB: query DBUser by id (no is_active filter ⚠️)
    DB-->>SpendAPI: target_user or 404
    SpendAPI->>SpendAPI: _assert_user_access(current_user, role, target_user)
    SpendAPI->>DB: _get_region_or_404(region_id)
    DB-->>SpendAPI: region
    SpendAPI->>LiteLLMService: get_user_daily_activity(user_id, start, end)
    LiteLLMService->>LiteLLM: "GET /user/daily/activity?user_id=&page=1"
    LiteLLM-->>LiteLLMService: page results
    loop "paginate until has_more=false or max_pages"
        LiteLLMService->>LiteLLM: "GET /user/daily/activity?page=N"
        LiteLLM-->>LiteLLMService: page results
    end
    LiteLLMService-->>SpendAPI: raw rows[]
    SpendAPI->>SpendAPI: _rows_to_daily_activity(rows)
    SpendAPI-->>Client: UserDailyActivityResponse

    Note over Client,LiteLLM: GET /{region_id}/team/{team_id}/daily-activity
    Client->>SpendAPI: "GET /spend/{region_id}/team/{team_id}/daily-activity"
    SpendAPI->>SpendAPI: "validate start_date <= end_date"
    SpendAPI->>DB: query DBTeam (filtered by deleted_at IS NULL)
    DB-->>SpendAPI: team or 404
    SpendAPI->>SpendAPI: _assert_team_access(current_user, role, team_id)
    SpendAPI->>DB: _get_region_or_404(region_id)
    DB-->>SpendAPI: region
    SpendAPI->>LiteLLMService: get_team_daily_activity(lite_team_id, start, end)
    LiteLLMService->>LiteLLM: "GET /team/daily/activity?team_ids=&page=1"
    LiteLLM-->>LiteLLMService: page results
    LiteLLMService-->>SpendAPI: raw rows[]
    SpendAPI->>SpendAPI: _rows_to_daily_activity(rows)
    SpendAPI-->>Client: TeamDailyActivityResponse
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant SpendAPI as spend.py (API)
    participant DB as Database
    participant LiteLLMService
    participant LiteLLM as LiteLLM Proxy

    Note over Client,LiteLLM: GET /{region_id}/user/{user_id}/daily-activity
    Client->>SpendAPI: "GET /spend/{region_id}/user/{user_id}/daily-activity"
    SpendAPI->>SpendAPI: "validate start_date <= end_date"
    SpendAPI->>DB: query DBUser by id (no is_active filter ⚠️)
    DB-->>SpendAPI: target_user or 404
    SpendAPI->>SpendAPI: _assert_user_access(current_user, role, target_user)
    SpendAPI->>DB: _get_region_or_404(region_id)
    DB-->>SpendAPI: region
    SpendAPI->>LiteLLMService: get_user_daily_activity(user_id, start, end)
    LiteLLMService->>LiteLLM: "GET /user/daily/activity?user_id=&page=1"
    LiteLLM-->>LiteLLMService: page results
    loop "paginate until has_more=false or max_pages"
        LiteLLMService->>LiteLLM: "GET /user/daily/activity?page=N"
        LiteLLM-->>LiteLLMService: page results
    end
    LiteLLMService-->>SpendAPI: raw rows[]
    SpendAPI->>SpendAPI: _rows_to_daily_activity(rows)
    SpendAPI-->>Client: UserDailyActivityResponse

    Note over Client,LiteLLM: GET /{region_id}/team/{team_id}/daily-activity
    Client->>SpendAPI: "GET /spend/{region_id}/team/{team_id}/daily-activity"
    SpendAPI->>SpendAPI: "validate start_date <= end_date"
    SpendAPI->>DB: query DBTeam (filtered by deleted_at IS NULL)
    DB-->>SpendAPI: team or 404
    SpendAPI->>SpendAPI: _assert_team_access(current_user, role, team_id)
    SpendAPI->>DB: _get_region_or_404(region_id)
    DB-->>SpendAPI: region
    SpendAPI->>LiteLLMService: get_team_daily_activity(lite_team_id, start, end)
    LiteLLMService->>LiteLLM: "GET /team/daily/activity?team_ids=&page=1"
    LiteLLM-->>LiteLLMService: page results
    LiteLLMService-->>SpendAPI: raw rows[]
    SpendAPI->>SpendAPI: _rows_to_daily_activity(rows)
    SpendAPI-->>Client: TeamDailyActivityResponse
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/test_spend.py`, line 936-993 ([link](https://github.com/amazeeio/amazee.ai/blob/ed3c79b7b73223349b32f84c625ba544d32b29e0/tests/test_spend.py#L936-L993)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Missing forbidden-access test for team endpoint**

   The user daily-activity tests include `test_user_daily_activity_forbidden_other_user`, which verifies a regular user from a different team gets a 403. The team daily-activity suite has no symmetrical test — there is no case that sends a request as a user belonging to a *different* team and asserts a 403 response. Without that test, a regression in `_assert_team_access` could go undetected.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["style: Clean up code formatting and spac..."](https://github.com/amazeeio/amazee.ai/commit/ed3c79b7b73223349b32f84c625ba544d32b29e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42960152)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->