### PR TITLE
chore: expose openapi.json to public again

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -31,11 +31,9 @@ class Settings(BaseSettings):
     # in backend-start.sh (a FastAPI constructor kwarg does NOT reach uvicorn).
     PUBLIC_PATHS: list[str] = [
         "/health",
-        # /openapi.json is only registered in local (see main.py openapi_url);
-        # it must stay public so the local Swagger UI can fetch the schema. In
-        # deployed envs the route does not exist, so this entry is inert.
-        # (/docs is never registered — docs_url=None — so it is not listed.)
+        # The schema and the Swagger UI at / are the public API docs.
         "/openapi.json",
+        "/",
         "/public/models",
         "/public/models/",
     ]

--- a/app/main.py
+++ b/app/main.py
@@ -23,12 +23,11 @@ from app.api import (
     webhooks,
 )
 from app.core.config import settings
-from app.core.security import get_current_user_from_auth
 from app.middleware.audit import AuditLogMiddleware
 from app.middleware.auth import AuthMiddleware
 from app.middleware.caching import CacheControlMiddleware
 from app.middleware.prometheus import PrometheusMiddleware
-from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.openapi.docs import get_swagger_ui_html
@@ -87,11 +86,10 @@ app = FastAPI(
     or you can provide a Bearer token in the Authorization header.
     """,
     version=__version__,
-    docs_url=None,  # Disable default /docs endpoint
+    docs_url=None,  # Disable default /docs endpoint; custom Swagger UI at /
     redoc_url=None,  # Disable default /redoc endpoint
-    # Disable FastAPI's default unauthenticated /openapi.json route.
-    # A custom authenticated endpoint is registered below (M5).
-    openapi_url=None,
+    # Public by design: the schema is the API's docs page (see PUBLIC_PATHS).
+    openapi_url="/openapi.json",
     root_path_in_servers=True,
     openapi_tags=[
         {
@@ -218,16 +216,8 @@ app.include_router(budgets.router, prefix="/budgets", tags=["budgets"])
 app.include_router(spend.router, prefix="/spend", tags=["spend"])
 
 
-@app.get("/openapi.json", include_in_schema=False)
-async def openapi_schema(user=Depends(get_current_user_from_auth)):
-    """Serve the OpenAPI schema to authenticated callers only (M5)."""
-    return app.openapi()
-
-
 @app.get("/", include_in_schema=False)
 async def custom_swagger_ui_html():
-    if settings.ENV_SUFFIX != "local":
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     return get_swagger_ui_html(
         openapi_url="/openapi.json",
         title="API Documentation",

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -212,19 +212,19 @@ async def test_get_current_user_from_auth_does_not_accept_local_bearer_from_cook
     assert exc_info.value.status_code == 401
 
 
-def test_openapi_requires_auth_when_not_local():
-    """M5: /openapi.json must be auth-gated in deployed envs; Swagger UI still 404.
+def test_openapi_and_docs_are_public_when_not_local():
+    """/openapi.json and the Swagger UI at / are the public API docs.
 
-    Unauthenticated callers get 401 (not the schema). The Swagger UI at / stays
-    404 in non-local envs. openapi_url is fixed at import time, so we use a
-    subprocess to import the app fresh with ENV_SUFFIX=production.
+    Both must be reachable without auth in deployed envs. Env-dependent app
+    setup is fixed at import time, so we use a subprocess to import the app
+    fresh with ENV_SUFFIX=production.
     """
     code = (
         "from fastapi.testclient import TestClient\n"
         "from app.main import app\n"
         "client = TestClient(app)\n"
-        "assert client.get('/openapi.json').status_code == 401\n"
-        "assert client.get('/').status_code == 404\n"
+        "assert client.get('/openapi.json').status_code == 200\n"
+        "assert client.get('/').status_code == 200\n"
     )
     result = subprocess.run(
         [sys.executable, "-c", code],


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR re-exposes `/openapi.json` and the custom Swagger UI at `/` as public endpoints in all environments, reverting a previous decision to gate them behind authentication. The custom authenticated `/openapi.json` route (`M5`) is removed in favour of FastAPI's native schema-serving, and the Swagger UI's production-env 404 guard is removed.

- `/openapi.json` moves from a `Depends(get_current_user_from_auth)`-protected custom endpoint to FastAPI's built-in schema route, with `PUBLIC_PATHS` granting it middleware-level bypass.
- `/` (Swagger UI) no longer raises 404 in non-local environments; it is now added to `PUBLIC_PATHS` and accessible everywhere.
- The security test is updated to assert 200 (was 401 / 404) for both paths when `ENV_SUFFIX=production`.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is deliberate and well-tested, and protected endpoints still require authentication.

The three changed files are tightly scoped and internally consistent: the custom auth-gated schema endpoint is fully removed, FastAPI's native serving takes over, PUBLIC_PATHS is updated, and the test is correctly updated to assert the new contract. The AuthMiddleware uses exact string matching, so adding "/" to PUBLIC_PATHS does not create a wildcard bypass. One point is held back because exposing the full API schema publicly is a meaningful security posture change — reviewers may want to confirm that internal endpoint shapes, parameter names, and response schemas in the OpenAPI document don't contain anything that should remain non-public.

Consider spot-checking the generated OpenAPI schema output on a staging environment to confirm no sensitive internal details are visible before this goes to production.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/main.py | Removes the authenticated /openapi.json custom endpoint and the ENV_SUFFIX guard on the Swagger UI; switches to FastAPI's native openapi_url="/openapi.json" serving. Clean removal with no leftover imports or stubs. |
| app/core/config.py | Adds "/openapi.json" and "/" to PUBLIC_PATHS; the AuthMiddleware performs exact-string path matching, so "/" only bypasses auth for the root path and does not create a wildcard exemption. |
| tests/test_security.py | Test renamed and assertions flipped from 401/404 to 200/200; subprocess approach correctly exercises the production ENV_SUFFIX import-time path. Coverage for the new public-access contract is adequate. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Request] --> B{Path in PUBLIC_PATHS?}
    B -- "/openapi.json or / or /health or /public/models" --> C[Skip Auth → call_next]
    B -- other paths --> D[AuthMiddleware: attempt token lookup]
    D --> E{Token present?}
    E -- yes --> F[Validate token, set request.state.user]
    E -- no --> G[request.state.user = None]
    F --> H[call_next to endpoint]
    G --> H

    C --> I{Which public path?}
    I -- "/openapi.json" --> J[FastAPI native schema serving]
    I -- "/" --> K[Swagger UI in ALL environments]
    I -- "/health" --> L[health_check handler]
    I -- "/public/models" --> M[public models list]

    subgraph BEFORE ["Before this PR"]
        N["/openapi.json"] --> O{Auth required}
        O -- authed --> P[Return schema]
        O -- unauthed --> Q[401 Unauthorized]
        R["/"] --> S{ENV_SUFFIX == local?}
        S -- yes --> T[Swagger UI]
        S -- no --> U[404 Not Found]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Incoming Request] --> B{Path in PUBLIC_PATHS?}
    B -- "/openapi.json or / or /health or /public/models" --> C[Skip Auth → call_next]
    B -- other paths --> D[AuthMiddleware: attempt token lookup]
    D --> E{Token present?}
    E -- yes --> F[Validate token, set request.state.user]
    E -- no --> G[request.state.user = None]
    F --> H[call_next to endpoint]
    G --> H

    C --> I{Which public path?}
    I -- "/openapi.json" --> J[FastAPI native schema serving]
    I -- "/" --> K[Swagger UI in ALL environments]
    I -- "/health" --> L[health_check handler]
    I -- "/public/models" --> M[public models list]

    subgraph BEFORE ["Before this PR"]
        N["/openapi.json"] --> O{Auth required}
        O -- authed --> P[Return schema]
        O -- unauthed --> Q[401 Unauthorized]
        R["/"] --> S{ENV_SUFFIX == local?}
        S -- yes --> T[Swagger UI]
        S -- no --> U[404 Not Found]
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: expose openapi.json to public aga..."](https://github.com/amazeeio/amazee.ai/commit/7899c22e8fce91cd647f066ddae367467fb6a3ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42963269)</sub>

<!-- /greptile_comment -->