### PR TITLE
fix(admin): restore show_all so admin dashboard lists all private AI keys

### DIFF
--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -627,6 +627,7 @@ async def list_private_ai_keys(
     owner_id: Optional[int] = None,
     team_id: Optional[int] = None,
     search: Optional[str] = None,
+    show_all: bool = False,
     current_user=Depends(get_current_user_from_auth),
     db: Session = Depends(get_db),
 ):
@@ -635,6 +636,7 @@ async def list_private_ai_keys(
     If user is admin:
         - Returns keys for specific owner if owner_id is provided
         - Returns keys for specific team if team_id is provided
+        - Returns every key in the system if show_all=true is passed
         - Otherwise (no params), returns only the admin's own keys — the
           same safe default as any other caller. This avoids handing back
           every secret in the database to any admin-scoped integration
@@ -675,9 +677,9 @@ async def list_private_ai_keys(
                 (DBPrivateAIKey.owner_id.in_(team_user_ids))
                 | (DBPrivateAIKey.team_id == team_id)
             )
-        else:
-            # Safe default: an admin with no filters gets only their own
-            # keys, not every key in the system.
+        elif not show_all:
+            # Safe default: no filters and no explicit opt-in means "my own
+            # keys", not "every key in the system".
             query = query.filter(DBPrivateAIKey.owner_id == current_user.id)
     else:
         # Check if user is a team admin
@@ -731,6 +733,7 @@ async def list_private_ai_keys_by_region(
     region_id: int,
     team_id: Optional[int] = None,
     user_id: Optional[int] = None,
+    show_all: bool = False,
     current_user=Depends(get_current_user_from_auth),
     db: Session = Depends(get_db),
 ):
@@ -748,9 +751,9 @@ async def list_private_ai_keys_by_region(
       parameter silently ignored. May be combined with `team_id` to further scope
       results to keys owned by that user within a particular team.
       Returns an empty list when the specified user does not exist.
-
-    Without team_id or user_id, an admin caller gets only their own keys in
-    this region rather than every key in the region.
+    - **show_all**: System admin only. Without it (and without team_id/user_id),
+      an admin caller gets only their own keys in this region rather than every
+      key in the region.
     """
     query = db.query(DBPrivateAIKey).outerjoin(
         DBTeam, DBPrivateAIKey.team_id == DBTeam.id
@@ -788,9 +791,9 @@ async def list_private_ai_keys_by_region(
                 return []
             query = query.filter(DBPrivateAIKey.owner_id == user_id)
 
-        if team_id is None and user_id is None:
-            # Safe default: an admin with no filters gets only their own keys
-            # in this region, not every key in the region.
+        if team_id is None and user_id is None and not show_all:
+            # Safe default: no filters and no explicit opt-in means "my own
+            # keys in this region", not "every key in the region".
             query = query.filter(DBPrivateAIKey.owner_id == current_user.id)
     else:
         # Check if user is a team admin

--- a/frontend/src/app/admin/private-ai-keys/page.tsx
+++ b/frontend/src/app/admin/private-ai-keys/page.tsx
@@ -21,7 +21,7 @@ export default function PrivateAIKeysPage() {
   // Fetch all private AI keys
   const { data: privateAIKeys = [], isLoading: isLoadingPrivateAIKeys } =
     useQuery<PrivateAIKey[]>({
-      queryKey: ["private-ai-keys"],
+      queryKey: ["private-ai-keys", { showAll: true }],
       queryFn: async () => {
         // show_all: admin-only opt-in; without it the API returns only the
         // caller's own keys as a safe default

--- a/frontend/src/app/admin/private-ai-keys/page.tsx
+++ b/frontend/src/app/admin/private-ai-keys/page.tsx
@@ -23,7 +23,9 @@ export default function PrivateAIKeysPage() {
     useQuery<PrivateAIKey[]>({
       queryKey: ["private-ai-keys"],
       queryFn: async () => {
-        const response = await get("/private-ai-keys");
+        // show_all: admin-only opt-in; without it the API returns only the
+        // caller's own keys as a safe default
+        const response = await get("/private-ai-keys?show_all=true");
         return response.json();
       },
     });

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -3261,3 +3261,43 @@ def test_list_private_ai_keys_by_region_user_filter_ignored_for_non_admin(
     returned_db_names = {key["database_name"] for key in data}
     assert "region-non-admin-user-own-db" in returned_db_names
     assert "region-non-admin-other-db" not in returned_db_names
+
+
+def test_list_private_ai_keys_show_all(
+    client, admin_token, test_token, test_region, test_user, test_admin, db
+):
+    """show_all=true returns every key for admins and is ignored for non-admins"""
+    user_key = DBPrivateAIKey(
+        database_name="show-all-user-db",
+        database_host="test-host",
+        database_username="test-user",
+        database_password="test-pass",
+        litellm_token="show-all-user-token",
+        owner_id=test_user.id,
+        region_id=test_region.id,
+    )
+    db.add(user_key)
+    db.commit()
+
+    # Admin without show_all: safe default, other users' keys are absent
+    response = client.get(
+        "/private-ai-keys/", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert response.status_code == 200
+    assert "show-all-user-db" not in {k["database_name"] for k in response.json()}
+
+    # Admin with show_all=true sees every key
+    response = client.get(
+        "/private-ai-keys/?show_all=true",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    assert "show-all-user-db" in {k["database_name"] for k in response.json()}
+
+    # Non-admin with show_all=true still only sees their own keys
+    response = client.get(
+        "/private-ai-keys/?show_all=true",
+        headers={"Authorization": f"Bearer {test_token}"},
+    )
+    assert response.status_code == 200
+    assert all(k["owner_id"] == test_user.id for k in response.json())

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -3263,6 +3263,50 @@ def test_list_private_ai_keys_by_region_user_filter_ignored_for_non_admin(
     assert "region-non-admin-other-db" not in returned_db_names
 
 
+def test_list_private_ai_keys_by_region_show_all(
+    client, admin_token, test_token, test_region, test_user, db
+):
+    """show_all=true in the region endpoint returns every key for admins and is
+    ignored for non-admins"""
+    user_key = DBPrivateAIKey(
+        database_name="region-show-all-user-db",
+        database_host="test-host",
+        database_username="test-user",
+        database_password="test-pass",
+        litellm_token="region-show-all-user-token",
+        owner_id=test_user.id,
+        region_id=test_region.id,
+    )
+    db.add(user_key)
+    db.commit()
+
+    # Admin without show_all: safe default, other users' keys are absent
+    response = client.get(
+        f"/private-ai-keys/region/{test_region.id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    assert "region-show-all-user-db" not in {
+        k["database_name"] for k in response.json()
+    }
+
+    # Admin with show_all=true sees every key in the region
+    response = client.get(
+        f"/private-ai-keys/region/{test_region.id}?show_all=true",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    assert "region-show-all-user-db" in {k["database_name"] for k in response.json()}
+
+    # Non-admin with show_all=true still only sees their own keys
+    response = client.get(
+        f"/private-ai-keys/region/{test_region.id}?show_all=true",
+        headers={"Authorization": f"Bearer {test_token}"},
+    )
+    assert response.status_code == 200
+    assert all(k["owner_id"] == test_user.id for k in response.json())
+
+
 def test_list_private_ai_keys_show_all(
     client, admin_token, test_token, test_region, test_user, test_admin, db
 ):

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -2233,7 +2233,7 @@ def test_restored_team_keys_are_accessible(
 
     # Verify key is not in list
     response = client.get(
-        f"/private-ai-keys?team_id={team_id}",
+        "/private-ai-keys?show_all=true",
         headers={"Authorization": f"Bearer {admin_token}"},
     )
     assert response.status_code == 200
@@ -2249,7 +2249,7 @@ def test_restored_team_keys_are_accessible(
 
     # Verify key is now in list
     response = client.get(
-        f"/private-ai-keys?team_id={team_id}",
+        "/private-ai-keys?show_all=true",
         headers={"Authorization": f"Bearer {admin_token}"},
     )
     assert response.status_code == 200

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -2233,7 +2233,7 @@ def test_restored_team_keys_are_accessible(
 
     # Verify key is not in list
     response = client.get(
-        "/private-ai-keys?show_all=true",
+        f"/private-ai-keys?team_id={team_id}",
         headers={"Authorization": f"Bearer {admin_token}"},
     )
     assert response.status_code == 200
@@ -2249,7 +2249,7 @@ def test_restored_team_keys_are_accessible(
 
     # Verify key is now in list
     response = client.get(
-        "/private-ai-keys?show_all=true",
+        f"/private-ai-keys?team_id={team_id}",
         headers={"Authorization": f"Bearer {admin_token}"},
     )
     assert response.status_code == 200


### PR DESCRIPTION
## Problem

`/admin/private-ai-keys` only shows the logged-in admin's own keys. The removal of the `show_all` parameter in daea6d5fc1b4 made `GET /private-ai-keys` fall back to the "own keys only" safe default for admins with no filters, and the admin dashboard calls the endpoint unfiltered.

## Fix

- Revert daea6d5fc1b4, restoring `show_all` as an explicit opt-in on both list endpoints. It is only honored for system admins; the safe default for unfiltered admin calls (and all non-admin behavior) is unchanged.
- Admin dashboard page now requests `/private-ai-keys?show_all=true`.
- New regression test: admin without `show_all` gets own keys only, admin with `show_all=true` sees all keys, non-admin with `show_all=true` still sees only their own.

## Testing

`make backend-test-regex regex="list_private_ai_keys"` — 15 passed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restores the admin all-keys view for private AI keys. The main changes are:

- Adds `show_all` as an admin-only opt-in on the global and region list endpoints.
- Updates the admin dashboard to call `/private-ai-keys?show_all=true`.
- Scopes the admin dashboard query cache key for the all-keys result.
- Adds tests for admin and non-admin `show_all` behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/private_ai_keys.py | Restores `show_all` on private AI key list endpoints while preserving the default self-only behavior. |
| frontend/src/app/admin/private-ai-keys/page.tsx | Requests the admin all-keys endpoint and uses a scoped query key for that result. |
| tests/test_private_ai.py | Adds tests covering `show_all` for admins and non-admins on both list endpoints. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test: cover show\_all on by-region endpoi..."](https://github.com/amazeeio/amazee.ai/commit/45cc70a60f5a631f184b896533a4acf307e7d124) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43543736)</sub>

<!-- /greptile_comment -->