### PR TITLE
feat(spend): include cache token usage in daily-activity responses, model breakdown

### DIFF
--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -39,6 +39,7 @@ from app.schemas.limits import OwnerType, ResourceType
 from app.api.users import invalidate_user_spend_cache
 from app.schemas.models import (
     BudgetType,
+    DailyActivityModelBreakdown,
     KeyDailyActivityResponse,
     KeyDailyActivityRow,
     KeyLastUsedResponse,
@@ -273,42 +274,69 @@ def _extract_token_usage(data: dict) -> tuple[int | None, int | None, int | None
     )
 
 
-def _rows_to_daily_activity(rows: list[dict]) -> list[KeyDailyActivityRow]:
+def _daily_metric_fields(metrics: dict) -> dict:
+    """Extract the shared per-day metric fields from a LiteLLM ``metrics`` block.
+
+    Returns kwargs common to both the flat daily row and each per-model
+    breakdown entry, coercing missing/null values to 0 (0.0 for spend). Note
+    ``request_count`` maps from LiteLLM's ``api_requests``.
+    """
+    spend_val = metrics.get("spend")
+
+    def _int(key: str) -> int:
+        val = metrics.get(key)
+        return val if val is not None else 0
+
+    return {
+        "spend": spend_val if spend_val is not None else 0.0,
+        "prompt_tokens": _int("prompt_tokens"),
+        "completion_tokens": _int("completion_tokens"),
+        "total_tokens": _int("total_tokens"),
+        "cache_read_input_tokens": _int("cache_read_input_tokens"),
+        "cache_creation_input_tokens": _int("cache_creation_input_tokens"),
+        "request_count": _int("api_requests"),
+    }
+
+
+def _row_model_breakdown(row: dict) -> list[DailyActivityModelBreakdown]:
+    """Build the per-model breakdown for one raw LiteLLM daily row.
+
+    Reads ``breakdown.models`` (a dict keyed by model name) and returns a list
+    ordered by descending spend. Returns an empty list when LiteLLM reports no
+    model breakdown for the day.
+    """
+    models = ((row.get("breakdown") or {}).get("models")) or {}
+    breakdown = [
+        DailyActivityModelBreakdown(
+            model=name, **_daily_metric_fields(entry.get("metrics") or {})
+        )
+        for name, entry in models.items()
+    ]
+    breakdown.sort(key=lambda b: b.spend, reverse=True)
+    return breakdown
+
+
+def _rows_to_daily_activity(
+    rows: list[dict], include_breakdown: bool = False
+) -> list[KeyDailyActivityRow]:
     """Map raw LiteLLM daily-activity rows to daily-activity response rows.
 
     Each raw row carries ``date`` and a ``metrics`` block; rows without a date
-    are skipped and the result is ordered ascending by date. The ``breakdown``
-    block returned by LiteLLM (per model/provider/key) is intentionally dropped
-    to keep the response flat.
+    are skipped and the result is ordered ascending by date. LiteLLM's
+    ``breakdown`` block (per model/provider/key) is dropped by default to keep
+    the response flat; when ``include_breakdown`` is set, the per-model slice is
+    attached to each row's ``breakdown`` field.
     """
     activity: list[KeyDailyActivityRow] = []
     for row in rows:
         if not row.get("date"):
             continue
         metrics = row.get("metrics") or {}
-        spend_val = metrics.get("spend")
         activity.append(
             KeyDailyActivityRow(
                 date=row["date"],
-                spend=spend_val if spend_val is not None else 0.0,
-                prompt_tokens=metrics.get("prompt_tokens")
-                if metrics.get("prompt_tokens") is not None
-                else 0,
-                completion_tokens=metrics.get("completion_tokens")
-                if metrics.get("completion_tokens") is not None
-                else 0,
-                total_tokens=metrics.get("total_tokens")
-                if metrics.get("total_tokens") is not None
-                else 0,
-                cache_read_input_tokens=metrics.get("cache_read_input_tokens")
-                if metrics.get("cache_read_input_tokens") is not None
-                else 0,
-                cache_creation_input_tokens=metrics.get("cache_creation_input_tokens")
-                if metrics.get("cache_creation_input_tokens") is not None
-                else 0,
-                request_count=metrics.get("api_requests")
-                if metrics.get("api_requests") is not None
-                else 0,
+                breakdown=_row_model_breakdown(row) if include_breakdown else None,
+                **_daily_metric_fields(metrics),
             )
         )
     activity.sort(key=lambda r: r.date)
@@ -1489,6 +1517,7 @@ async def get_key_last_used(
 @router.get(
     "/{region_id}/key/{key_id}/daily-activity",
     response_model=KeyDailyActivityResponse,
+    response_model_exclude_none=True,
     summary="Get key daily activity by region",
     description=(
         "Returns per-day usage (spend, tokens and request count) for a specific "
@@ -1515,6 +1544,13 @@ async def get_key_daily_activity(
         description=(
             "End date (inclusive), formatted YYYY-MM-DD. "
             "Defaults to today (UTC) when omitted."
+        ),
+    ),
+    include_breakdown: bool = Query(
+        False,
+        description=(
+            "When true, include a per-model breakdown on each daily row. "
+            "Defaults to false, leaving the flat response unchanged."
         ),
     ),
     current_user: DBUser = Depends(get_current_user_from_auth),
@@ -1562,13 +1598,14 @@ async def get_key_daily_activity(
         key_id=key_id,
         start_date=start_date,
         end_date=end_date,
-        activity=_rows_to_daily_activity(rows),
+        activity=_rows_to_daily_activity(rows, include_breakdown=include_breakdown),
     )
 
 
 @router.get(
     "/{region_id}/user/{user_id}/daily-activity",
     response_model=UserDailyActivityResponse,
+    response_model_exclude_none=True,
     summary="Get user daily activity by region",
     description=(
         "Returns per-day usage (spend, tokens and request count) aggregated "
@@ -1602,6 +1639,13 @@ async def get_user_daily_activity(
             "Defaults to today (UTC) when omitted."
         ),
     ),
+    include_breakdown: bool = Query(
+        False,
+        description=(
+            "When true, include a per-model breakdown on each daily row. "
+            "Defaults to false, leaving the flat response unchanged."
+        ),
+    ),
     current_user: DBUser = Depends(get_current_user_from_auth),
     user_role: str = Depends(get_private_ai_access),
     db: Session = Depends(get_db),
@@ -1629,13 +1673,14 @@ async def get_user_daily_activity(
         user_id=user_id,
         start_date=start_date,
         end_date=end_date,
-        activity=_rows_to_daily_activity(rows),
+        activity=_rows_to_daily_activity(rows, include_breakdown=include_breakdown),
     )
 
 
 @router.get(
     "/{region_id}/team/{team_id}/daily-activity",
     response_model=TeamDailyActivityResponse,
+    response_model_exclude_none=True,
     summary="Get team daily activity by region",
     description=(
         "Returns per-day usage (spend, tokens and request count) aggregated "
@@ -1667,6 +1712,13 @@ async def get_team_daily_activity(
         description=(
             "End date (inclusive), formatted YYYY-MM-DD. "
             "Defaults to today (UTC) when omitted."
+        ),
+    ),
+    include_breakdown: bool = Query(
+        False,
+        description=(
+            "When true, include a per-model breakdown on each daily row. "
+            "Defaults to false, leaving the flat response unchanged."
         ),
     ),
     current_user: DBUser = Depends(get_current_user_from_auth),
@@ -1701,7 +1753,7 @@ async def get_team_daily_activity(
         team_id=team_id,
         start_date=start_date,
         end_date=end_date,
-        activity=_rows_to_daily_activity(rows),
+        activity=_rows_to_daily_activity(rows, include_breakdown=include_breakdown),
     )
 
 

--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -300,6 +300,12 @@ def _rows_to_daily_activity(rows: list[dict]) -> list[KeyDailyActivityRow]:
                 total_tokens=metrics.get("total_tokens")
                 if metrics.get("total_tokens") is not None
                 else 0,
+                cache_read_input_tokens=metrics.get("cache_read_input_tokens")
+                if metrics.get("cache_read_input_tokens") is not None
+                else 0,
+                cache_creation_input_tokens=metrics.get("cache_creation_input_tokens")
+                if metrics.get("cache_creation_input_tokens") is not None
+                else 0,
                 request_count=metrics.get("api_requests")
                 if metrics.get("api_requests") is not None
                 else 0,

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -652,6 +652,29 @@ class KeyLastUsedResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class DailyActivityModelBreakdown(BaseModel):
+    """Per-model slice of a day's usage, taken from LiteLLM's breakdown block.
+
+    Only present on daily-activity rows when the request opts in with
+    ``include_breakdown=true``. The metric fields mirror the flat row and, for
+    a given day, sum to the row's aggregate totals.
+    """
+
+    model: str = Field(
+        description="LiteLLM model name, e.g. 'bedrock/us.anthropic.claude-sonnet-4-6'.",
+    )
+    spend: float = 0.0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    request_count: int = 0
+    # `model` is a normal field here; opt out of pydantic's protected `model_`
+    # namespace so it doesn't warn/clash.
+    model_config = ConfigDict(from_attributes=True, protected_namespaces=())
+
+
 class KeyDailyActivityRow(BaseModel):
     date: date
     spend: float = 0.0
@@ -675,6 +698,14 @@ class KeyDailyActivityRow(BaseModel):
     request_count: int = Field(
         default=0,
         description="Number of API requests made with this key on this day.",
+    )
+    breakdown: Optional[List[DailyActivityModelBreakdown]] = Field(
+        default=None,
+        description=(
+            "Per-model usage for this day, ordered by descending spend. Only "
+            "populated when the request sets include_breakdown=true; omitted "
+            "otherwise."
+        ),
     )
     model_config = ConfigDict(from_attributes=True)
 

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -658,6 +658,20 @@ class KeyDailyActivityRow(BaseModel):
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
+    cache_read_input_tokens: int = Field(
+        default=0,
+        description=(
+            "Prompt tokens served from LiteLLM's prompt cache on this day "
+            "(billed at the cheaper cache-read rate)."
+        ),
+    )
+    cache_creation_input_tokens: int = Field(
+        default=0,
+        description=(
+            "Prompt tokens written to LiteLLM's prompt cache on this day "
+            "(billed at the cache-write rate)."
+        ),
+    )
     request_count: int = Field(
         default=0,
         description="Number of API requests made with this key on this day.",

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -290,6 +290,8 @@ def test_key_daily_activity(
                 "prompt_tokens": 100,
                 "completion_tokens": 20,
                 "total_tokens": 120,
+                "cache_read_input_tokens": 70,
+                "cache_creation_input_tokens": 30,
                 "api_requests": 2,
             },
         },
@@ -312,7 +314,13 @@ def test_key_daily_activity(
     assert first["prompt_tokens"] == 100
     assert first["completion_tokens"] == 20
     assert first["total_tokens"] == 120
+    assert first["cache_read_input_tokens"] == 70
+    assert first["cache_creation_input_tokens"] == 30
     assert first["request_count"] == 2
+    # Cache fields default to 0 when LiteLLM omits them from the metrics block.
+    second = data["activity"][1]
+    assert second["cache_read_input_tokens"] == 0
+    assert second["cache_creation_input_tokens"] == 0
 
     # Endpoint forwards the key's plaintext token and the requested range.
     mock_get_daily_activity.assert_awaited_once()

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -321,6 +321,10 @@ def test_key_daily_activity(
     second = data["activity"][1]
     assert second["cache_read_input_tokens"] == 0
     assert second["cache_creation_input_tokens"] == 0
+    # Without include_breakdown the per-model breakdown is omitted entirely
+    # (not serialized as null), keeping the flat response shape unchanged.
+    assert "breakdown" not in first
+    assert "breakdown" not in second
 
     # Endpoint forwards the key's plaintext token and the requested range.
     mock_get_daily_activity.assert_awaited_once()
@@ -328,6 +332,86 @@ def test_key_daily_activity(
     assert kwargs["litellm_token"] == "sk-daily-token"
     assert kwargs["start_date"] == "2025-06-01"
     assert kwargs["end_date"] == "2025-06-02"
+
+
+@patch("app.api.spend.LiteLLMService.get_daily_activity", new_callable=AsyncMock)
+def test_key_daily_activity_include_breakdown(
+    mock_get_daily_activity, client, team_admin_token, test_team_user, test_region, db
+):
+    key = DBPrivateAIKey(
+        name="daily-activity-breakdown-key",
+        litellm_token="sk-daily-breakdown-token",
+        region_id=test_region.id,
+        owner_id=test_team_user.id,
+        team_id=test_team_user.team_id,
+    )
+    db.add(key)
+    db.commit()
+
+    mock_get_daily_activity.return_value = [
+        {
+            "date": "2025-06-01",
+            "metrics": {
+                "spend": 3.0,
+                "prompt_tokens": 300,
+                "completion_tokens": 60,
+                "total_tokens": 360,
+                "cache_read_input_tokens": 40,
+                "cache_creation_input_tokens": 10,
+                "api_requests": 5,
+            },
+            "breakdown": {
+                "models": {
+                    "cheap-model": {
+                        "metrics": {
+                            "spend": 1.0,
+                            "prompt_tokens": 100,
+                            "completion_tokens": 20,
+                            "total_tokens": 120,
+                            "api_requests": 2,
+                        }
+                    },
+                    "pricey-model": {
+                        "metrics": {
+                            "spend": 2.0,
+                            "prompt_tokens": 200,
+                            "completion_tokens": 40,
+                            "total_tokens": 240,
+                            "cache_read_input_tokens": 40,
+                            "cache_creation_input_tokens": 10,
+                            "api_requests": 3,
+                        }
+                    },
+                }
+            },
+        }
+    ]
+
+    response = client.get(
+        f"/spend/{test_region.id}/key/{key.id}/daily-activity",
+        params={
+            "start_date": "2025-06-01",
+            "end_date": "2025-06-01",
+            "include_breakdown": "true",
+        },
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code == 200
+    row = response.json()["activity"][0]
+    # Flat aggregate is unchanged by the opt-in.
+    assert row["spend"] == 3.0
+    assert row["request_count"] == 5
+    # Breakdown is present and ordered by descending spend.
+    breakdown = row["breakdown"]
+    assert [m["model"] for m in breakdown] == ["pricey-model", "cheap-model"]
+    pricey = breakdown[0]
+    assert pricey["spend"] == 2.0
+    assert pricey["total_tokens"] == 240
+    assert pricey["cache_read_input_tokens"] == 40
+    assert pricey["cache_creation_input_tokens"] == 10
+    assert pricey["request_count"] == 3
+    # Missing cache fields on a model default to 0.
+    assert breakdown[1]["cache_read_input_tokens"] == 0
 
 
 @patch("app.api.spend.LiteLLMService.get_daily_activity", new_callable=AsyncMock)


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds cache token usage and optional model details to daily activity responses. The main changes are:

- Adds cache read and cache creation token fields to daily activity rows.
- Adds an opt-in `include_breakdown` query parameter for key, user, and team daily activity endpoints.
- Maps LiteLLM per-model breakdown data into a new response schema.
- Extends spend tests for cache token defaults and key-level model breakdown output.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The default response shape stays flat when `include_breakdown` is not set.
- Missing cache token fields are handled with zero defaults.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/spend.py | Adds shared daily metric mapping, optional model breakdown mapping, and query support across daily activity endpoints. |
| app/schemas/models.py | Adds the model breakdown schema and extends daily activity rows with cache token and optional breakdown fields. |
| tests/test_spend.py | Adds tests for cache token serialization, breakdown omission by default, and opt-in model breakdown ordering. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(spend): optional per-model breakdow..."](https://github.com/amazeeio/amazee.ai/commit/19d71d3070ee35befbe82d50da981ba7539587e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43753442)</sub>

<!-- /greptile_comment -->