### PR TITLE
fix: defence-in-depth team scope on key-by-id endpoints (IDOR #600)

### DIFF
--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -36,6 +36,7 @@ from app.core.security import (
     get_role_min_system_admin,
 )
 from app.core.roles import UserRole
+from app.core.rbac import enforce_declared_team_scope
 from app.core.config import settings
 from app.core.limit_service import (
     LimitService,
@@ -846,6 +847,7 @@ async def list_private_ai_keys_by_region(
 )
 async def get_private_ai_key(
     key_id: int,
+    team_id: Optional[int] = None,
     current_user=Depends(get_current_user_from_auth),
     db: Session = Depends(get_db),
 ):
@@ -869,8 +871,15 @@ async def get_private_ai_key(
 
     Note: You must be authenticated to use this endpoint.
     Only system administrators can access this endpoint.
+
+    Optional query parameter:
+    - **team_id**: When provided, the key must belong to this team or the
+      request 404s — a defence-in-depth scope check (issue #600) that applies
+      even to system-admin callers.
     """
-    private_ai_key = _get_key_if_allowed(key_id, current_user, "system_admin", db)
+    private_ai_key = _get_key_if_allowed(
+        key_id, current_user, "system_admin", db, declared_team_id=team_id
+    )
 
     # Get the region
     region = db.query(DBRegion).filter(DBRegion.id == private_ai_key.region_id).first()
@@ -920,7 +929,11 @@ async def get_private_ai_key(
 
 
 def _get_key_if_allowed(
-    key_id: int, current_user: DBUser, user_role: UserRole, db: Session
+    key_id: int,
+    current_user: DBUser,
+    user_role: UserRole,
+    db: Session,
+    declared_team_id: Optional[int] = None,
 ) -> DBPrivateAIKey:
     # First try to find the key
     private_ai_key = (
@@ -931,6 +944,11 @@ def _get_key_if_allowed(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Private AI Key not found"
         )
+
+    # Defence-in-depth (issue #600): when the caller declares the team it is
+    # acting for, the key must belong to that team — enforced even for system
+    # admins (e.g. the moad shared-admin token), closing the cross-tenant IDOR.
+    enforce_declared_team_scope(private_ai_key, declared_team_id, db)
 
     # Check if user has permission to view the key
     team_users: list[UserRole] = [UserRole.TEAM_ADMIN, UserRole.KEY_CREATOR]
@@ -970,11 +988,14 @@ def _get_key_if_allowed(
 @router.delete("/{key_id}")
 async def delete_private_ai_key(
     key_id: int,
+    team_id: Optional[int] = None,
     current_user=Depends(get_current_user_from_auth),
     user_role: UserRole = Depends(get_private_ai_access),
     db: Session = Depends(get_db),
 ):
-    private_ai_key = _get_key_if_allowed(key_id, current_user, user_role, db)
+    private_ai_key = _get_key_if_allowed(
+        key_id, current_user, user_role, db, declared_team_id=team_id
+    )
     # Get the region
     region = db.query(DBRegion).filter(DBRegion.id == private_ai_key.region_id).first()
     if not region:

--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -12,6 +12,7 @@ from app.core.config import settings
 from app.core.limit_service import DEFAULT_MAX_SPEND, LimitService
 from app.core.litellm_user_sync import team_role_for_litellm
 from app.core.roles import UserRole
+from app.core.rbac import enforce_declared_team_scope
 from app.core.periodic_budget_ledger_service import compute_active_topup_remaining
 from app.core.pool_budget_service import (
     pool_available_budget_for_team_region as shared_pool_available_budget_for_team_region,
@@ -1311,6 +1312,7 @@ async def get_user_spend(
 async def get_key_spend_alias(
     region_id: int,
     key_id: int,
+    team_id: int | None = None,
     current_user: DBUser = Depends(get_current_user_from_auth),
     user_role: str = Depends(get_private_ai_access),
     db: Session = Depends(get_db),
@@ -1322,6 +1324,10 @@ async def get_key_spend_alias(
         raise HTTPException(
             status_code=404, detail="Private AI Key not found in region"
         )
+
+    # Defence-in-depth scope gate (issue #600): enforce declared team scope
+    # even for system-admin callers before applying role-based access.
+    enforce_declared_team_scope(key, team_id, db)
 
     # Reuse authorization semantics from private-ai-keys endpoints.
     if current_user.is_admin:
@@ -1466,6 +1472,7 @@ async def get_key_spend_alias(
 async def get_key_last_used(
     region_id: int,
     key_id: int,
+    team_id: int | None = None,
     current_user: DBUser = Depends(get_current_user_from_auth),
     user_role: str = Depends(get_private_ai_access),
     db: Session = Depends(get_db),
@@ -1477,6 +1484,9 @@ async def get_key_last_used(
         raise HTTPException(
             status_code=404, detail="Private AI Key not found in region"
         )
+
+    # Defence-in-depth scope gate (issue #600).
+    enforce_declared_team_scope(key, team_id, db)
 
     # Reuse authorization semantics from get_key_spend_alias.
     if current_user.is_admin:
@@ -1553,6 +1563,14 @@ async def get_key_daily_activity(
             "Defaults to false, leaving the flat response unchanged."
         ),
     ),
+    team_id: int | None = Query(
+        None,
+        description=(
+            "When provided, the key must belong to this team or the request "
+            "404s — a defence-in-depth scope check (issue #600) applied even "
+            "to system-admin callers."
+        ),
+    ),
     current_user: DBUser = Depends(get_current_user_from_auth),
     user_role: str = Depends(get_private_ai_access),
     db: Session = Depends(get_db),
@@ -1566,6 +1584,9 @@ async def get_key_daily_activity(
         raise HTTPException(
             status_code=404, detail="Private AI Key not found in region"
         )
+
+    # Defence-in-depth scope gate (issue #600).
+    enforce_declared_team_scope(key, team_id, db)
 
     # Reuse authorization semantics from get_key_spend_alias.
     if current_user.is_admin:
@@ -2182,6 +2203,7 @@ async def update_key_budget(
     region_id: int,
     key_id: int,
     body: SpendBudgetUpdateRequest,
+    team_id: int | None = None,
     current_user: DBUser = Depends(get_current_user_from_auth),
     role: str = Depends(get_role_min_team_admin),
     db: Session = Depends(get_db),
@@ -2191,6 +2213,9 @@ async def update_key_budget(
         raise HTTPException(
             status_code=404, detail="Private AI Key not found in region"
         )
+    # Defence-in-depth scope gate (issue #600): enforce declared team scope
+    # before the budget write, even for system-admin callers.
+    enforce_declared_team_scope(key, team_id, db)
     owner = None
     team_for_budget_check = None
     if key.team_id is not None:
@@ -2337,6 +2362,7 @@ async def update_key_budget(
 async def clear_key_budget(
     region_id: int,
     key_id: int,
+    team_id: int | None = None,
     current_user: DBUser = Depends(get_current_user_from_auth),
     role: str = Depends(get_role_min_team_admin),
     db: Session = Depends(get_db),
@@ -2346,6 +2372,8 @@ async def clear_key_budget(
         raise HTTPException(
             status_code=404, detail="Private AI Key not found in region"
         )
+    # Defence-in-depth scope gate (issue #600).
+    enforce_declared_team_scope(key, team_id, db)
     if key.team_id is not None:
         _assert_team_budget_write_access(current_user, role, key.team_id)
     else:

--- a/app/core/rbac.py
+++ b/app/core/rbac.py
@@ -1,7 +1,8 @@
 from fastapi import HTTPException, status
 from typing import List
+from sqlalchemy.orm import Session
 from app.core.roles import UserRole
-from app.db.models import DBUser
+from app.db.models import DBUser, DBPrivateAIKey
 import logging
 
 
@@ -130,3 +131,41 @@ def require_roles(*roles: str):
 def require_roles_with_team(*roles: str):
     """Create a dependency that requires specific roles and team membership"""
     return RBACDependency(list(roles), require_team_membership=True)
+
+
+def key_in_team(private_ai_key: DBPrivateAIKey, team_id: int, db: Session) -> bool:
+    """Return True when a private AI key is scoped to ``team_id``.
+
+    A key is in-team when it is directly team-owned (its ``team_id`` matches)
+    or, for user-owned keys, when its owner belongs to that team. Mirrors the
+    team-scoping logic already used by the private-ai-keys and spend endpoints
+    so declared-scope enforcement stays consistent.
+    """
+    if private_ai_key.team_id is not None:
+        return private_ai_key.team_id == team_id
+    owner = db.query(DBUser).filter(DBUser.id == private_ai_key.owner_id).first()
+    return owner is not None and owner.team_id == team_id
+
+
+def enforce_declared_team_scope(
+    private_ai_key: DBPrivateAIKey, declared_team_id: int | None, db: Session
+) -> None:
+    """Defence-in-depth scope gate for key-by-id endpoints (issue #600).
+
+    Callers that authenticate with a shared system-admin token (notably the
+    moad BFF) otherwise bypass all ownership checks, turning any endpoint keyed
+    by an integer ``key_id`` into a cross-tenant IDOR. When such a caller
+    declares the ``team_id`` it is acting for, the key must actually belong to
+    that team — enforced here even for system admins. The failure mode is an
+    indistinguishable 404 so ids cannot be enumerated.
+
+    No-op when ``declared_team_id`` is None, so existing callers that do not
+    pass a scope are unaffected (the change is backward compatible).
+    """
+    if declared_team_id is None:
+        return
+    if not key_in_team(private_ai_key, declared_team_id, db):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Private AI Key not found",
+        )

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -3345,3 +3345,152 @@ def test_list_private_ai_keys_show_all(
     )
     assert response.status_code == 200
     assert all(k["owner_id"] == test_user.id for k in response.json())
+
+
+# ---------------------------------------------------------------------------
+# Issue #600 — declared `team_id` scope (defence in depth) on key-by-id
+# endpoints. A caller authenticating with a shared system-admin token (the moad
+# BFF) must declare the team it is acting for; the key must belong to that team
+# or the request 404s, even for system admins. Backward compatible: omitting
+# team_id preserves prior behaviour.
+# ---------------------------------------------------------------------------
+
+
+def _make_scope_key(db, region, *, team_id=None, owner_id=None, name="scope-key"):
+    key = DBPrivateAIKey(
+        database_name=f"db-{name}",
+        name=name,
+        database_host="h",
+        database_username="u",
+        database_password="p",
+        litellm_token=f"token-{name}",
+        litellm_api_url="https://test-litellm.com",
+        team_id=team_id,
+        owner_id=owner_id,
+        region_id=region.id,
+    )
+    db.add(key)
+    db.commit()
+    db.refresh(key)
+    return key
+
+
+@patch("httpx.AsyncClient")
+def test_get_private_ai_key_matching_team_id_allows(
+    mock_client_class, client, admin_token, test_region, db, test_team, mock_httpx_get_client
+):
+    """Declared team_id matching the key's team is allowed (issue #600)."""
+    db.refresh(test_team)
+    key = _make_scope_key(db, test_region, team_id=test_team.id, name="get-match")
+    mock_client_class.return_value = mock_httpx_get_client
+
+    response = client.get(
+        f"/private-ai-keys/{key.id}?team_id={test_team.id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    assert response.json()["id"] == key.id
+
+    db.delete(key)
+    db.commit()
+
+
+@patch("httpx.AsyncClient")
+def test_get_private_ai_key_wrong_team_id_is_404(
+    mock_client_class, client, admin_token, test_region, db, test_team, mock_httpx_get_client
+):
+    """A system-admin caller declaring a mismatched team_id is denied — the
+    cross-tenant IDOR defence. 404 matches a missing key and LiteLLM is never
+    contacted."""
+    db.refresh(test_team)
+    key = _make_scope_key(db, test_region, team_id=test_team.id, name="get-wrong")
+    mock_client_class.return_value = mock_httpx_get_client
+
+    response = client.get(
+        f"/private-ai-keys/{key.id}?team_id={test_team.id + 999}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 404
+    assert "Private AI Key not found" in response.json()["detail"]
+    mock_httpx_get_client.get.assert_not_called()
+
+    db.delete(key)
+    db.commit()
+
+
+@patch("httpx.AsyncClient")
+def test_get_private_ai_key_user_owned_scoped_by_owner_team(
+    mock_client_class,
+    client,
+    admin_token,
+    test_region,
+    db,
+    test_team,
+    test_team_user,
+    mock_httpx_get_client,
+):
+    """User-owned keys (team_id NULL) resolve scope via the owner's team: a
+    matching declared team_id is allowed, a mismatch is denied."""
+    db.refresh(test_team)
+    db.refresh(test_team_user)
+    key = _make_scope_key(db, test_region, owner_id=test_team_user.id, name="get-user-owned")
+    mock_client_class.return_value = mock_httpx_get_client
+
+    allowed = client.get(
+        f"/private-ai-keys/{key.id}?team_id={test_team.id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert allowed.status_code == 200
+
+    denied = client.get(
+        f"/private-ai-keys/{key.id}?team_id={test_team.id + 999}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert denied.status_code == 404
+
+    db.delete(key)
+    db.commit()
+
+
+@patch("httpx.AsyncClient")
+def test_get_private_ai_key_without_team_id_is_unrestricted(
+    mock_client_class, client, admin_token, test_region, db, test_team, mock_httpx_get_client
+):
+    """Backward compatibility: omitting team_id keeps the prior admin behaviour."""
+    db.refresh(test_team)
+    key = _make_scope_key(db, test_region, team_id=test_team.id, name="get-no-scope")
+    mock_client_class.return_value = mock_httpx_get_client
+
+    response = client.get(
+        f"/private-ai-keys/{key.id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+
+    db.delete(key)
+    db.commit()
+
+
+@patch("httpx.AsyncClient")
+def test_delete_private_ai_key_wrong_team_id_is_404_and_persists(
+    mock_client_class, client, admin_token, test_region, db, test_team, mock_httpx_get_client
+):
+    """Cross-team delete is blocked and the victim key is left intact (issue #600)."""
+    db.refresh(test_team)
+    key = _make_scope_key(db, test_region, team_id=test_team.id, name="del-wrong")
+    key_id = key.id
+    mock_client_class.return_value = mock_httpx_get_client
+
+    response = client.delete(
+        f"/private-ai-keys/{key_id}?team_id={test_team.id + 999}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 404
+
+    survivor = (
+        db.query(DBPrivateAIKey).filter(DBPrivateAIKey.id == key_id).first()
+    )
+    assert survivor is not None
+
+    db.delete(survivor)
+    db.commit()

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -3377,7 +3377,13 @@ def _make_scope_key(db, region, *, team_id=None, owner_id=None, name="scope-key"
 
 @patch("httpx.AsyncClient")
 def test_get_private_ai_key_matching_team_id_allows(
-    mock_client_class, client, admin_token, test_region, db, test_team, mock_httpx_get_client
+    mock_client_class,
+    client,
+    admin_token,
+    test_region,
+    db,
+    test_team,
+    mock_httpx_get_client,
 ):
     """Declared team_id matching the key's team is allowed (issue #600)."""
     db.refresh(test_team)
@@ -3397,7 +3403,13 @@ def test_get_private_ai_key_matching_team_id_allows(
 
 @patch("httpx.AsyncClient")
 def test_get_private_ai_key_wrong_team_id_is_404(
-    mock_client_class, client, admin_token, test_region, db, test_team, mock_httpx_get_client
+    mock_client_class,
+    client,
+    admin_token,
+    test_region,
+    db,
+    test_team,
+    mock_httpx_get_client,
 ):
     """A system-admin caller declaring a mismatched team_id is denied — the
     cross-tenant IDOR defence. 404 matches a missing key and LiteLLM is never
@@ -3433,7 +3445,9 @@ def test_get_private_ai_key_user_owned_scoped_by_owner_team(
     matching declared team_id is allowed, a mismatch is denied."""
     db.refresh(test_team)
     db.refresh(test_team_user)
-    key = _make_scope_key(db, test_region, owner_id=test_team_user.id, name="get-user-owned")
+    key = _make_scope_key(
+        db, test_region, owner_id=test_team_user.id, name="get-user-owned"
+    )
     mock_client_class.return_value = mock_httpx_get_client
 
     allowed = client.get(
@@ -3454,7 +3468,13 @@ def test_get_private_ai_key_user_owned_scoped_by_owner_team(
 
 @patch("httpx.AsyncClient")
 def test_get_private_ai_key_without_team_id_is_unrestricted(
-    mock_client_class, client, admin_token, test_region, db, test_team, mock_httpx_get_client
+    mock_client_class,
+    client,
+    admin_token,
+    test_region,
+    db,
+    test_team,
+    mock_httpx_get_client,
 ):
     """Backward compatibility: omitting team_id keeps the prior admin behaviour."""
     db.refresh(test_team)
@@ -3473,7 +3493,13 @@ def test_get_private_ai_key_without_team_id_is_unrestricted(
 
 @patch("httpx.AsyncClient")
 def test_delete_private_ai_key_wrong_team_id_is_404_and_persists(
-    mock_client_class, client, admin_token, test_region, db, test_team, mock_httpx_get_client
+    mock_client_class,
+    client,
+    admin_token,
+    test_region,
+    db,
+    test_team,
+    mock_httpx_get_client,
 ):
     """Cross-team delete is blocked and the victim key is left intact (issue #600)."""
     db.refresh(test_team)
@@ -3487,9 +3513,7 @@ def test_delete_private_ai_key_wrong_team_id_is_404_and_persists(
     )
     assert response.status_code == 404
 
-    survivor = (
-        db.query(DBPrivateAIKey).filter(DBPrivateAIKey.id == key_id).first()
-    )
+    survivor = db.query(DBPrivateAIKey).filter(DBPrivateAIKey.id == key_id).first()
     assert survivor is not None
 
     db.delete(survivor)

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -6,9 +6,11 @@ from app.core.rbac import (
     require_key_creator_or_higher,
     require_read_only_or_higher,
     require_sales_or_higher,
+    key_in_team,
+    enforce_declared_team_scope,
 )
 from app.core.roles import UserRole
-from app.db.models import DBUser
+from app.db.models import DBUser, DBPrivateAIKey
 
 
 class TestRBACDependency:
@@ -267,3 +269,34 @@ class TestUserRole:
         assert "admin" in roles
         assert "key_creator" in roles
         assert "read_only" in roles
+
+
+class TestDeclaredTeamScope:
+    """Issue #600 — declared team scope gate for key-by-id endpoints.
+
+    The team-owned and no-scope branches never touch the DB, so these cases are
+    exercised with db=None. The user-owned (owner-lookup) branch is covered by
+    the HTTP-level tests in test_private_ai.py.
+    """
+
+    def _team_key(self, team_id):
+        return DBPrivateAIKey(id=1, team_id=team_id, owner_id=None)
+
+    def test_team_owned_key_in_team_true(self):
+        assert key_in_team(self._team_key(5), 5, None) is True
+
+    def test_team_owned_key_in_team_false(self):
+        assert key_in_team(self._team_key(5), 6, None) is False
+
+    def test_enforce_noop_when_no_scope_declared(self):
+        # No declared scope → no-op, backward compatible (and no DB access).
+        enforce_declared_team_scope(self._team_key(5), None, None)
+
+    def test_enforce_allows_matching_team(self):
+        enforce_declared_team_scope(self._team_key(5), 5, None)
+
+    def test_enforce_denies_mismatched_team_with_404(self):
+        with pytest.raises(HTTPException) as exc_info:
+            enforce_declared_team_scope(self._team_key(5), 6, None)
+        assert exc_info.value.status_code == 404
+        assert "Private AI Key not found" in exc_info.value.detail

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -3532,3 +3532,89 @@ def test_periodic_live_remaining_invariant(
     assert response.status_code == 200
     data = response.json()
     assert data["periodic_budget"]["remaining_budget_cents"] == expected_remaining
+
+
+# ---------------------------------------------------------------------------
+# Issue #600 — declared `team_id` scope (defence in depth) on key-level spend
+# and budget endpoints. A mismatched team_id 404s before any LiteLLM call,
+# even for system-admin callers (the moad shared-admin token scenario).
+# ---------------------------------------------------------------------------
+
+
+def _make_spend_scope_key(db, region, team, name):
+    key = DBPrivateAIKey(
+        name=name,
+        litellm_token=f"token-{name}",
+        litellm_api_url="https://test-litellm.com",
+        region_id=region.id,
+        team_id=team.id,
+    )
+    db.add(key)
+    db.commit()
+    db.refresh(key)
+    return key
+
+
+def test_update_key_budget_wrong_team_id_is_404(
+    client, admin_token, test_team, test_region, db
+):
+    db.refresh(test_team)
+    key = _make_spend_scope_key(db, test_region, test_team, "budget-wrong")
+
+    response = client.put(
+        f"/spend/{test_region.id}/key/{key.id}/budget?team_id={test_team.id + 999}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"max_budget": 5.0},
+    )
+    assert response.status_code == 404
+
+    db.delete(key)
+    db.commit()
+
+
+def test_clear_key_budget_wrong_team_id_is_404(
+    client, admin_token, test_team, test_region, db
+):
+    db.refresh(test_team)
+    key = _make_spend_scope_key(db, test_region, test_team, "budget-clear-wrong")
+
+    response = client.post(
+        f"/spend/{test_region.id}/key/{key.id}/budget/clear?team_id={test_team.id + 999}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 404
+
+    db.delete(key)
+    db.commit()
+
+
+def test_get_key_spend_wrong_team_id_is_404(
+    client, admin_token, test_team, test_region, db
+):
+    db.refresh(test_team)
+    key = _make_spend_scope_key(db, test_region, test_team, "spend-wrong")
+
+    response = client.get(
+        f"/spend/{test_region.id}/key/{key.id}?team_id={test_team.id + 999}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 404
+
+    db.delete(key)
+    db.commit()
+
+
+def test_get_key_daily_activity_wrong_team_id_is_404(
+    client, admin_token, test_team, test_region, db
+):
+    db.refresh(test_team)
+    key = _make_spend_scope_key(db, test_region, test_team, "daily-wrong")
+
+    response = client.get(
+        f"/spend/{test_region.id}/key/{key.id}/daily-activity?team_id={test_team.id + 999}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 404
+
+    db.delete(key)
+    db.commit()

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -3618,3 +3618,19 @@ def test_get_key_daily_activity_wrong_team_id_is_404(
 
     db.delete(key)
     db.commit()
+
+
+def test_get_key_last_used_wrong_team_id_is_404(
+    client, admin_token, test_team, test_region, db
+):
+    db.refresh(test_team)
+    key = _make_spend_scope_key(db, test_region, test_team, "last-used-wrong")
+
+    response = client.get(
+        f"/spend/{test_region.id}/key/{key.id}/last-used?team_id={test_team.id + 999}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 404
+
+    db.delete(key)
+    db.commit()


### PR DESCRIPTION
Backend half of the fix for the cross-tenant IDOR reported in amazeeio/moad#600. Pairs with the moad PR (declared `team_id` is sent from moad).

## Why

The moad BFF calls this backend with a **shared system-admin token**, so every endpoint keyed by an integer `key_id` takes the `is_admin` bypass in `_get_key_if_allowed` / the inline spend checks / `_assert_*budget*_access` and never scopes to the end user. Any authenticated portal member could therefore read (incl. the live `litellm_token`), delete, re-budget, or read spend/usage for **any** tenant's key by enumerating ids.

moad now guards this at its own layer, but relying solely on the caller is fragile. This adds an **independent enforcement point in the backend** so the tenant boundary holds even if the BFF regresses or another client calls in — defence in depth (this is option 2 from the issue).

## What

- **`app/core/rbac.py`** — new `enforce_declared_team_scope(key, declared_team_id, db)` (+ `key_in_team` helper). When a caller declares the `team_id` it is acting for, the key must belong to that team — enforced **even for system admins** — otherwise an indistinguishable `404` (so ids can't be enumerated). Team membership is resolved exactly as the endpoints already do it: team-owned keys by `team_id`, user-owned keys via the owner's team.
- Optional **`team_id` query param** wired through every key-by-id endpoint:
  - `private_ai_keys`: `GET /{key_id}`, `DELETE /{key_id}` (via `_get_key_if_allowed`)
  - `spend`: key spend, last-used, daily-activity, `PUT .../budget`, `POST .../budget/clear`

## Backward compatibility

The param is **optional and enforced only when present** — existing callers that don't pass `team_id` are unaffected, and a moad that passes `team_id` to an older backend is harmless (FastAPI ignores unknown query params). This lets backend and moad deploy independently.

## Tests

New regression tests (run via `make backend-test-regex`):
- `test_private_ai.py`: cross-team get/delete → 404 (and the victim key persists), user-owned key scoped via owner team, matching/absent `team_id` still allowed.
- `test_spend.py`: cross-team budget update / budget clear / spend / daily-activity → 404.
- `test_rbac.py`: unit tests for the scope gate (team match/mismatch, no-op when unset, 404 on mismatch).

All 14 new tests pass; existing get/delete/budget/spend tests (incl. `test_update_key_budget_forbidden_for_cross_team_admin`) still green.

Refs amazeeio/moad#600

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds defence-in-depth tenant scoping to all key-by-id endpoints to address a cross-tenant IDOR (#600). A shared system-admin token used by the moad BFF previously bypassed ownership checks on every `key_id`-keyed endpoint; a new optional `team_id` query parameter, when present, is validated by `enforce_declared_team_scope` even for admins, returning an indistinguishable 404 on mismatch.

- **`app/core/rbac.py`**: New `key_in_team` helper and `enforce_declared_team_scope` gate; team-owned keys match directly, user-owned keys resolve scope via their owner's team.
- **`app/api/private_ai_keys.py` / `app/api/spend.py`**: `team_id: int | None = None` added to five spend endpoints and two private-key endpoints, with `enforce_declared_team_scope` called immediately after the key is fetched and the region check passes.
- **Tests**: 14 new tests covering cross-team 404, user-owned resolution, backward compatibility (no `team_id`), and key persistence after blocked delete.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The scope gate is correctly positioned, returns an indistinguishable 404 on mismatch, and is a no-op when team_id is absent — existing callers are unaffected.

The core logic in enforce_declared_team_scope and key_in_team correctly handles team-owned keys, user-owned keys (resolved via owner's team), and orphaned keys. The gate is inserted at the right point in every patched endpoint. All seven endpoints mentioned in the PR description are covered with thorough tests.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/core/rbac.py | Adds key_in_team helper and enforce_declared_team_scope gate; logic is correct for team-owned, user-owned, and orphaned-key cases. |
| app/api/private_ai_keys.py | team_id wired through _get_key_if_allowed for GET and DELETE; scope gate fires after key fetch but before RBAC, which is the correct ordering. |
| app/api/spend.py | All five key-level spend/budget endpoints patched with the scope gate, consistently placed after the region check and before downstream logic. |
| tests/test_rbac.py | Unit tests for key_in_team and enforce_declared_team_scope; db=None is safe for team-owned branches that never touch the DB. |
| tests/test_private_ai.py | Five integration tests covering team-match allow, wrong-team 404, user-owned-key resolution, backward compat, and delete-blocked key persistence. |
| tests/test_spend.py | Five integration tests covering all patched spend endpoints with a wrong team_id; all assert 404. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test: cover get\_key\_last\_used team scope..."](https://github.com/amazeeio/amazee.ai/commit/a56da216aa2bdee2b5fd10147daaa300238c7687) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44050675)</sub>

<!-- /greptile_comment -->