### PR TITLE
chore: make stripe webhook and top-up sync failures retryable

### DIFF
--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -647,15 +647,15 @@ async def purchase_periodic_topup(
                     region_id,
                     str(rollback_exc),
                 )
-        # Top-up purchase failed to reach LiteLLM; do not keep allocatable
-        # balance in the periodic ledger for this failed API purchase.
+        # Top-up purchase failed to reach LiteLLM. Delete the ledger entry
+        # rather than deactivating it: uq_periodic_ledger_topup_payment makes
+        # (team_id, region_id, entry_type, stripe_payment_id) unique, so a
+        # lingering row would both block the duplicate guard (409) and collide
+        # on re-insert. Deleting lets a resubmission run the full flow fresh.
         if topup_entry is not None:
-            # Keep audit visibility but ensure failed top-up cannot contribute
-            # to future allocatable balance.
-            topup_entry.is_active = False
-            topup_entry.consumed_cents = topup_entry.amount_cents
-            db.add(topup_entry)
+            db.delete(topup_entry)
             db.flush()
+            topup_entry = None
         payment_record.sync_status = "sync_failed"
         payment_record.error_log = (
             f"Periodic top-up sync failed for region_id={region_id}: {str(exc)}"

--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -655,7 +655,6 @@ async def purchase_periodic_topup(
         if topup_entry is not None:
             db.delete(topup_entry)
             db.flush()
-            topup_entry = None
         payment_record.sync_status = "sync_failed"
         payment_record.error_log = (
             f"Periodic top-up sync failed for region_id={region_id}: {str(exc)}"

--- a/app/api/webhooks.py
+++ b/app/api/webhooks.py
@@ -3,7 +3,6 @@ import os
 
 from fastapi import (
     APIRouter,
-    BackgroundTasks,
     Depends,
     HTTPException,
     Request,
@@ -28,13 +27,13 @@ LEGACY_STRIPE_DRAIN_MODE_ENV = "LEGACY_STRIPE_DRAIN_MODE"
 @router.post("/events")
 async def handle_events(
     request: Request,
-    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
 ):
     """Handle Stripe webhook events.
 
-    Verifies the Stripe signature, then dispatches processing to a
-    background task so Stripe receives a fast 200 response.
+    Verifies the Stripe signature, then processes the event synchronously so
+    a processing failure is reported to Stripe (non-2xx) and retried, rather
+    than being acknowledged with 200 and silently lost.
     """
     try:
         # Temporary post-migration safety valve: once PROD billing has moved to
@@ -98,13 +97,25 @@ async def handle_events(
                     content="Webhook already processed",
                 )
 
-        # Process in the background — use the request-scoped event object
-        # and let the background task create its own DB session.
-        background_tasks.add_task(handle_stripe_event_background, event)
+        # Process synchronously so a processing failure can be reported to
+        # Stripe (non-2xx => Stripe retries). Doing this in a BackgroundTask
+        # would send 200 before the work ran, so a failure would leave the
+        # event marked processed but never applied — permanently lost.
+        try:
+            await handle_stripe_event_background(event)
+        except Exception:
+            # Release the claim row so the idempotency guard does not block
+            # Stripe's re-delivery of this event, then surface the failure.
+            if event_id:
+                db.query(DBStripeProcessedEvent).filter(
+                    DBStripeProcessedEvent.stripe_event_id == event_id
+                ).delete()
+                db.commit()
+            raise
 
         return Response(
             status_code=status.HTTP_200_OK,
-            content="Webhook received and processing started",
+            content="Webhook received and processed",
         )
 
     except HTTPException:

--- a/app/api/webhooks.py
+++ b/app/api/webhooks.py
@@ -106,11 +106,22 @@ async def handle_events(
         except Exception:
             # Release the claim row so the idempotency guard does not block
             # Stripe's re-delivery of this event, then surface the failure.
-            if event_id:
-                db.query(DBStripeProcessedEvent).filter(
-                    DBStripeProcessedEvent.stripe_event_id == event_id
-                ).delete()
-                db.commit()
+            # The cleanup is isolated so a failing commit here (e.g. broken DB
+            # connection) cannot replace the original processing exception —
+            # otherwise the claim could survive and be re-acked as a 200.
+            try:
+                if event_id:
+                    db.query(DBStripeProcessedEvent).filter(
+                        DBStripeProcessedEvent.stripe_event_id == event_id
+                    ).delete()
+                    db.commit()
+            except Exception as cleanup_exc:
+                logger.error(
+                    "Failed to release stripe event claim %s for retry: %s",
+                    event_id,
+                    cleanup_exc,
+                )
+                db.rollback()
             raise
 
         return Response(

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -775,7 +775,11 @@ async def handle_stripe_event_background(event):
                 await remove_product_from_team(db, customer_id, product_id)
 
     except Exception as exc:
-        logger.error("Error in background event handler: %s", exc, exc_info=True)
+        # Re-raise so the caller can release the idempotency claim and return
+        # a non-2xx to Stripe; swallowing here would mark the event processed
+        # while it was never applied.
+        logger.error("Error in stripe event handler: %s", exc, exc_info=True)
+        raise
     finally:
         db.close()
 


### PR DESCRIPTION
Fixes two billing-correctness bugs where a downstream failure permanently loses paid state.

## Lost Stripe events (webhooks.py, worker.py)
The webhook committed the `DBStripeProcessedEvent` idempotency claim and returned 200 to Stripe *before* the work ran in a background task. Any failure in the background handler (which swallowed all exceptions) left the event marked processed but never applied, and Stripe never retried.

- Process the event synchronously so a failure can be reported to Stripe.
- Worker re-raises on failure instead of swallowing.
- On failure, release the claim row and return non-2xx so Stripe re-delivers.

## Unrecoverable top-up (budgets.py)
On LiteLLM sync failure the top-up ledger entry was deactivated but kept. Because `uq_periodic_ledger_topup_payment` makes `(team_id, region_id, entry_type, stripe_payment_id)` unique, the lingering row blocked the duplicate guard (409) and would collide on re-insert, so a captured payment could never be re-applied via the API.

- Delete the ledger entry on sync failure so a resubmission runs fresh.

Full backend suite passes (1102 passed).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two billing-correctness bugs where downstream failures permanently lost paid state. It replaces background-task webhook dispatch with synchronous processing so Stripe receives a non-2xx on failure and retries, and it deletes (rather than deactivates) the periodic top-up ledger entry on LiteLLM sync failure so the unique constraint cannot block a clean resubmission.

- **webhooks.py**: `BackgroundTasks` is removed; `handle_stripe_event_background` is now `await`-ed synchronously. On failure, an isolated inner `try/except` deletes the idempotency claim row and the original exception is always re-raised — even when the cleanup commit itself fails — so Stripe gets a non-2xx and retries.
- **worker.py**: The catch-all `except` block now re-raises after logging, propagating failures to the webhook handler instead of swallowing them.
- **budgets.py**: On LiteLLM sync failure, the `topup_entry` row is deleted rather than deactivated, removing the stale row that the unique index `uq_periodic_ledger_topup_payment` would have turned into a permanent block on any retry.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The three targeted changes are logically correct and address real billing-correctness gaps with no new regressions introduced.

All three changes are narrowly scoped to their stated goals. The synchronous webhook processing with the isolated cleanup try/except correctly preserves the original exception in every code path, the worker re-raise is straightforward, and the ledger-entry deletion in budgets.py is well-reasoned — the deleted row is never accessed again (the error path always raises HTTPException before db.refresh). No new logic paths appear unsafe.

No files require special attention beyond the existing review thread discussion on webhooks.py.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/api/webhooks.py | Switches from BackgroundTasks to synchronous await with isolated cleanup try/except on failure; core retry logic is sound but claim-cleanup failure remains an edge-case gap (previously flagged in review thread). |
| app/core/worker.py | Adds re-raise after logging so callers receive the exception and can release the idempotency claim; finally block still closes the worker's own session correctly. |
| app/api/budgets.py | Replaces deactivation with deletion of the failed ledger entry, unblocking the unique constraint so a resubmission can run the full flow fresh; db.refresh(topup_entry) after the except block is unreachable on the error path due to the always-present raise HTTPException. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant S as Stripe
    participant W as webhooks.py
    participant DB as Database
    participant BG as worker.py

    S->>W: POST /events
    W->>DB: INSERT claim row (DBStripeProcessedEvent)
    alt duplicate event
        DB-->>W: IntegrityError
        W-->>S: 200 already processed
    else new event
        DB-->>W: commit OK
        W->>BG: await handle_stripe_event_background(event)
        BG->>DB: open own session, process event
        alt success
            BG-->>W: return normally
            W-->>S: 200 processed
        else failure
            BG-->>W: raise Exception
            W->>DB: DELETE claim row + commit (isolated try/except)
            alt cleanup succeeds
                DB-->>W: claim deleted
            else cleanup fails
                DB-->>W: exception caught, rollback, claim survives
            end
            W-->>S: 500 Stripe retries
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant S as Stripe
    participant W as webhooks.py
    participant DB as Database
    participant BG as worker.py

    S->>W: POST /events
    W->>DB: INSERT claim row (DBStripeProcessedEvent)
    alt duplicate event
        DB-->>W: IntegrityError
        W-->>S: 200 already processed
    else new event
        DB-->>W: commit OK
        W->>BG: await handle_stripe_event_background(event)
        BG->>DB: open own session, process event
        alt success
            BG-->>W: return normally
            W-->>S: 200 processed
        else failure
            BG-->>W: raise Exception
            W->>DB: DELETE claim row + commit (isolated try/except)
            alt cleanup succeeds
                DB-->>W: claim deleted
            else cleanup fails
                DB-->>W: exception caught, rollback, claim survives
            end
            W-->>S: 500 Stripe retries
        end
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/core/worker.py`, line 692-697 ([link](https://github.com/amazeeio/amazee.ai/blob/51c8696a0c1e5109abd3e75d3666131c344ac5ee/app/core/worker.py#L692-L697)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale docstring — function is no longer a background task**

   The docstring and function name both describe a background-task execution model that no longer applies: `webhooks.py` now calls this function directly with `await`, not via `BackgroundTasks`. The phrase "Background task to handle…" and the note about creating its own session "to avoid using the request-scoped session" are now misleading (the separation is still correct, but the reason has changed). Consider renaming to `handle_stripe_event` and updating the docstring to reflect synchronous, direct invocation.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["chore: isolate stripe claim-release clea..."](https://github.com/amazeeio/amazee.ai/commit/bc09a7d1da961053f6fb6153c51f6b03f2eab432) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44087002)</sub>

<!-- /greptile_comment -->