### PR TITLE
chore: require team membership on direct key-minting endpoints

### DIFF
--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -33,6 +33,7 @@ from app.core.security import (
     get_current_user_from_auth,
     get_role_min_team_admin,
     get_private_ai_access,
+    get_private_ai_direct_access,
     get_role_min_system_admin,
 )
 from app.core.roles import UserRole
@@ -119,7 +120,7 @@ def _validate_permissions_and_get_ownership_info(
 async def create_vector_db(
     vector_db: VectorDBCreate,
     current_user=Depends(get_current_user_from_auth),
-    user_role: UserRole = Depends(get_private_ai_access),
+    user_role: UserRole = Depends(get_private_ai_direct_access),
     db: Session = Depends(get_db),
     limit_service: LimitService = Depends(get_limit_service),
     store_result: bool = True,
@@ -419,7 +420,7 @@ async def _create_private_ai_key(
 async def create_llm_token(
     private_ai_key: PrivateAIKeyCreate,
     current_user=Depends(get_current_user_from_auth),
-    user_role: UserRole = Depends(get_private_ai_access),
+    user_role: UserRole = Depends(get_private_ai_direct_access),
     db: Session = Depends(get_db),
     limit_service: LimitService = Depends(get_limit_service),
     store_result: bool = True,

--- a/app/core/rbac.py
+++ b/app/core/rbac.py
@@ -107,6 +107,19 @@ def require_private_ai_access():
     )
 
 
+def require_private_ai_direct_access():
+    """Require access to endpoints that mint LiteLLM keys directly (no moad delegation).
+
+    Same roles as require_private_ai_access, but require_team_membership=True so a
+    self-registered, teamless USER cannot mint uncapped paid keys via /token or
+    /vector-db. Teamless users go through POST / (delegated to moad, which caps
+    them); system admins bypass the team check (see check_access).
+    """
+    return RBACDependency(
+        UserRole.KEY_MANAGEMENT_ROLES + [UserRole.USER], require_team_membership=True
+    )
+
+
 def require_read_only_or_higher():
     """Require read only role or higher (team context)"""
     return RBACDependency(UserRole.READ_ACCESS_ROLES, require_team_membership=True)

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -18,6 +18,7 @@ from app.core.rbac import (
     require_key_creator_or_higher,
     require_sales_or_higher,
     require_private_ai_access,
+    require_private_ai_direct_access,
 )
 
 logger = logging.getLogger(__name__)
@@ -302,6 +303,18 @@ async def get_private_ai_access(
 ):
     """Require access to private AI operations - allows system users or team key creators."""
     dependency = require_private_ai_access()
+    return dependency.check_access(current_user)
+
+
+async def get_private_ai_direct_access(
+    current_user: DBUser = Depends(get_current_user_from_auth),
+):
+    """Require access to endpoints that mint LiteLLM keys directly (no moad delegation).
+
+    Blocks teamless non-admin users so they cannot mint uncapped paid keys via
+    /token or /vector-db; system admins bypass the team check.
+    """
+    dependency = require_private_ai_direct_access()
     return dependency.check_access(current_user)
 
 


### PR DESCRIPTION
Fixes the HIGH finding where teamless accounts could mint uncapped paid keys.

`POST /private-ai-keys/token` and `/vector-db` mint LiteLLM keys directly (no moad delegation) and were reachable by a self-registered, teamless USER — the teamless branch applied no per-account key-count limit and, when `ENABLE_LIMITS` is false, no budget cap either. Looping this yielded unbounded free paid-model access.

- New `require_private_ai_direct_access` dependency requires team membership on the two direct-mint endpoints.
- System admins bypass the team check; teamless users still onboard via `POST /` (delegated to moad, which caps them), so that path is unchanged.

Full backend suite passes (1102 passed).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR closes a security gap where self-registered, teamless users could call `POST /private-ai-keys/token` and `POST /private-ai-keys/vector-db` to mint LiteLLM keys directly (no moad delegation), bypassing budget caps when `ENABLE_LIMITS` is false.

- A new `require_private_ai_direct_access` RBAC dependency is added in `rbac.py`, mirroring `require_private_ai_access` but with `require_team_membership=True`, blocking teamless non-admin users from the two direct-mint endpoints.
- `get_private_ai_direct_access` in `security.py` wires the new dependency into FastAPI's injection system, and both `create_vector_db` and `create_llm_token` are updated to use it; the delegated `POST /` path intentionally retains the old, uncapped-safe dependency.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge — it tightens access on two direct key-minting endpoints without touching any other code paths.

The new require_private_ai_direct_access dependency is a minimal, targeted addition: it reuses the fully-tested RBACDependency class and flips a single boolean flag (require_team_membership=True). The admin bypass is handled correctly by the existing check_access guard (not user.is_admin). All four call sites in private_ai_keys.py use the correct dependency for their context — the delegated POST / and DELETE /{key_id} paths are intentionally unchanged. The role set (KEY_MANAGEMENT_ROLES + [USER]) is unchanged from the original, so no legitimate access is removed.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/core/rbac.py | Adds require_private_ai_direct_access() — identical to require_private_ai_access() but with require_team_membership=True; the existing check_access admin bypass (not user.is_admin) correctly lets system admins through while blocking teamless regular users. |
| app/core/security.py | Adds get_private_ai_direct_access FastAPI dependency, following the exact same pattern as get_private_ai_access; no logic issues. |
| app/api/private_ai_keys.py | Switches create_vector_db and create_llm_token to get_private_ai_direct_access; the delegated POST / endpoint and DELETE /{key_id} correctly retain the original dependency. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Authenticated Request]) --> B{Endpoint?}
    B -->|POST /| C[create_private_ai_key\nget_private_ai_access\nrequire_team_membership=False]
    B -->|POST /token| D[create_llm_token\nget_private_ai_direct_access\nrequire_team_membership=True]
    B -->|POST /vector-db| E[create_vector_db\nget_private_ai_direct_access\nrequire_team_membership=True]
    B -->|DELETE /key_id| F[delete_private_ai_key\nget_private_ai_access\nrequire_team_membership=False]
    C --> G{Role in KEY_MANAGEMENT_ROLES + USER?}
    D --> H{Role in KEY_MANAGEMENT_ROLES + USER?}
    E --> H
    G -->|No| X1([403 Forbidden])
    G -->|Yes| C1([Delegates to moad which applies caps])
    H -->|No| X2([403 Forbidden])
    H -->|Yes| I{is_admin=True OR team_id is not None?}
    I -->|No - Teamless user| X3([403 Forbidden - New guard])
    I -->|Yes| J([Mint LiteLLM key directly])
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([Authenticated Request]) --> B{Endpoint?}
    B -->|POST /| C[create_private_ai_key\nget_private_ai_access\nrequire_team_membership=False]
    B -->|POST /token| D[create_llm_token\nget_private_ai_direct_access\nrequire_team_membership=True]
    B -->|POST /vector-db| E[create_vector_db\nget_private_ai_direct_access\nrequire_team_membership=True]
    B -->|DELETE /key_id| F[delete_private_ai_key\nget_private_ai_access\nrequire_team_membership=False]
    C --> G{Role in KEY_MANAGEMENT_ROLES + USER?}
    D --> H{Role in KEY_MANAGEMENT_ROLES + USER?}
    E --> H
    G -->|No| X1([403 Forbidden])
    G -->|Yes| C1([Delegates to moad which applies caps])
    H -->|No| X2([403 Forbidden])
    H -->|Yes| I{is_admin=True OR team_id is not None?}
    I -->|No - Teamless user| X3([403 Forbidden - New guard])
    I -->|Yes| J([Mint LiteLLM key directly])
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: require team membership on direct..."](https://github.com/amazeeio/amazee.ai/commit/321508a38487e4a75fb4ba05a5d0af4aba7432f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44087097)</sub>

<!-- /greptile_comment -->