### PR TITLE
chore: fix functional bugs found by deepsec scan

### DIFF
--- a/.github/workflows/helm-package-publish.yml
+++ b/.github/workflows/helm-package-publish.yml
@@ -25,7 +25,7 @@ jobs:
   package-and-publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write  # pushes the release tag in "Create Release Tag"
       packages: write
       security-events: write
 

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -145,6 +145,11 @@ def create_and_set_access_token(
 
     # Set cookie expiration based on user role
     # System administrators get 8 hours (28800 seconds), regular users get 30 minutes (1800 seconds)
+    # NOTE: this cookie lifetime is deliberately independent of the JWT lifetime
+    # (settings.ACCESS_TOKEN_EXPIRE_MINUTES, applied in create_access_token). The
+    # effective session ends when the *shorter* of the two expires, so adjust
+    # both together — raising ACCESS_TOKEN_EXPIRE_MINUTES alone won't lengthen a
+    # regular user's session (this cookie dies first).
     cookie_expiration = 28800 if user and user.is_admin else 1800
 
     # Prepare cookie settings

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -21,7 +21,7 @@ from app.db.database import get_db
 from app.core.dependencies import get_limit_service
 from app.schemas.models import (
     User,
-    UserUpdate,
+    AdminUserUpdate,
     UserCreate,
     TeamOperation,
     UserAdminRegionResponse,
@@ -899,7 +899,7 @@ async def get_user(
 )
 async def update_user(
     user_id: int,
-    user_update: UserUpdate,
+    user_update: AdminUserUpdate,
     current_user: DBUser = Depends(get_current_user_from_auth),
     db: Session = Depends(get_db),
 ):
@@ -1071,7 +1071,7 @@ async def add_user_to_team(
 @router.post(
     "/{user_id}/remove-from-team",
     response_model=User,
-    dependencies=[Depends(get_role_min_system_admin)],
+    dependencies=[Depends(get_role_min_team_admin)],
 )
 async def remove_user_from_team(
     user_id: int,
@@ -1079,11 +1079,20 @@ async def remove_user_from_team(
     db: Session = Depends(get_db),
 ):
     """
-    Remove a user from a team. Accessible by admin users.
+    Remove a user from a team. Accessible by system admins or team admins for
+    members of their own team.
     """
     db_user = db.query(DBUser).filter(DBUser.id == user_id).first()
     if not db_user:
         raise HTTPException(status_code=404, detail="User not found")
+
+    # Team admins may only remove members of their own team (mirrors
+    # update_user_role); system admins are unrestricted.
+    if not current_user.is_admin and db_user.team_id != current_user.team_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to perform this action",
+        )
 
     # Check if user is a member of a team
     if db_user.team_id is None:

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -1110,6 +1110,25 @@ async def remove_user_from_team(
             detail="User is not a member of any team",
         )
 
+    # Don't orphan a team: block removing its last remaining team admin (a team
+    # admin can now remove members, including themselves). Promote another admin
+    # first.
+    if db_user.role == UserRole.TEAM_ADMIN:
+        other_admins = (
+            db.query(DBUser)
+            .filter(
+                DBUser.team_id == db_user.team_id,
+                DBUser.id != db_user.id,
+                DBUser.role == UserRole.TEAM_ADMIN,
+            )
+            .count()
+        )
+        if other_admins == 0:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Cannot remove the last team admin from the team",
+            )
+
     # Remove user from team
     previous_team_id = db_user.team_id
     db_user.team_id = None

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -925,6 +925,15 @@ async def update_user(
                 detail="Team members cannot be made administrators",
             )
 
+    # Only system admins may change a user's activation status (mirrors the
+    # is_admin guard above). Team admins manage membership/role, not whether an
+    # account is active.
+    if user_update.is_active is not None and not current_user.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to perform this action",
+        )
+
     previous_email = db_user.email
     for key, value in user_update.model_dump(exclude_unset=True).items():
         setattr(db_user, key, value)

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -45,7 +45,9 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -
     if expires_delta:
         expire = datetime.now(UTC) + expires_delta
     else:
-        expire = datetime.now(UTC) + timedelta(minutes=60)  # Default to 60 minutes
+        expire = datetime.now(UTC) + timedelta(
+            minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES
+        )
     to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(
         to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM

--- a/app/main.py
+++ b/app/main.py
@@ -30,7 +30,10 @@ from app.middleware.prometheus import PrometheusMiddleware
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
-from fastapi.openapi.docs import get_swagger_ui_html
+from fastapi.openapi.docs import (
+    get_swagger_ui_html,
+    get_swagger_ui_oauth2_redirect_html,
+)
 from fastapi.openapi.utils import get_openapi
 from prometheus_fastapi_instrumentator import Instrumentator, metrics
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -232,7 +235,7 @@ async def custom_swagger_ui_html():
 
 @app.get("/oauth2-redirect", include_in_schema=False)
 async def oauth2_redirect():
-    return get_swagger_ui_html(openapi_url="/openapi.json", title="OAuth2 Redirect")
+    return get_swagger_ui_oauth2_redirect_html()
 
 
 def custom_openapi():

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -61,6 +61,23 @@ class UserUpdate(BaseModel):
     new_password: Optional[str] = None
 
 
+class AdminUserUpdate(BaseModel):
+    """Fields an admin/team-admin may change via PUT /users/{id}.
+
+    Deliberately excludes password fields: this route never applied them (it
+    silently dropped current_password/new_password). extra='forbid' now rejects
+    them with a 422 instead of pretending to succeed. Self-service password
+    changes go through /auth/me.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    email: Optional[CaseInsensitiveEmailStr] = None
+    is_admin: Optional[bool] = None
+    is_active: Optional[bool] = None
+    receive_marketing_updates: Optional[bool] = None
+
+
 class User(UserBase):
     id: int
     is_active: bool

--- a/frontend/src/app/auth/token/page.tsx
+++ b/frontend/src/app/auth/token/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Loader2, X } from "lucide-react";
-import { useState, useEffect, useCallback } from "react";
+import { useState } from "react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -24,9 +24,9 @@ export default function APITokensPage() {
   const queryClient = useQueryClient();
   const [newTokenName, setNewTokenName] = useState("");
   const [showNewToken, setShowNewToken] = useState<APIToken | null>(null);
-  const [tokens, setTokens] = useState<APIToken[]>([]);
 
-  const { isLoading: queryLoading } = useQuery({
+  // React Query is the single source of truth for the token list.
+  const { data: tokens = [], isLoading: queryLoading } = useQuery<APIToken[]>({
     queryKey: ["tokens"],
     queryFn: async () => {
       const response = await get("/auth/token");
@@ -81,48 +81,11 @@ export default function APITokensPage() {
     },
   });
 
-  const fetchTokens = useCallback(async () => {
-    try {
-      const response = await get("auth/token", { credentials: "include" });
-      const data = await response.json();
-      setTokens(data);
-    } catch (error) {
-      console.error("Error fetching tokens:", error);
-      toast({
-        title: "Error",
-        description: "Failed to fetch tokens",
-        variant: "destructive",
-      });
-    }
-  }, [toast, setTokens]);
-
   const handleCreateToken = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!newTokenName.trim()) return;
     createMutation.mutate(newTokenName);
   };
-
-  const handleDeleteToken = async (tokenId: string) => {
-    try {
-      await del("/auth/token/" + tokenId, { credentials: "include" });
-      setTokens(tokens.filter((token) => token.id !== tokenId));
-      toast({
-        title: "Success",
-        description: "Token deleted successfully",
-      });
-    } catch (error) {
-      console.error("Error deleting token:", error);
-      toast({
-        title: "Error",
-        description: "Failed to delete token",
-        variant: "destructive",
-      });
-    }
-  };
-
-  useEffect(() => {
-    void fetchTokens();
-  }, [fetchTokens]);
 
   if (queryLoading) {
     return (
@@ -218,7 +181,7 @@ export default function APITokensPage() {
                 <DeleteConfirmationDialog
                   title="Delete Token"
                   description="Are you sure you want to delete this token? This action cannot be undone."
-                  onConfirm={() => handleDeleteToken(token.id)}
+                  onConfirm={() => deleteMutation.mutate(token.id)}
                   isLoading={deleteMutation.isPending}
                 />
               </div>

--- a/frontend/src/components/private-ai-keys-table.tsx
+++ b/frontend/src/components/private-ai-keys-table.tsx
@@ -83,7 +83,8 @@ export function PrivateAIKeysTable({
   };
 
   const getSortedAndFilteredKeys = () => {
-    let filteredKeys = keys;
+    // Copy so the later in-place .sort() never mutates the `keys` prop.
+    let filteredKeys = [...keys];
 
     // Apply name filter
     if (nameFilter.trim()) {

--- a/frontend/src/stores/use-config.ts
+++ b/frontend/src/stores/use-config.ts
@@ -2,6 +2,11 @@
 
 import { create } from "zustand";
 
+// Shared in-flight load so concurrent callers await the same request and get
+// the real config (or a genuine null on error), never an ambiguous "still
+// loading" null that callers would misread as a hard failure.
+let inFlightLoad: Promise<Config | null> | null = null;
+
 export interface Config {
   NEXT_PUBLIC_API_URL: string;
   PASSWORDLESS_SIGN_IN: boolean;
@@ -39,34 +44,40 @@ export const useConfig = create<ConfigState>((set, get) => ({
       return state.config; // Return cached config if already loaded successfully
     }
 
-    if (state.loading) {
-      return null; // Return null if already loading
+    if (inFlightLoad) {
+      return inFlightLoad; // Await the existing load instead of a bare null
     }
 
     set({ loading: true, error: null });
 
-    try {
-      const response = await fetch("/api/config");
-      if (!response.ok) {
-        throw new Error("Failed to load configuration");
-      }
+    inFlightLoad = (async () => {
+      try {
+        const response = await fetch("/api/config");
+        if (!response.ok) {
+          throw new Error("Failed to load configuration");
+        }
 
-      const config: Config = await response.json();
-      set({ config, loading: false, error: null, isLoaded: true });
-      return config;
-    } catch (error) {
-      console.error("Error loading configuration:", error);
-      set({
-        config: null,
-        loading: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : "Failed to load configuration",
-        isLoaded: false,
-      });
-      return null;
-    }
+        const config: Config = await response.json();
+        set({ config, loading: false, error: null, isLoaded: true });
+        return config;
+      } catch (error) {
+        console.error("Error loading configuration:", error);
+        set({
+          config: null,
+          loading: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to load configuration",
+          isLoaded: false,
+        });
+        return null;
+      } finally {
+        inFlightLoad = null;
+      }
+    })();
+
+    return inFlightLoad;
   },
 
   getApiUrl: () => {

--- a/frontend/src/utils/config.ts
+++ b/frontend/src/utils/config.ts
@@ -7,6 +7,19 @@ interface Config {
 let configCache: Config | null = null;
 let configPromise: Promise<Config> | null = null;
 
+// PASSWORDLESS_SIGN_IN and STRIPE_PUBLISHABLE_KEY come only from the server via
+// /api/config — they are not NEXT_PUBLIC_ vars, so process.env cannot read them
+// in the browser (it previously always yielded false/""). The fallback uses
+// inert defaults and relies on the async /api/config load for the real values.
+function fallbackConfig(): Config {
+  return {
+    NEXT_PUBLIC_API_URL:
+      process.env.NEXT_PUBLIC_API_URL || "http://localhost:8800",
+    PASSWORDLESS_SIGN_IN: false,
+    STRIPE_PUBLISHABLE_KEY: "",
+  };
+}
+
 export async function getConfig(): Promise<Config> {
   // If we have a cached value, return it
   if (configCache) {
@@ -31,13 +44,7 @@ export async function getConfig(): Promise<Config> {
       return config;
     } catch (error) {
       console.error("Error loading configuration:", error);
-      // Fallback configuration
-      const fallback: Config = {
-        NEXT_PUBLIC_API_URL:
-          process.env.NEXT_PUBLIC_API_URL || "http://localhost:8800",
-        PASSWORDLESS_SIGN_IN: process.env.PASSWORDLESS_SIGN_IN === "true",
-        STRIPE_PUBLISHABLE_KEY: process.env.STRIPE_PUBLISHABLE_KEY || "",
-      };
+      const fallback = fallbackConfig();
       configCache = fallback;
       return fallback;
     } finally {
@@ -57,14 +64,8 @@ export async function getApiUrl(): Promise<string> {
 // Synchronous function to get cached config (use this when you can't use async/await)
 export function getCachedConfig(): Config {
   if (!configCache) {
-    // Initialize with fallback values
-    configCache = {
-      NEXT_PUBLIC_API_URL:
-        process.env.NEXT_PUBLIC_API_URL || "http://localhost:8800",
-      PASSWORDLESS_SIGN_IN: process.env.PASSWORDLESS_SIGN_IN === "true",
-      STRIPE_PUBLISHABLE_KEY: process.env.STRIPE_PUBLISHABLE_KEY || "",
-    };
-    // Trigger async load
+    // Seed with inert fallback, then trigger the async load for real values.
+    configCache = fallbackConfig();
     getConfig().catch(console.error);
   }
   return configCache;

--- a/scripts/wait_for_database.py
+++ b/scripts/wait_for_database.py
@@ -5,6 +5,7 @@ Script to wait for PostgreSQL database to be ready and create it if it doesn't e
 
 import sys
 import psycopg2
+from psycopg2 import sql
 import os
 from urllib.parse import urlparse
 import time
@@ -40,8 +41,11 @@ def create_database_if_not_exists():
                 # Extract database name from the original URL
                 db_name = parsed.path.lstrip("/")
 
-                # Create the database
-                cursor.execute(f"CREATE DATABASE {db_name}")
+                # Create the database. Quote the identifier so names with
+                # hyphens/special chars (common in k8s/Lagoon) produce valid DDL.
+                cursor.execute(
+                    sql.SQL("CREATE DATABASE {}").format(sql.Identifier(db_name))
+                )
                 cursor.close()
                 conn.close()
 

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -908,6 +908,22 @@ def test_team_admin_cannot_remove_other_team_user(
     assert other_user.team_id == other_team.id
 
 
+def test_cannot_remove_last_team_admin(client, team_admin_token, test_team_admin):
+    """
+    Removing a team's last team admin would orphan the team, so it is blocked.
+
+    GIVEN: A team whose only admin is the requesting team admin
+    WHEN: they try to remove that admin from the team
+    THEN: A 400 is returned and the admin stays in the team
+    """
+    response = client.post(
+        f"/users/{test_team_admin.id}/remove-from-team",
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code == 400
+    assert "last team admin" in response.json()["detail"].lower()
+
+
 @patch("httpx.AsyncClient.post", new_callable=AsyncMock)
 @patch("app.api.teams.SESService")
 def test_extend_team_trial_success(

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -848,31 +848,64 @@ def test_remove_user_not_in_team(client, admin_token, test_user):
     assert "User is not a member of any team" in response.json()["detail"]
 
 
-def test_team_admin_cannot_remove_user_from_team(
+def test_team_admin_can_remove_same_team_user(
     client, team_admin_token, test_team_user
 ):
     """
-    Test that a team admin cannot remove a user from their team.
+    Test that a team admin can remove a member of their own team.
 
-    GIVEN: User A is a member of Team 1
-    WHEN: a team admin tries to remove the user from the team
-    THEN: A 403 - Forbidden is returned
+    GIVEN: User A and a team admin are members of Team 1
+    WHEN: the team admin removes User A from the team
+    THEN: A 200 is returned and the user is no longer in the team
     """
     response = client.post(
         f"/users/{test_team_user.id}/remove-from-team",
         headers={"Authorization": f"Bearer {team_admin_token}"},
     )
+    assert response.status_code == 200
+    assert response.json()["team_id"] is None
+
+
+def test_team_admin_cannot_remove_other_team_user(
+    client, db, team_admin_token, test_team_user
+):
+    """
+    Test that a team admin cannot remove a user from a different team.
+
+    GIVEN: User B belongs to Team 2, a team admin belongs to Team 1
+    WHEN: the team admin tries to remove User B
+    THEN: A 403 - Forbidden is returned and User B stays in Team 2
+    """
+    other_team = DBTeam(
+        name="Other Team",
+        admin_email="other-team@example.com",
+        created_at=datetime.now(UTC),
+    )
+    db.add(other_team)
+    db.commit()
+    db.refresh(other_team)
+    other_user = DBUser(
+        email="other-team-user@example.com",
+        hashed_password=get_password_hash("password123"),
+        is_active=True,
+        is_admin=False,
+        role="key_creator",
+        team_id=other_team.id,
+        created_at=datetime.now(UTC),
+    )
+    db.add(other_user)
+    db.commit()
+    db.refresh(other_user)
+
+    response = client.post(
+        f"/users/{other_user.id}/remove-from-team",
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
     assert response.status_code == 403
     assert "Not authorized to perform this action" in response.json()["detail"]
 
-    # Verify user is still in the team
-    response = client.get(
-        f"/users/{test_team_user.id}",
-        headers={"Authorization": f"Bearer {team_admin_token}"},
-    )
-    assert response.status_code == 200
-    user_data = response.json()
-    assert user_data["team_id"] == test_team_user.team_id
+    db.refresh(other_user)
+    assert other_user.team_id == other_team.id
 
 
 @patch("httpx.AsyncClient.post", new_callable=AsyncMock)

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1004,6 +1004,25 @@ def test_user_privilege_escalation(client, team_admin_token):
     assert "User not found" in response.json()["detail"]
 
 
+def test_team_admin_cannot_change_is_active(
+    client, team_admin_token, test_team_user
+):
+    """
+    A team admin may manage their own team members but not toggle activation.
+
+    GIVEN: A team member in the team admin's team
+    WHEN: the team admin tries to deactivate them via PUT /users/{id}
+    THEN: A 403 is returned and the member stays active
+    """
+    response = client.put(
+        f"/users/{test_team_user.id}",
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+        json={"is_active": False},
+    )
+    assert response.status_code == 403
+    assert "Not authorized to perform this action" in response.json()["detail"]
+
+
 @patch("app.api.users.settings.ENABLE_LIMITS", True)
 def test_create_user_with_limits_enabled(client, team_admin_token, test_team, db):
     """

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1004,6 +1004,20 @@ def test_user_privilege_escalation(client, team_admin_token):
     assert "User not found" in response.json()["detail"]
 
 
+def test_admin_update_user_rejects_password_fields(client, admin_token, test_user):
+    """
+    PUT /users/{id} does not support password changes and must reject them
+    with a 422 (previously they were silently discarded). Password changes go
+    through /auth/me.
+    """
+    response = client.put(
+        f"/users/{test_user.id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"new_password": "brand-new-password"},
+    )
+    assert response.status_code == 422
+
+
 def test_team_admin_cannot_change_is_active(
     client, team_admin_token, test_team_user
 ):


### PR DESCRIPTION
Addresses all 11 BUG-severity findings from the deepsec scan. All functional (non-exploitable) bugs.

## Backend
- **Team-admin "Remove user" always 403'd** — `remove_user_from_team` was system-admin-only, but the button only appears for team admins. Relaxed to team-admin with a same-team ownership check (mirrors `update_user_role`); system admins unrestricted.
- **Admin PUT /users/{id} silently discarded password fields** — added a dedicated `AdminUserUpdate` schema (no password fields, `extra='forbid'`) so passwords now return a clear 422 instead of a silent no-op. Self-service password change still goes through /auth/me. (`is_active` added to the schema since callers already send it.)
- **ACCESS_TOKEN_EXPIRE_MINUTES ignored** — token lifetime now reads the setting instead of a hardcoded 60m.
- **/oauth2-redirect returned the full Swagger page** — now returns `get_swagger_ui_oauth2_redirect_html()`.
- **CREATE DATABASE unquoted identifier** — `wait_for_database.py` now quotes via `psycopg2.sql.Identifier` so hyphenated DB names produce valid DDL.

## CI
- **Release tag push failed under `contents: read`** — helm-package-publish job now has `contents: write`.

## Frontend
- **API tokens page** — consolidated on a single React Query source of truth: fixes the duplicate mount fetch, the never-shown delete spinner, and the newly created token not appearing in the list.
- **config client env** — stopped reading non-`NEXT_PUBLIC_` env vars (always undefined in the browser); fallbacks use inert defaults + the async /api/config load.
- **use-config** — awaits the in-flight load instead of returning an ambiguous null, so a concurrent caller no longer sees a spurious hard-error screen.
- **private-ai-keys-table** — copy before in-place sort so the `keys` prop is not mutated.

Full backend suite passes (1103 passed); changed frontend files typecheck clean.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR addresses 11 functional bugs identified by a security scan, spanning backend authorization, schema correctness, token expiry, frontend state management, and a CI permissions gap. All changes are targeted and well-scoped, with a full backend test suite passing and updated/new tests for the changed authorization logic.

- **Backend**: Fixes team-admin `remove_user_from_team` authorization (was always 403), swaps `UserUpdate` for a new `AdminUserUpdate` schema with `extra='forbid'` on the admin PUT endpoint (making silently-dropped password fields into explicit 422s, and activating `is_active` writes), corrects the `ACCESS_TOKEN_EXPIRE_MINUTES` being ignored, and returns the proper OAuth2 redirect HTML from `/oauth2-redirect`.
- **Frontend**: Consolidates API token page to React Query as the single source of truth (removing a duplicate manual fetch, a never-shown delete spinner, and missing post-create list refresh); stops reading non-`NEXT_PUBLIC_` env vars in the browser; deduplicates concurrent `loadConfig` calls via a shared in-flight promise; and copies the `keys` prop before sorting to avoid prop mutation.
- **Scripts / CI**: Quotes the database identifier in `wait_for_database.py` via `psycopg2.sql.Identifier` to handle hyphenated names, and upgrades the helm-publish job to `contents: write` so the release tag push succeeds.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is safe to merge; the logic changes are well-targeted and backed by passing tests.

All backend fixes are correct and well-tested. The frontend token page consolidation is an improvement, but the shared deleteMutation.isPending across all token rows means every delete button enters loading state when any one token is deleted. The redundant double-fetch on mutation success and the newly functional is_active write path for team admins are worth a second look.

frontend/src/app/auth/token/page.tsx — shared delete loading state and double-fetch on mutation success; app/schemas/models.py — newly active is_active write path for team admins.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/app/auth/token/page.tsx | Consolidated to React Query as sole source of truth; removes manual fetch/state; redundant invalidate+refetch pattern and shared isPending across all delete buttons are P2 concerns. |
| app/schemas/models.py | Introduces AdminUserUpdate with extra='forbid'; correctly excludes password fields; newly active is_active field gives team admins ability to deactivate users — intentional but worth confirming. |
| app/api/users.py | Relaxes remove_user_from_team to team-admin with same-team ownership check; switches update_user to AdminUserUpdate; logic is correct and mirrors existing update_user_role pattern. |
| app/core/security.py | Fixes hardcoded 60-minute token expiry to read ACCESS_TOKEN_EXPIRE_MINUTES from settings; straightforward and correct. |
| app/main.py | Replaces incorrect get_swagger_ui_html call on /oauth2-redirect with get_swagger_ui_oauth2_redirect_html(); correct fix. |
| scripts/wait_for_database.py | Quotes database identifier via psycopg2.sql.Identifier, fixing DDL syntax for hyphenated names; clean and correct. |
| frontend/src/stores/use-config.ts | Introduces module-level inFlightLoad to deduplicate concurrent loadConfig calls; pattern is correct — inFlightLoad holds the Promise synchronously and is cleared in finally after settling. |
| frontend/src/utils/config.ts | Extracts fallbackConfig() helper and removes incorrect browser reads of non-NEXT_PUBLIC_ env vars; correct fix for always-undefined browser env reads. |
| frontend/src/components/private-ai-keys-table.tsx | Copies keys array before sorting to avoid mutating the prop; simple, correct fix. |
| .github/workflows/helm-package-publish.yml | Upgrades helm-package-publish job to contents: write so the release tag push no longer fails under read-only permissions. |
| tests/test_teams.py | Splits one incorrect test into two correct scenarios: team admin can remove same-team member (200) and cannot remove other-team member (403); coverage is thorough. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["POST /users/id/remove-from-team"] --> B{get_role_min_team_admin}
    B -- "not authorized" --> Z[403 Forbidden]
    B -- "authorized" --> C{current_user.is_admin?}
    C -- "yes - system admin" --> E{db_user.team_id is None?}
    C -- "no - team admin" --> D{Same team?}
    D -- "no" --> Z
    D -- "yes" --> E
    E -- "yes - not in team" --> Y[400 Bad Request]
    E -- "no" --> F[Clear team_id in DB]
    F --> G[Sync LiteLLM]
    G --> I[200 User response]

    subgraph "PUT /users/id - AdminUserUpdate schema"
        K["is_admin=true by non-admin?"] -- "yes" --> Z2[403 Forbidden]
        K -- "no" --> L["Update: email, is_admin, is_active, receive_marketing_updates"]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["POST /users/id/remove-from-team"] --> B{get_role_min_team_admin}
    B -- "not authorized" --> Z[403 Forbidden]
    B -- "authorized" --> C{current_user.is_admin?}
    C -- "yes - system admin" --> E{db_user.team_id is None?}
    C -- "no - team admin" --> D{Same team?}
    D -- "no" --> Z
    D -- "yes" --> E
    E -- "yes - not in team" --> Y[400 Bad Request]
    E -- "no" --> F[Clear team_id in DB]
    F --> G[Sync LiteLLM]
    G --> I[200 User response]

    subgraph "PUT /users/id - AdminUserUpdate schema"
        K["is_admin=true by non-admin?"] -- "yes" --> Z2[403 Forbidden]
        K -- "no" --> L["Update: email, is_admin, is_active, receive_marketing_updates"]
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `frontend/src/app/auth/token/page.tsx`, line 63-82 ([link](https://github.com/amazeeio/amazee.ai/blob/4a2e6385bcd1f8a994df4f09d9b89a087dfb2eea/frontend/src/app/auth/token/page.tsx#L63-L82)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Shared loading state across all delete buttons**

   `deleteMutation` is a single mutation instance, so `deleteMutation.isPending` becomes `true` for all rendered `DeleteConfirmationDialog` components simultaneously when any one token deletion is in progress. If the dialog's `isLoading` prop disables the confirm button (which it appears to), every token's delete button is blocked while one is being deleted — and there's no per-token visual cue about which deletion is in flight. This is a UX regression from the previous per-token async handler (which had no loading state at all) and could confuse users with many tokens.

   A common fix is to track the in-flight token id in local state (e.g. `const [deletingId, setDeletingId] = useState<string | null>(null)`) and pass `isLoading={deleteMutation.isPending && deletingId === token.id}` per row.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


2. `frontend/src/app/auth/token/page.tsx`, line 44-47 ([link](https://github.com/amazeeio/amazee.ai/blob/4a2e6385bcd1f8a994df4f09d9b89a087dfb2eea/frontend/src/app/auth/token/page.tsx#L44-L47)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Calling both `invalidateQueries` and `refetchQueries` is redundant. `invalidateQueries` already marks the `"tokens"` query stale and immediately triggers a refetch when there are active subscribers. The subsequent `refetchQueries` fires a second network request in parallel, doubling the API calls after every create or delete.


3. `frontend/src/app/auth/token/page.tsx`, line 67-70 ([link](https://github.com/amazeeio/amazee.ai/blob/4a2e6385bcd1f8a994df4f09d9b89a087dfb2eea/frontend/src/app/auth/token/page.tsx#L67-L70)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Same redundant double-fetch pattern on the delete mutation's `onSuccess`. `invalidateQueries` is sufficient.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["chore: fix functional bugs found by deep..."](https://github.com/amazeeio/amazee.ai/commit/4a2e6385bcd1f8a994df4f09d9b89a087dfb2eea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44097641)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->