### PR TITLE
fix(helm): drop broken redundant "latest" chart push

### DIFF
--- a/.github/workflows/helm-package-publish.yml
+++ b/.github/workflows/helm-package-publish.yml
@@ -66,12 +66,11 @@ jobs:
             # Package the chart
             helm package "$chart_name"
 
-            # Push to OCI registry with version tag
+            # Push to OCI registry with version tag. helm derives the OCI tag
+            # from the chart's SemVer version (Chart.yaml), not the filename, so
+            # there is no separate "latest" push — consumers select an explicit
+            # version via --version / `helm search repo --versions`.
             helm push "$chart_name-$version.tgz" oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-            # Also push with latest tag by copying the chart and updating its version
-            cp "$chart_name-$version.tgz" "$chart_name-latest.tgz"
-            helm push "$chart_name-latest.tgz" oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
             echo "✅ Published $chart_name:$version to GHCR via OCI"
           done
@@ -90,12 +89,9 @@ jobs:
           version=$(grep '^version:' Chart.yaml | awk '{print $2}')
           echo "Main chart version: $version"
 
-          # Push to OCI registry with version tag
+          # Push to OCI registry with version tag (SemVer from Chart.yaml is the
+          # OCI tag; no separate "latest" push — see subchart step above).
           helm push "amazee-ai-$version.tgz" oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-          # Also push with latest tag by copying the chart
-          cp "amazee-ai-$version.tgz" "amazee-ai-latest.tgz"
-          helm push "amazee-ai-latest.tgz" oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
           echo "✅ Published amazee-ai:$version to GHCR via OCI"
 


### PR DESCRIPTION
## Problem
The `package-and-publish` job intermittently fails on the chart push with:

```
Error: sha256:…: not found
##[error]Process completed with exit code 1.
```

## Root cause
`helm push` tags OCI artifacts by the chart's **SemVer version** (from `Chart.yaml`), **not** by the filename. The workflow copied each package to `*-latest.tgz` and pushed it again — which re-pushed the *same* version tag rather than a `:latest` tag. That redundant duplicate push is what flakes: sometimes the registry treats it as idempotent (green), sometimes it returns a blob-mount error (red).

It never actually produced a working `:latest` tag, and **nothing consumes one** — `helm/README.md` installs charts by explicit `--version` / `helm search repo --versions`.

## Fix
Remove the dead `latest`-push from both the subchart loop and the main-chart step. Charts continue to publish under their proper SemVer tag. The job becomes deterministically green.

## Scope / risk
- Workflow-only change; no app code touched.
- The `contents: write` permission is unrelated and intentionally kept (needed by the `Create Release Tag` step).
- Bug has existed since the workflow was introduced (2025-06-27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes the broken "latest" re-push logic from the Helm chart publish workflow. `helm push` always tags OCI artifacts using the chart's SemVer version from `Chart.yaml` — the filename is ignored — so copying a package to `*-latest.tgz` and re-pushing it simply repeated the same version-tagged push, occasionally causing a registry blob-mount error.

- Removes the `cp *-latest.tgz` + duplicate `helm push` calls from both the subchart loop and the main-chart step.
- Adds inline comments explaining why no separate `:latest` push is needed, so future readers won't reintroduce it.
- No app code is touched; the change is workflow-only.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — removes a redundant push that never produced a usable :latest tag and intermittently broke the workflow.

The removal is surgical: two cp calls and two duplicate helm push calls are deleted, leaving one deterministic push per chart. The root cause (helm derives the OCI tag from Chart.yaml, not the filename) is well-established, and the fix aligns the workflow with that behaviour. No consumers of a :latest tag exist in the repo, so nothing is broken by removing it.

No files require special attention. The single changed workflow file is straightforward.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/helm-package-publish.yml | Removes dead copy-and-re-push logic for a non-functional :latest OCI tag; correctly leaves one helm push per chart using the SemVer version from Chart.yaml. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant W as Workflow
    participant FS as Filesystem
    participant R as GHCR OCI Registry

    Note over W,R: Before (broken)
    W->>FS: helm package chart → chart-1.2.3.tgz
    W->>R: helm push chart-1.2.3.tgz → tag :1.2.3
    W->>FS: cp chart-1.2.3.tgz chart-latest.tgz
    W->>R: helm push chart-latest.tgz → tag :1.2.3 (duplicate, flaky blob-mount error)

    Note over W,R: After (fixed)
    W->>FS: helm package chart → chart-1.2.3.tgz
    W->>R: helm push chart-1.2.3.tgz → tag :1.2.3 (single deterministic push)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant W as Workflow
    participant FS as Filesystem
    participant R as GHCR OCI Registry

    Note over W,R: Before (broken)
    W->>FS: helm package chart → chart-1.2.3.tgz
    W->>R: helm push chart-1.2.3.tgz → tag :1.2.3
    W->>FS: cp chart-1.2.3.tgz chart-latest.tgz
    W->>R: helm push chart-latest.tgz → tag :1.2.3 (duplicate, flaky blob-mount error)

    Note over W,R: After (fixed)
    W->>FS: helm package chart → chart-1.2.3.tgz
    W->>R: helm push chart-1.2.3.tgz → tag :1.2.3 (single deterministic push)
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(helm): drop broken redundant &quot;latest..."](https://github.com/amazeeio/amazee.ai/commit/19b2862b80ed7d01f1f144b7047ea7354730c008) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44458847)</sub>

<!-- /greptile_comment -->