### PR TITLE
chore(helm): trim workflow permissions to only what's used

### DIFF
--- a/.github/workflows/helm-package-publish.yml
+++ b/.github/workflows/helm-package-publish.yml
@@ -25,9 +25,7 @@ jobs:
   package-and-publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # pushes the release tag in "Create Release Tag"
-      packages: write
-      security-events: write
+      packages: write  # helm push charts to GHCR (GitHub Packages)
 
     steps:
       - name: Checkout code
@@ -39,11 +37,6 @@ jobs:
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           version: v3.18.0
-
-      - name: Configure Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Log in to Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -94,15 +87,6 @@ jobs:
           helm push "amazee-ai-$version.tgz" oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
           echo "✅ Published amazee-ai:$version to GHCR via OCI"
-
-      - name: Create Release Tag
-        if: github.event_name == 'release'
-        run: |
-          cd helm
-          version=$(grep '^version:' Chart.yaml | awk '{print $2}')
-          echo "Creating release tag: v$version"
-          git tag -a "v$version" -m "Release Helm charts version $version"
-          git push origin "v$version"
 
   test-charts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What
The `package-and-publish` job carried three write permissions; only one is used. Trim to `packages: write`.

| Permission | Used by | Verdict |
|---|---|---|
| `packages: write` | `helm push` charts → GHCR | **kept** (required) |
| `contents: write` | `Create Release Tag` step (`git push` tag), gated to `release` events | **removed** — our flow never fires `release` events (releases = dev→main PR merge = `push`); step was dead |
| `security-events: write` | nothing (no SARIF upload) | **removed** — unused |

Also removes the now-orphan `Configure Git` step (only existed to support the tag push).

## Why
- Least privilege: the job only publishes charts.
- Removing the sole *new* write grant clears the **Scorecard Token-Permissions high-severity alert** on this workflow **without needing a dismissal**.

## Risk
- Charts still publish exactly as before (`packages: write` retained).
- No `release`-event auto-tagging anymore. Not currently used; if GitHub Releases are adopted later, reintroduce a scoped `contents: write` at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR applies least-privilege hardening to the `package-and-publish` job by dropping two unnecessary permissions (`contents: write`, `security-events: write`) and removing the dead code that was their justification (`Configure Git` + `Create Release Tag` steps). Chart publishing to GHCR is unaffected.

- `packages: write` is retained as the sole permission — it is the only one actually exercised by `helm push`.
- `contents: write` and `security-events: write` are removed along with the release-tagging steps that were only reachable via `release` events, which the team confirms are never fired in practice.
- Two small follow-ups worth considering: removing `fetch-depth: 0` from the checkout (now unnecessary) and either removing or annotating the lingering `release: types: [published]` top-level trigger.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — chart publishing is unchanged and only dead code plus over-broad permissions are removed.

The change is a straightforward permission and dead-code cleanup. The one retained permission (packages: write) covers the only active operation (helm push to GHCR), and the removed steps were genuinely unreachable in the team's stated flow. The two style notes (orphaned release trigger and unnecessary fetch-depth: 0) have no runtime impact.

No files require special attention; the single changed workflow file is clean.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/helm-package-publish.yml | Removes two unused permissions (contents: write, security-events: write) and deletes the dead 'Configure Git' + 'Create Release Tag' steps; retains packages: write for GHCR helm push. The release trigger still exists in the workflow top-level on/release block and fetch-depth: 0 in the checkout step is now unnecessary. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Workflow Trigger
push / pull_request / release] --> B{package-and-publish job}

    subgraph BEFORE["Before (removed)"]
        B1["permissions:
  contents: write
  packages: write
  security-events: write"]
        S1["Configure Git
(git config user/email)"]
        S2["Create Release Tag
(if: release event)
git tag + git push"]
    end

    subgraph AFTER["After (this PR)"]
        B2["permissions:
  packages: write"]
        S3["Checkout code
(fetch-depth: 0)"]
        S4["Set up Helm"]
        S5["Login to GHCR"]
        S6["Package & publish
subcharts → GHCR"]
        S7["Package & publish
main chart → GHCR"]
    end

    B --> B2
    B2 --> S3 --> S4 --> S5 --> S6 --> S7
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Workflow Trigger
push / pull_request / release] --> B{package-and-publish job}

    subgraph BEFORE["Before (removed)"]
        B1["permissions:
  contents: write
  packages: write
  security-events: write"]
        S1["Configure Git
(git config user/email)"]
        S2["Create Release Tag
(if: release event)
git tag + git push"]
    end

    subgraph AFTER["After (this PR)"]
        B2["permissions:
  packages: write"]
        S3["Checkout code
(fetch-depth: 0)"]
        S4["Set up Helm"]
        S5["Login to GHCR"]
        S6["Package & publish
subcharts → GHCR"]
        S7["Package & publish
main chart → GHCR"]
    end

    B --> B2
    B2 --> S3 --> S4 --> S5 --> S6 --> S7
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `.github/workflows/helm-package-publish.yml`, line 31-34 ([link](https://github.com/amazeeio/amazee.ai/blob/70e3d65462055594b0b85b0fefc9de42cd7d8bde/.github/workflows/helm-package-publish.yml#L31-L34)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `fetch-depth: 0` fetches the full git history, which was needed by the now-removed `Create Release Tag` step to push tags. Since the `package-and-publish` job no longer does any git history operations (only `helm package` + `helm push`), a shallow clone (`fetch-depth: 1`, the default) is sufficient and slightly faster.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


2. `.github/workflows/helm-package-publish.yml`, line 14-15 ([link](https://github.com/amazeeio/amazee.ai/blob/70e3d65462055594b0b85b0fefc9de42cd7d8bde/.github/workflows/helm-package-publish.yml#L14-L15)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Orphaned `release` trigger after tag-step removal**

   The workflow still declares `release: types: [published]` as a trigger, but the only step that acted on `release` events (`Create Release Tag`, gated with `if: github.event_name == 'release'`) was just removed. Publishing charts on a release event is harmless, but the trigger now has no release-specific behaviour and may confuse future contributors into thinking tagging is still happening. If GitHub Releases are not part of the current flow, consider removing the `release` trigger entirely — or leaving it with a comment explaining it republishes charts on a release.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["chore(helm): trim workflow permissions t..."](https://github.com/amazeeio/amazee.ai/commit/70e3d65462055594b0b85b0fefc9de42cd7d8bde) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44463573)</sub>

<!-- /greptile_comment -->