### PR TITLE
feat(auth, teams, users, services): implement disposable email blocki…

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -23,6 +23,10 @@ environments:
         schedule: "0 2 * * *"
         command: python scripts/trigger_refresh_disposable_domains_job.py
         service: backend
+      - name: prune-signup-events
+        schedule: "30 2 * * *"
+        command: python scripts/trigger_prune_signup_events_job.py
+        service: backend
     routes:
       - backend:
         - api.amazee.ai:
@@ -57,6 +61,10 @@ environments:
       - name: refresh-disposable-domains
         schedule: "0 2 * * *"
         command: python scripts/trigger_refresh_disposable_domains_job.py
+        service: backend
+      - name: prune-signup-events
+        schedule: "30 2 * * *"
+        command: python scripts/trigger_prune_signup_events_job.py
         service: backend
 
 tasks:

--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -19,6 +19,10 @@ environments:
         schedule: "0 5 1 * *"
         command: python scripts/trigger_trial_recon_job.py
         service: backend
+      - name: refresh-disposable-domains
+        schedule: "0 2 * * *"
+        command: python scripts/trigger_refresh_disposable_domains_job.py
+        service: backend
     routes:
       - backend:
         - api.amazee.ai:
@@ -49,6 +53,10 @@ environments:
       - name: monitor-trial-users
         schedule: "0 5 1 * *"
         command: python scripts/trigger_trial_recon_job.py
+        service: backend
+      - name: refresh-disposable-domains
+        schedule: "0 2 * * *"
+        command: python scripts/trigger_refresh_disposable_domains_job.py
         service: backend
 
 tasks:

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -541,6 +541,10 @@ async def validate_email(
     # Block disposable / dynamic-DNS domains before we even send an OTP.
     assert_email_domain_allowed(db, email)
 
+    # Cap OTP sends per IP: this endpoint triggers an email, so an unlimited
+    # loop from one client could be used to spam arbitrary addresses.
+    enforce_signup_velocity(request, db, email=email, endpoint="validate-email")
+
     send_validation_code(email, db)
     return {"message": "Validation code has been generated and sent"}
 

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -62,6 +62,8 @@ from app.schemas.models import (
 from app.api.teams import register_team
 from app.api.users import _create_user_in_db, get_user_by_email
 from app.core.email import normalize_email_for_lookup
+from app.services.disposable_domains import assert_email_domain_allowed
+from app.services.signup_velocity import enforce_signup_velocity
 
 auth_logger = logging.getLogger(__name__)
 
@@ -323,6 +325,9 @@ async def register(request: Request, user: UserCreate, db: Session = Depends(get
             status_code=status.HTTP_400_BAD_REQUEST, detail="Email already registered"
         )
 
+    # New account: apply the per-IP signup velocity cap (self-registration is anonymous).
+    enforce_signup_velocity(request, db, email=user.email, endpoint="register")
+
     db_user = await _create_user_in_db(user, db)
     auth_logger.info(f"Successfully registered new user: {user.email}")
     return db_user
@@ -385,6 +390,11 @@ async def sign_in(
     # If user doesn't exist, create a new user and team
     if not user:
         auth_logger.info(f"Creating new user and team for: {sign_in_username}")
+        # Only NEW-account creation is velocity-limited; existing-user code logins
+        # (the common case, incl. many users behind one corporate IP) are not.
+        enforce_signup_velocity(
+            request, db, email=sign_in_username, endpoint="sign-in"
+        )
         # First create the team
         team_data = TeamCreate(
             name=f"Team {sign_in_username}",
@@ -529,6 +539,9 @@ async def validate_email(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid email format: {e}"
         )
+
+    # Block disposable / dynamic-DNS domains before we even send an OTP.
+    assert_email_domain_allowed(email)
 
     send_validation_code(email, db)
     return {"message": "Validation code has been generated and sent"}
@@ -749,6 +762,7 @@ def send_validation_url(email: str) -> None:
 
 @router.post("/generate-trial-access", response_model=TrialAccessResponse)
 async def generate_trial_access(
+    request: Request,
     response: Response,
     db: Session = Depends(get_db),
     limit_service: LimitService = Depends(get_limit_service),
@@ -761,6 +775,10 @@ async def generate_trial_access(
     Returns the private AI key (which includes both LiteLLM token and VectorDB credentials),
     along with user and team information.
     """
+    # Unauthenticated free-key endpoint: cap per-IP request velocity (in addition
+    # to the global AI_TRIAL_MAX_USERS ceiling).
+    enforce_signup_velocity(request, db, endpoint="generate-trial-access")
+
     # Get default region by name and ensure it is active
     region = (
         db.query(DBRegion)

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -392,9 +392,7 @@ async def sign_in(
         auth_logger.info(f"Creating new user and team for: {sign_in_username}")
         # Only NEW-account creation is velocity-limited; existing-user code logins
         # (the common case, incl. many users behind one corporate IP) are not.
-        enforce_signup_velocity(
-            request, db, email=sign_in_username, endpoint="sign-in"
-        )
+        enforce_signup_velocity(request, db, email=sign_in_username, endpoint="sign-in")
         # First create the team
         team_data = TeamCreate(
             name=f"Team {sign_in_username}",

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -539,7 +539,7 @@ async def validate_email(
         )
 
     # Block disposable / dynamic-DNS domains before we even send an OTP.
-    assert_email_domain_allowed(email)
+    assert_email_domain_allowed(db, email)
 
     send_validation_code(email, db)
     return {"message": "Validation code has been generated and sent"}

--- a/app/api/teams.py
+++ b/app/api/teams.py
@@ -148,7 +148,7 @@ async def register_team(
     """
     # Defense-in-depth: block disposable / dynamic-DNS admin emails before any
     # team is created (the sign-in auto-provision path creates a team first).
-    assert_email_domain_allowed(team.admin_email)
+    assert_email_domain_allowed(db, team.admin_email)
 
     # Check if team email already exists (case insensitive)
     db_team = (

--- a/app/api/teams.py
+++ b/app/api/teams.py
@@ -45,6 +45,7 @@ from app.schemas.models import (
     TeamUpdate,
     TeamWithUsers,
 )
+from app.services.disposable_domains import assert_email_domain_allowed
 from app.services.litellm import LiteLLMService
 from app.services.ses import SESService
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -145,6 +146,10 @@ async def register_team(
     """
     Register a new team. Requires authentication.
     """
+    # Defense-in-depth: block disposable / dynamic-DNS admin emails before any
+    # team is created (the sign-in auto-provision path creates a team first).
+    assert_email_domain_allowed(team.admin_email)
+
     # Check if team email already exists (case insensitive)
     db_team = (
         db.query(DBTeam)

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -50,6 +50,7 @@ from app.core.security import (
 from app.core.email import normalize_email_for_lookup
 from app.core.roles import UserRole
 from app.services.litellm import LiteLLMService
+from app.services.disposable_domains import assert_email_domain_allowed
 from app.services.hubspot import HubSpotService
 from datetime import datetime, UTC
 import logging
@@ -805,6 +806,10 @@ async def create_user(
 
 
 async def _create_user_in_db(user: UserCreate, db: Session) -> DBUser:
+    # Defense-in-depth: reject disposable / dynamic-DNS domains at the narrowest
+    # user-creation choke point (covers create_user, sign-in auto-provision, trial).
+    assert_email_domain_allowed(user.email)
+
     limit_service = get_limit_service(db)
     if settings.ENABLE_LIMITS and user.team_id is not None:
         limit_service.check_team_user_limit(user.team_id)

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -808,7 +808,7 @@ async def create_user(
 async def _create_user_in_db(user: UserCreate, db: Session) -> DBUser:
     # Defense-in-depth: reject disposable / dynamic-DNS domains at the narrowest
     # user-creation choke point (covers create_user, sign-in auto-provision, trial).
-    assert_email_domain_allowed(user.email)
+    assert_email_domain_allowed(db, user.email)
 
     limit_service = get_limit_service(db)
     if settings.ENABLE_LIMITS and user.team_id is not None:

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -99,6 +99,11 @@ class Settings(BaseSettings):
     SIGNUP_VELOCITY_WINDOW_MINUTES: int = int(
         os.getenv("SIGNUP_VELOCITY_WINDOW_MINUTES", "60")
     )
+    # Retention for the append-only signup_events table; rows older than this are
+    # removed by the daily prune cron so the table can't grow without bound.
+    SIGNUP_EVENTS_RETENTION_DAYS: int = int(
+        os.getenv("SIGNUP_EVENTS_RETENTION_DAYS", "7")
+    )
     PROMETHEUS_API_KEY: str = os.getenv("PROMETHEUS_API_KEY", "")
     POOL_PURCHASE_EXPIRY_DAYS: int = int(os.getenv("POOL_PURCHASE_EXPIRY_DAYS", "365"))
     PERIODIC_TOPUP_EXPIRY_DAYS: int = int(

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -85,10 +85,9 @@ class Settings(BaseSettings):
         "https://disposable.github.io/disposable-email-domains/domains.txt",
     )
     # Extra domains merged with the committed baseline (comma-separated).
+    # The blocklist itself lives in the disposable_domains table, repopulated by
+    # the daily refresh cron (scripts/trigger_refresh_disposable_domains_job.py).
     DISPOSABLE_DOMAINS_EXTRA: str = os.getenv("DISPOSABLE_DOMAINS_EXTRA", "")
-    DISPOSABLE_DOMAINS_REFRESH_HOURS: int = int(
-        os.getenv("DISPOSABLE_DOMAINS_REFRESH_HOURS", "24")
-    )
 
     # Layer 2: per-IP signup velocity cap (backed by the signup_events table).
     ENABLE_SIGNUP_VELOCITY_LIMIT: bool = (

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -73,6 +73,33 @@ class Settings(BaseSettings):
     MOAD_DASHBOARD_API_URL: str = os.getenv("MOAD_DASHBOARD_API_URL", "")
     MOAD_DASHBOARD_API_TOKEN: str = os.getenv("MOAD_DASHBOARD_API_TOKEN", "")
     ENABLE_METRICS: bool = os.getenv("ENABLE_METRICS", "false") == "true"
+
+    # --- Trial-account abuse protection (moad #620) ---
+    # Layer 1: disposable / dynamic-DNS email-domain blocking (defense-in-depth;
+    # the backend must not trust callers to have filtered signup emails).
+    ENABLE_DISPOSABLE_EMAIL_BLOCKING: bool = (
+        os.getenv("ENABLE_DISPOSABLE_EMAIL_BLOCKING", "true") == "true"
+    )
+    DISPOSABLE_DOMAINS_URL: str = os.getenv(
+        "DISPOSABLE_DOMAINS_URL",
+        "https://disposable.github.io/disposable-email-domains/domains.txt",
+    )
+    # Extra domains merged with the committed baseline (comma-separated).
+    DISPOSABLE_DOMAINS_EXTRA: str = os.getenv("DISPOSABLE_DOMAINS_EXTRA", "")
+    DISPOSABLE_DOMAINS_REFRESH_HOURS: int = int(
+        os.getenv("DISPOSABLE_DOMAINS_REFRESH_HOURS", "24")
+    )
+
+    # Layer 2: per-IP signup velocity cap (backed by the signup_events table).
+    ENABLE_SIGNUP_VELOCITY_LIMIT: bool = (
+        os.getenv("ENABLE_SIGNUP_VELOCITY_LIMIT", "true") == "true"
+    )
+    SIGNUP_MAX_PER_IP_PER_WINDOW: int = int(
+        os.getenv("SIGNUP_MAX_PER_IP_PER_WINDOW", "5")
+    )
+    SIGNUP_VELOCITY_WINDOW_MINUTES: int = int(
+        os.getenv("SIGNUP_VELOCITY_WINDOW_MINUTES", "60")
+    )
     PROMETHEUS_API_KEY: str = os.getenv("PROMETHEUS_API_KEY", "")
     POOL_PURCHASE_EXPIRY_DAYS: int = int(os.getenv("POOL_PURCHASE_EXPIRY_DAYS", "365"))
     PERIODIC_TOPUP_EXPIRY_DAYS: int = int(

--- a/app/data/disposable_domains_extra.txt
+++ b/app/data/disposable_domains_extra.txt
@@ -1,0 +1,61 @@
+# Curated baseline of blocked email domains, merged with the upstream
+# disposable list (https://disposable.github.io/disposable-email-domains/domains.txt)
+# that DisposableDomainService fetches at runtime.
+#
+# This file is the ALWAYS-ON guarantee: even if the upstream fetch fails, these
+# domains stay blocked. Matching is suffix-based, so listing an apex domain
+# (e.g. "dynv6.net") also blocks every subdomain ("*.dynv6.net").
+#
+# Format: one registrable/apex domain per line, lowercase. Blank lines and
+# lines starting with "#" are ignored.
+#
+# Focus: free dynamic-DNS / free-subdomain providers (heavily abused for
+# throwaway signups, and only partially covered by the upstream disposable
+# list), plus specific domains seen abusing the amazee.ai AI trial.
+
+# --- Seen abusing the amazee.ai AI trial (moad #620) ---
+dynv6.net
+kozow.com
+baileybridge.org
+
+# --- Free dynamic-DNS / free-subdomain providers ---
+duckdns.org
+freemyip.com
+mooo.com
+afraid.org
+crabdance.com
+strangled.net
+twilightparadox.com
+us.to
+ignorelist.com
+chickenkiller.com
+# no-ip.com family
+no-ip.com
+no-ip.org
+no-ip.biz
+no-ip.info
+noip.com
+noip.me
+hopto.org
+zapto.org
+sytes.net
+ddns.net
+myftp.biz
+myftp.org
+serveblog.net
+servebeer.com
+servehttp.com
+serveftp.com
+servegame.com
+servehalflife.com
+serveminecraft.net
+servemp3.com
+servepics.com
+servequake.com
+redirectme.net
+webhop.me
+bounceme.net
+freedynamicdns.net
+freedynamicdns.org
+onthewifi.com
+myvnc.com

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -461,7 +461,9 @@ class DBAuditLog(Base):
     user_agent = Column(String, nullable=True)
     request_source = Column(String, nullable=True)  # Values: 'frontend', 'api', or None
     referer = Column(String, nullable=True)  # Referer header, query string stripped
-    origin = Column(String, nullable=True)  # Origin header, sanitized (scheme+host+port)
+    origin = Column(
+        String, nullable=True
+    )  # Origin header, sanitized (scheme+host+port)
 
     user = relationship("DBUser", back_populates="audit_logs")
 

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -739,3 +739,18 @@ class DBSignupEvent(Base):
     created_at = Column(
         DateTime(timezone=True), default=func.now(), nullable=False, index=True
     )
+
+
+class DBDisposableDomain(Base):
+    """Blocklist of disposable / dynamic-DNS email domains (trial-account abuse
+    protection, moad #620). Populated by the daily refresh cron from a committed
+    baseline merged with the upstream disposable-email-domains list. Signup paths
+    cross-check an email's domain (and its parent domains) against this table."""
+
+    __tablename__ = "disposable_domains"
+
+    domain = Column(String, primary_key=True)  # registrable/apex domain, lowercased
+    source = Column(String, nullable=True)  # "baseline" | "upstream"
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -721,3 +721,19 @@ class DBTeamSpendPeriodKey(Base):
             sqlite_where=text("key_id IS NULL"),
         ),
     )
+
+
+class DBSignupEvent(Base):
+    """Append-only log of anonymous signup attempts, used for per-IP velocity
+    limiting (trial-account abuse protection, moad #620). Not tied to a user/team
+    so it can be recorded before (and independently of) account creation."""
+
+    __tablename__ = "signup_events"
+
+    id = Column(Integer, primary_key=True, index=True)
+    ip_address = Column(String, nullable=True, index=True)
+    email = Column(String, nullable=True)
+    endpoint = Column(String, nullable=True)
+    created_at = Column(
+        DateTime(timezone=True), default=func.now(), nullable=False, index=True
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import os
 from contextlib import asynccontextmanager
@@ -58,51 +57,9 @@ class HTTPSRedirectMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
-async def _refresh_disposable_domains_periodically(interval_seconds: int):
-    """Background task: keep the disposable-domain list fresh."""
-    from app.services.disposable_domains import get_disposable_domain_service
-
-    service = get_disposable_domain_service()
-    while True:
-        try:
-            await asyncio.sleep(interval_seconds)
-            await service.refresh()
-        except asyncio.CancelledError:
-            break
-        except Exception:  # noqa: BLE001 - a bad refresh must not kill the loop
-            logging.getLogger(__name__).exception(
-                "Disposable domain refresh loop error"
-            )
-
-
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Load the disposable-domain list once at startup (baseline is available
-    # immediately; this pulls in the larger upstream list). Never block startup
-    # on a network failure — the service falls back to the committed baseline.
-    refresh_task = None
-    if settings.ENABLE_DISPOSABLE_EMAIL_BLOCKING:
-        from app.services.disposable_domains import get_disposable_domain_service
-
-        try:
-            await get_disposable_domain_service().refresh()
-        except Exception:  # noqa: BLE001
-            logging.getLogger(__name__).exception(
-                "Initial disposable domain load failed"
-            )
-        interval = max(1, settings.DISPOSABLE_DOMAINS_REFRESH_HOURS) * 3600
-        refresh_task = asyncio.create_task(
-            _refresh_disposable_domains_periodically(interval)
-        )
-    try:
-        yield
-    finally:
-        if refresh_task is not None:
-            refresh_task.cancel()
-            try:
-                await refresh_task
-            except asyncio.CancelledError:
-                pass
+    yield
 
 
 app = FastAPI(

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 from contextlib import asynccontextmanager
@@ -57,9 +58,47 @@ class HTTPSRedirectMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
+async def _refresh_disposable_domains_periodically(interval_seconds: int):
+    """Background task: keep the disposable-domain list fresh."""
+    from app.services.disposable_domains import get_disposable_domain_service
+
+    service = get_disposable_domain_service()
+    while True:
+        try:
+            await asyncio.sleep(interval_seconds)
+            await service.refresh()
+        except asyncio.CancelledError:
+            break
+        except Exception:  # noqa: BLE001 - a bad refresh must not kill the loop
+            logging.getLogger(__name__).exception("Disposable domain refresh loop error")
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    yield
+    # Load the disposable-domain list once at startup (baseline is available
+    # immediately; this pulls in the larger upstream list). Never block startup
+    # on a network failure — the service falls back to the committed baseline.
+    refresh_task = None
+    if settings.ENABLE_DISPOSABLE_EMAIL_BLOCKING:
+        from app.services.disposable_domains import get_disposable_domain_service
+
+        try:
+            await get_disposable_domain_service().refresh()
+        except Exception:  # noqa: BLE001
+            logging.getLogger(__name__).exception("Initial disposable domain load failed")
+        interval = max(1, settings.DISPOSABLE_DOMAINS_REFRESH_HOURS) * 3600
+        refresh_task = asyncio.create_task(
+            _refresh_disposable_domains_periodically(interval)
+        )
+    try:
+        yield
+    finally:
+        if refresh_task is not None:
+            refresh_task.cancel()
+            try:
+                await refresh_task
+            except asyncio.CancelledError:
+                pass
 
 
 app = FastAPI(

--- a/app/main.py
+++ b/app/main.py
@@ -70,7 +70,9 @@ async def _refresh_disposable_domains_periodically(interval_seconds: int):
         except asyncio.CancelledError:
             break
         except Exception:  # noqa: BLE001 - a bad refresh must not kill the loop
-            logging.getLogger(__name__).exception("Disposable domain refresh loop error")
+            logging.getLogger(__name__).exception(
+                "Disposable domain refresh loop error"
+            )
 
 
 @asynccontextmanager
@@ -85,7 +87,9 @@ async def lifespan(app: FastAPI):
         try:
             await get_disposable_domain_service().refresh()
         except Exception:  # noqa: BLE001
-            logging.getLogger(__name__).exception("Initial disposable domain load failed")
+            logging.getLogger(__name__).exception(
+                "Initial disposable domain load failed"
+            )
         interval = max(1, settings.DISPOSABLE_DOMAINS_REFRESH_HOURS) * 3600
         refresh_task = asyncio.create_task(
             _refresh_disposable_domains_periodically(interval)

--- a/app/migrations/versions/20260720_100000_b5c6d7e8f9a0_add_signup_events.py
+++ b/app/migrations/versions/20260720_100000_b5c6d7e8f9a0_add_signup_events.py
@@ -1,0 +1,56 @@
+"""add signup_events table for per-IP signup velocity limiting
+
+Revision ID: b5c6d7e8f9a0
+Revises: a3f2b1c0d9e8
+Create Date: 2026-07-20 10:00:00.000000+00:00
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "b5c6d7e8f9a0"
+down_revision: Union[str, None] = "a3f2b1c0d9e8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "signup_events",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("ip_address", sa.String(), nullable=True),
+        sa.Column("email", sa.String(), nullable=True),
+        sa.Column("endpoint", sa.String(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_signup_events_id"), "signup_events", ["id"])
+    op.create_index(
+        op.f("ix_signup_events_ip_address"), "signup_events", ["ip_address"]
+    )
+    op.create_index(
+        op.f("ix_signup_events_created_at"), "signup_events", ["created_at"]
+    )
+    # Composite index for the hot query: recent events by IP.
+    op.create_index(
+        "ix_signup_events_ip_created",
+        "signup_events",
+        ["ip_address", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_signup_events_ip_created", table_name="signup_events")
+    op.drop_index(op.f("ix_signup_events_created_at"), table_name="signup_events")
+    op.drop_index(op.f("ix_signup_events_ip_address"), table_name="signup_events")
+    op.drop_index(op.f("ix_signup_events_id"), table_name="signup_events")
+    op.drop_table("signup_events")

--- a/app/migrations/versions/20260720_100000_b5c6d7e8f9a0_add_signup_events.py
+++ b/app/migrations/versions/20260720_100000_b5c6d7e8f9a0_add_signup_events.py
@@ -6,16 +6,14 @@ Create Date: 2026-07-20 10:00:00.000000+00:00
 
 """
 
-from typing import Sequence, Union
+from typing import Union
 
 from alembic import op
 import sqlalchemy as sa
 
-# revision identifiers, used by Alembic.
+# revision identifiers, used by Alembic (read via module reflection).
 revision: str = "b5c6d7e8f9a0"
 down_revision: Union[str, None] = "a3f2b1c0d9e8"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:

--- a/app/migrations/versions/20260720_110000_c6d7e8f9a0b1_add_disposable_domains.py
+++ b/app/migrations/versions/20260720_110000_c6d7e8f9a0b1_add_disposable_domains.py
@@ -1,0 +1,74 @@
+"""add disposable_domains table (trial-account abuse protection) and seed baseline
+
+Revision ID: c6d7e8f9a0b1
+Revises: b5c6d7e8f9a0
+Create Date: 2026-07-20 11:00:00.000000+00:00
+
+The daily refresh cron repopulates this table from the upstream disposable list.
+We seed the committed baseline here so disposable domains are blocked immediately
+after deploy, before the first cron run.
+"""
+
+from pathlib import Path
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "c6d7e8f9a0b1"
+down_revision: Union[str, None] = "b5c6d7e8f9a0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# app/migrations/versions/<this> -> parents[2] == app/
+_BASELINE_FILE = (
+    Path(__file__).resolve().parents[2] / "data" / "disposable_domains_extra.txt"
+)
+
+
+def _baseline_domains() -> list[str]:
+    try:
+        lines = _BASELINE_FILE.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return []
+    out = set()
+    for raw in lines:
+        line = raw.strip().lower()
+        if not line or line.startswith("#"):
+            continue
+        if "@" in line:
+            line = line.rsplit("@", 1)[-1]
+        line = line.strip(".")
+        if line:
+            out.add(line)
+    return sorted(out)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "disposable_domains",
+        sa.Column("domain", sa.String(), nullable=False),
+        sa.Column("source", sa.String(), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("domain"),
+    )
+    domains = _baseline_domains()
+    if domains:
+        op.bulk_insert(
+            sa.table(
+                "disposable_domains",
+                sa.column("domain", sa.String),
+                sa.column("source", sa.String),
+            ),
+            [{"domain": d, "source": "baseline"} for d in domains],
+        )
+
+
+def downgrade() -> None:
+    op.drop_table("disposable_domains")

--- a/app/migrations/versions/20260720_110000_c6d7e8f9a0b1_add_disposable_domains.py
+++ b/app/migrations/versions/20260720_110000_c6d7e8f9a0b1_add_disposable_domains.py
@@ -10,16 +10,14 @@ after deploy, before the first cron run.
 """
 
 from pathlib import Path
-from typing import Sequence, Union
+from typing import Union
 
 from alembic import op
 import sqlalchemy as sa
 
-# revision identifiers, used by Alembic.
+# revision identifiers, used by Alembic (read via module reflection).
 revision: str = "c6d7e8f9a0b1"
 down_revision: Union[str, None] = "b5c6d7e8f9a0"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
 
 # app/migrations/versions/<this> -> parents[2] == app/
 _BASELINE_FILE = (

--- a/app/services/disposable_domains.py
+++ b/app/services/disposable_domains.py
@@ -1,32 +1,36 @@
-"""Disposable / dynamic-DNS email-domain blocking.
+"""Disposable / dynamic-DNS email-domain blocking (trial-account abuse protection, moad #620).
 
 Defense-in-depth for the amazee.ai backend: it must not blindly trust callers
-(moad, Drupal, direct API) to have filtered signup emails. This service holds an
-in-memory set of blocked apex domains and matches an email's domain against it
-using suffix matching, so blocking "dynv6.net" also blocks "*.dynv6.net".
+(moad, Drupal, direct API) to have filtered signup emails.
 
-Sources (merged):
-  1. A committed curated baseline (app/data/disposable_domains_extra.txt) plus
-     any domains from settings.DISPOSABLE_DOMAINS_EXTRA — the always-on guarantee.
-  2. The upstream disposable list fetched at startup and refreshed periodically
-     (settings.DISPOSABLE_DOMAINS_URL). If the fetch fails we keep the current
-     set and never fall back to an empty (fail-open) set.
+Design (mirrors the Keycloak plugin's practice, but persisted):
+  - The blocklist lives in the ``disposable_domains`` DB table (shared across pods).
+  - A cron job calls ``refresh_disposable_domains`` once per day to (re)populate it
+    from a committed baseline (dynv6.net + dynamic-DNS providers) merged with the
+    upstream ``disposable-email-domains`` list.
+  - Signup paths cross-check the email's domain against the table, with
+    suffix/subdomain matching so blocking ``dynv6.net`` also blocks ``a.b.dynv6.net``.
 """
 
 import logging
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Iterable
 
 import httpx
 from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
 
 from app.core.config import settings
+from app.db.models import DBDisposableDomain
 
 logger = logging.getLogger(__name__)
 
 _BASELINE_FILE = (
     Path(__file__).resolve().parent.parent / "data" / "disposable_domains_extra.txt"
 )
+
+SOURCE_BASELINE = "baseline"
+SOURCE_UPSTREAM = "upstream"
 
 
 def _parse_domains(lines: Iterable[str]) -> set[str]:
@@ -35,8 +39,7 @@ def _parse_domains(lines: Iterable[str]) -> set[str]:
         line = raw.strip().lower()
         if not line or line.startswith("#"):
             continue
-        # Defend against list entries that are full emails or have a leading "@".
-        if "@" in line:
+        if "@" in line:  # tolerate list entries that are full emails / have "@"
             line = line.rsplit("@", 1)[-1]
         line = line.strip(".")
         if line:
@@ -52,10 +55,11 @@ def extract_domain(email_or_domain: str) -> str:
     return value.strip().strip(".")
 
 
-def _candidate_suffixes(domain: str) -> list[str]:
+def candidate_suffixes(domain: str) -> list[str]:
     """Parent suffixes to test, e.g. a.b.dynv6.net -> [a.b.dynv6.net, b.dynv6.net, dynv6.net].
 
     Stops at the registrable-pair level (two labels); never returns a bare TLD.
+    This is what makes blocking an apex domain also block all of its subdomains.
     """
     labels = [p for p in domain.split(".") if p]
     if len(labels) < 2:
@@ -63,95 +67,107 @@ def _candidate_suffixes(domain: str) -> list[str]:
     return [".".join(labels[i:]) for i in range(0, len(labels) - 1)]
 
 
-class DisposableDomainService:
-    """Singleton holding the blocked-domain set. Reads are lock-free: refresh
-    swaps in a brand-new frozenset atomically."""
+def baseline_domains() -> set[str]:
+    """The committed custom baseline (file) plus DISPOSABLE_DOMAINS_EXTRA."""
+    domains: set[str] = set()
+    try:
+        domains |= _parse_domains(
+            _BASELINE_FILE.read_text(encoding="utf-8").splitlines()
+        )
+    except FileNotFoundError:
+        logger.warning("Disposable baseline file missing at %s", _BASELINE_FILE)
+    extra = settings.DISPOSABLE_DOMAINS_EXTRA or ""
+    domains |= _parse_domains(extra.replace(",", "\n").splitlines())
+    return domains
 
-    _instance: Optional["DisposableDomainService"] = None
 
-    def __init__(self) -> None:
-        self._baseline: frozenset[str] = frozenset()
-        self._domains: frozenset[str] = frozenset()
-        self._loaded_remote = False
-        self._load_baseline()
+def _fetch_upstream_domains(url: str) -> set[str]:
+    """Fetch and parse the upstream disposable-domains list. Raises on HTTP error."""
+    with httpx.Client(timeout=30.0) as client:
+        resp = client.get(url)
+        resp.raise_for_status()
+        return _parse_domains(resp.text.splitlines())
 
-    @classmethod
-    def get_instance(cls) -> "DisposableDomainService":
-        if cls._instance is None:
-            cls._instance = cls()
-        return cls._instance
 
-    def _load_baseline(self) -> None:
-        baseline: set[str] = set()
+def refresh_disposable_domains(db: Session) -> dict:
+    """(Re)populate the disposable_domains table. Intended to run from the daily cron.
+
+    - Baseline (committed file + env) is always ensured.
+    - The upstream list is merged in when reachable.
+    - On upstream failure the existing table is preserved (never emptied); we only
+      ensure the baseline rows are present. Returns a small summary dict.
+    """
+    baseline = baseline_domains()
+    url = settings.DISPOSABLE_DOMAINS_URL
+    remote: set[str] = set()
+    upstream_ok = True
+
+    if url:
         try:
-            baseline |= _parse_domains(
-                _BASELINE_FILE.read_text(encoding="utf-8").splitlines()
-            )
-        except FileNotFoundError:
-            logger.warning("Disposable baseline file missing at %s", _BASELINE_FILE)
-        extra = settings.DISPOSABLE_DOMAINS_EXTRA or ""
-        baseline |= _parse_domains(extra.replace(",", "\n").splitlines())
-        self._baseline = frozenset(baseline)
-        # Start with at least the baseline so blocking works before the first refresh.
-        if not self._domains:
-            self._domains = self._baseline
-        logger.info("Disposable baseline loaded: %d domains", len(self._baseline))
-
-    async def refresh(self, client: Optional[httpx.AsyncClient] = None) -> bool:
-        """Fetch the upstream list and merge with the baseline. Returns True on
-        success. On failure keeps the existing set (never fail-open)."""
-        url = settings.DISPOSABLE_DOMAINS_URL
-        if not url:
-            self._domains = self._baseline
-            return True
-        owns_client = client is None
-        try:
-            client = client or httpx.AsyncClient(timeout=15.0)
-            resp = await client.get(url)
-            resp.raise_for_status()
-            remote = _parse_domains(resp.text.splitlines())
+            remote = _fetch_upstream_domains(url)
             if not remote:
                 raise ValueError("upstream list was empty")
-            self._domains = frozenset(self._baseline | remote)
-            self._loaded_remote = True
-            logger.info(
-                "Disposable domains refreshed: %d total (%d upstream + %d baseline)",
-                len(self._domains),
-                len(remote),
-                len(self._baseline),
-            )
-            return True
-        except Exception as exc:  # noqa: BLE001 - never let a refresh failure break signups
+        except Exception as exc:  # noqa: BLE001 - refresh must never crash the cron
+            upstream_ok = False
             logger.warning(
-                "Disposable domain refresh failed (%s); keeping %d domains",
-                exc,
-                len(self._domains),
+                "Disposable upstream fetch failed (%s); preserving table", exc
             )
-            return False
-        finally:
-            if owns_client and client is not None:
-                await client.aclose()
 
-    def is_blocked(self, email_or_domain: str) -> bool:
-        if not settings.ENABLE_DISPOSABLE_EMAIL_BLOCKING:
-            return False
-        domain = extract_domain(email_or_domain)
-        if not domain:
-            return False
-        return any(suffix in self._domains for suffix in _candidate_suffixes(domain))
+    if upstream_ok:
+        full = baseline | remote
+        # Replace the table in one transaction: readers see the old rows until commit,
+        # so there is never an empty (fail-open) window.
+        db.query(DBDisposableDomain).delete()
+        db.bulk_insert_mappings(
+            DBDisposableDomain,
+            [
+                {
+                    "domain": d,
+                    "source": SOURCE_BASELINE if d in baseline else SOURCE_UPSTREAM,
+                }
+                for d in full
+            ],
+        )
+        db.commit()
+        logger.info(
+            "Disposable domains refreshed: %d total (%d upstream + %d baseline)",
+            len(full),
+            len(remote),
+            len(baseline),
+        )
+        return {"total": len(full), "upstream": len(remote), "baseline": len(baseline)}
 
-    @property
-    def size(self) -> int:
-        return len(self._domains)
+    # Upstream failed: keep whatever is there, just make sure baseline is present.
+    existing = {row[0] for row in db.query(DBDisposableDomain.domain).all()}
+    to_add = baseline - existing
+    if to_add:
+        db.bulk_insert_mappings(
+            DBDisposableDomain,
+            [{"domain": d, "source": SOURCE_BASELINE} for d in to_add],
+        )
+        db.commit()
+    return {"total": len(existing | baseline), "upstream": 0, "baseline": len(baseline)}
 
 
-def get_disposable_domain_service() -> DisposableDomainService:
-    return DisposableDomainService.get_instance()
+def is_blocked(db: Session, email_or_domain: str) -> bool:
+    """True if the email/domain (or any parent domain) is in the disposable table."""
+    if not settings.ENABLE_DISPOSABLE_EMAIL_BLOCKING:
+        return False
+    domain = extract_domain(email_or_domain)
+    suffixes = candidate_suffixes(domain)
+    if not suffixes:
+        return False
+    hit = (
+        db.query(DBDisposableDomain.domain)
+        .filter(DBDisposableDomain.domain.in_(suffixes))
+        .first()
+    )
+    return hit is not None
 
 
-def assert_email_domain_allowed(email: str) -> None:
+def assert_email_domain_allowed(db: Session, email: str) -> None:
     """Raise 422 if the email's domain is a known disposable / dynamic-DNS domain."""
-    if get_disposable_domain_service().is_blocked(email):
+    if is_blocked(db, email):
         logger.info(
             "Blocked signup for disposable email domain: %s", extract_domain(email)
         )

--- a/app/services/disposable_domains.py
+++ b/app/services/disposable_domains.py
@@ -24,7 +24,9 @@ from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
-_BASELINE_FILE = Path(__file__).resolve().parent.parent / "data" / "disposable_domains_extra.txt"
+_BASELINE_FILE = (
+    Path(__file__).resolve().parent.parent / "data" / "disposable_domains_extra.txt"
+)
 
 
 def _parse_domains(lines: Iterable[str]) -> set[str]:
@@ -82,7 +84,9 @@ class DisposableDomainService:
     def _load_baseline(self) -> None:
         baseline: set[str] = set()
         try:
-            baseline |= _parse_domains(_BASELINE_FILE.read_text(encoding="utf-8").splitlines())
+            baseline |= _parse_domains(
+                _BASELINE_FILE.read_text(encoding="utf-8").splitlines()
+            )
         except FileNotFoundError:
             logger.warning("Disposable baseline file missing at %s", _BASELINE_FILE)
         extra = settings.DISPOSABLE_DOMAINS_EXTRA or ""
@@ -112,12 +116,17 @@ class DisposableDomainService:
             self._loaded_remote = True
             logger.info(
                 "Disposable domains refreshed: %d total (%d upstream + %d baseline)",
-                len(self._domains), len(remote), len(self._baseline),
+                len(self._domains),
+                len(remote),
+                len(self._baseline),
             )
             return True
         except Exception as exc:  # noqa: BLE001 - never let a refresh failure break signups
-            logger.warning("Disposable domain refresh failed (%s); keeping %d domains",
-                           exc, len(self._domains))
+            logger.warning(
+                "Disposable domain refresh failed (%s); keeping %d domains",
+                exc,
+                len(self._domains),
+            )
             return False
         finally:
             if owns_client and client is not None:
@@ -143,7 +152,9 @@ def get_disposable_domain_service() -> DisposableDomainService:
 def assert_email_domain_allowed(email: str) -> None:
     """Raise 422 if the email's domain is a known disposable / dynamic-DNS domain."""
     if get_disposable_domain_service().is_blocked(email):
-        logger.info("Blocked signup for disposable email domain: %s", extract_domain(email))
+        logger.info(
+            "Blocked signup for disposable email domain: %s", extract_domain(email)
+        )
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="Invalid email domain.",

--- a/app/services/disposable_domains.py
+++ b/app/services/disposable_domains.py
@@ -1,0 +1,150 @@
+"""Disposable / dynamic-DNS email-domain blocking.
+
+Defense-in-depth for the amazee.ai backend: it must not blindly trust callers
+(moad, Drupal, direct API) to have filtered signup emails. This service holds an
+in-memory set of blocked apex domains and matches an email's domain against it
+using suffix matching, so blocking "dynv6.net" also blocks "*.dynv6.net".
+
+Sources (merged):
+  1. A committed curated baseline (app/data/disposable_domains_extra.txt) plus
+     any domains from settings.DISPOSABLE_DOMAINS_EXTRA — the always-on guarantee.
+  2. The upstream disposable list fetched at startup and refreshed periodically
+     (settings.DISPOSABLE_DOMAINS_URL). If the fetch fails we keep the current
+     set and never fall back to an empty (fail-open) set.
+"""
+
+import logging
+from pathlib import Path
+from typing import Iterable, Optional
+
+import httpx
+from fastapi import HTTPException, status
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+_BASELINE_FILE = Path(__file__).resolve().parent.parent / "data" / "disposable_domains_extra.txt"
+
+
+def _parse_domains(lines: Iterable[str]) -> set[str]:
+    domains: set[str] = set()
+    for raw in lines:
+        line = raw.strip().lower()
+        if not line or line.startswith("#"):
+            continue
+        # Defend against list entries that are full emails or have a leading "@".
+        if "@" in line:
+            line = line.rsplit("@", 1)[-1]
+        line = line.strip(".")
+        if line:
+            domains.add(line)
+    return domains
+
+
+def extract_domain(email_or_domain: str) -> str:
+    """Return the lowercased domain part of an email (or a bare domain)."""
+    value = (email_or_domain or "").strip().lower()
+    if "@" in value:
+        value = value.rsplit("@", 1)[-1]
+    return value.strip().strip(".")
+
+
+def _candidate_suffixes(domain: str) -> list[str]:
+    """Parent suffixes to test, e.g. a.b.dynv6.net -> [a.b.dynv6.net, b.dynv6.net, dynv6.net].
+
+    Stops at the registrable-pair level (two labels); never returns a bare TLD.
+    """
+    labels = [p for p in domain.split(".") if p]
+    if len(labels) < 2:
+        return [domain] if domain else []
+    return [".".join(labels[i:]) for i in range(0, len(labels) - 1)]
+
+
+class DisposableDomainService:
+    """Singleton holding the blocked-domain set. Reads are lock-free: refresh
+    swaps in a brand-new frozenset atomically."""
+
+    _instance: Optional["DisposableDomainService"] = None
+
+    def __init__(self) -> None:
+        self._baseline: frozenset[str] = frozenset()
+        self._domains: frozenset[str] = frozenset()
+        self._loaded_remote = False
+        self._load_baseline()
+
+    @classmethod
+    def get_instance(cls) -> "DisposableDomainService":
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    def _load_baseline(self) -> None:
+        baseline: set[str] = set()
+        try:
+            baseline |= _parse_domains(_BASELINE_FILE.read_text(encoding="utf-8").splitlines())
+        except FileNotFoundError:
+            logger.warning("Disposable baseline file missing at %s", _BASELINE_FILE)
+        extra = settings.DISPOSABLE_DOMAINS_EXTRA or ""
+        baseline |= _parse_domains(extra.replace(",", "\n").splitlines())
+        self._baseline = frozenset(baseline)
+        # Start with at least the baseline so blocking works before the first refresh.
+        if not self._domains:
+            self._domains = self._baseline
+        logger.info("Disposable baseline loaded: %d domains", len(self._baseline))
+
+    async def refresh(self, client: Optional[httpx.AsyncClient] = None) -> bool:
+        """Fetch the upstream list and merge with the baseline. Returns True on
+        success. On failure keeps the existing set (never fail-open)."""
+        url = settings.DISPOSABLE_DOMAINS_URL
+        if not url:
+            self._domains = self._baseline
+            return True
+        owns_client = client is None
+        try:
+            client = client or httpx.AsyncClient(timeout=15.0)
+            resp = await client.get(url)
+            resp.raise_for_status()
+            remote = _parse_domains(resp.text.splitlines())
+            if not remote:
+                raise ValueError("upstream list was empty")
+            self._domains = frozenset(self._baseline | remote)
+            self._loaded_remote = True
+            logger.info(
+                "Disposable domains refreshed: %d total (%d upstream + %d baseline)",
+                len(self._domains), len(remote), len(self._baseline),
+            )
+            return True
+        except Exception as exc:  # noqa: BLE001 - never let a refresh failure break signups
+            logger.warning("Disposable domain refresh failed (%s); keeping %d domains",
+                           exc, len(self._domains))
+            return False
+        finally:
+            if owns_client and client is not None:
+                await client.aclose()
+
+    def is_blocked(self, email_or_domain: str) -> bool:
+        if not settings.ENABLE_DISPOSABLE_EMAIL_BLOCKING:
+            return False
+        domain = extract_domain(email_or_domain)
+        if not domain:
+            return False
+        return any(suffix in self._domains for suffix in _candidate_suffixes(domain))
+
+    @property
+    def size(self) -> int:
+        return len(self._domains)
+
+
+def get_disposable_domain_service() -> DisposableDomainService:
+    return DisposableDomainService.get_instance()
+
+
+def assert_email_domain_allowed(email: str) -> None:
+    """Raise 422 if the email's domain is a known disposable / dynamic-DNS domain."""
+    if get_disposable_domain_service().is_blocked(email):
+        logger.info("Blocked signup for disposable email domain: %s", extract_domain(email))
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Invalid email domain.",
+        )

--- a/app/services/signup_velocity.py
+++ b/app/services/signup_velocity.py
@@ -71,7 +71,10 @@ def enforce_signup_velocity(
     if recent >= settings.SIGNUP_MAX_PER_IP_PER_WINDOW:
         logger.warning(
             "Signup velocity cap hit: ip=%s recent=%d cap=%d endpoint=%s",
-            ip, recent, settings.SIGNUP_MAX_PER_IP_PER_WINDOW, endpoint,
+            ip,
+            recent,
+            settings.SIGNUP_MAX_PER_IP_PER_WINDOW,
+            endpoint,
         )
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,

--- a/app/services/signup_velocity.py
+++ b/app/services/signup_velocity.py
@@ -68,6 +68,13 @@ def enforce_signup_velocity(
     db.add(DBSignupEvent(ip_address=ip, email=email, endpoint=endpoint))
     db.commit()
 
+    # NOTE: the count above and the insert here are not atomic, so the cap is a
+    # soft limit, not a hard one. Under a burst of concurrent requests from one
+    # IP, several can observe recent == cap - 1 before any commits, letting a
+    # handful through at the boundary. This is acceptable for abuse mitigation
+    # (impact is bounded to a few extra signups) and is the trade-off of a
+    # DB-backed limiter without Redis / SELECT ... FOR UPDATE. Do not assume this
+    # blocks exactly SIGNUP_MAX_PER_IP_PER_WINDOW attempts.
     if recent >= settings.SIGNUP_MAX_PER_IP_PER_WINDOW:
         logger.warning(
             "Signup velocity cap hit: ip=%s recent=%d cap=%d endpoint=%s",
@@ -80,3 +87,27 @@ def enforce_signup_velocity(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail="Too many signup attempts from this network. Please try again later.",
         )
+
+
+def prune_signup_events(db: Session) -> int:
+    """Delete signup_events older than the retention window. Returns rows removed.
+
+    The table is append-only and grows one row per signup attempt, so under
+    sustained abuse (the scenario this feature targets) it would accumulate
+    indefinitely without cleanup. Only recent rows matter for the velocity
+    query, so anything older than SIGNUP_EVENTS_RETENTION_DAYS can be dropped.
+    Intended to run from the daily cron alongside the disposable-domain refresh.
+    """
+    cutoff = datetime.now(UTC) - timedelta(days=settings.SIGNUP_EVENTS_RETENTION_DAYS)
+    deleted = (
+        db.query(DBSignupEvent)
+        .filter(DBSignupEvent.created_at < cutoff)
+        .delete(synchronize_session=False)
+    )
+    db.commit()
+    logger.info(
+        "Pruned %d signup_events older than %d day(s)",
+        deleted,
+        settings.SIGNUP_EVENTS_RETENTION_DAYS,
+    )
+    return deleted

--- a/app/services/signup_velocity.py
+++ b/app/services/signup_velocity.py
@@ -1,0 +1,79 @@
+"""Per-IP signup velocity limiting (trial-account abuse protection, moad #620).
+
+The public, unauthenticated signup endpoints (validate-email, sign-in, register,
+generate-trial-access) can create users/teams for anyone. A single actor created
+dozens of trial teams in a day. This caps how many signup attempts one client IP
+may make within a rolling window, backed by the append-only ``signup_events``
+table (no Redis in this backend; the shared DB keeps the cap correct across pods).
+
+Per-IP (not per-email-domain) is deliberate: legit users share providers like
+gmail.com, and moad tags trial emails as ``base+<team_id>@<real-domain>``, so a
+per-domain cap would false-positive on shared domains.
+"""
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Optional
+
+from fastapi import HTTPException, Request, status
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.db.models import DBSignupEvent
+
+logger = logging.getLogger(__name__)
+
+
+def client_ip(request: Optional[Request]) -> Optional[str]:
+    """Best-effort client IP. Consistent with the audit middleware: uvicorn is
+    started with --forwarded-allow-ips, so request.client already reflects the
+    real client behind the ingress."""
+    if request is None or request.client is None:
+        return None
+    return request.client.host
+
+
+def enforce_signup_velocity(
+    request: Optional[Request],
+    db: Session,
+    email: Optional[str] = None,
+    endpoint: Optional[str] = None,
+) -> None:
+    """Record the signup attempt and raise 429 if this IP is over its per-window cap.
+
+    The attempt is always recorded (append-only), so sustained abuse keeps the
+    window saturated. Missing IPs (unknown client) are not limited, only logged.
+    """
+    if not settings.ENABLE_SIGNUP_VELOCITY_LIMIT:
+        return
+
+    ip = client_ip(request)
+    if not ip:
+        logger.warning("Signup velocity: no client IP for endpoint=%s", endpoint)
+        return
+
+    window_start = datetime.now(UTC) - timedelta(
+        minutes=settings.SIGNUP_VELOCITY_WINDOW_MINUTES
+    )
+    recent = (
+        db.query(DBSignupEvent)
+        .filter(
+            DBSignupEvent.ip_address == ip,
+            DBSignupEvent.created_at >= window_start,
+        )
+        .count()
+    )
+
+    # Always record the attempt (keeps the window saturated under hammering).
+    db.add(DBSignupEvent(ip_address=ip, email=email, endpoint=endpoint))
+    db.commit()
+
+    if recent >= settings.SIGNUP_MAX_PER_IP_PER_WINDOW:
+        logger.warning(
+            "Signup velocity cap hit: ip=%s recent=%d cap=%d endpoint=%s",
+            ip, recent, settings.SIGNUP_MAX_PER_IP_PER_WINDOW, endpoint,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many signup attempts from this network. Please try again later.",
+        )

--- a/scripts/trigger_prune_signup_events_job.py
+++ b/scripts/trigger_prune_signup_events_job.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import logging
+
+# Add the parent directory to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from sqlalchemy.orm import sessionmaker
+from app.db.database import engine
+from app.core.locking import try_acquire_lock, release_lock
+from app.services.signup_velocity import prune_signup_events
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+LOCK_NAME = "prune_signup_events"
+
+
+def main():
+    """Prune old rows from the append-only signup_events table.
+
+    Runs daily via the Lagoon cron. Uses the shared advisory lock so overlapping
+    runs (or a manual trigger) don't clobber each other.
+    """
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = SessionLocal()
+    try:
+        if not try_acquire_lock(LOCK_NAME, db, lock_timeout=10):
+            logger.warning(
+                "Another process holds the %s lock; skipping this run", LOCK_NAME
+            )
+            sys.exit(0)
+        try:
+            logger.info("Pruning old signup_events...")
+            deleted = prune_signup_events(db)
+            logger.info("✅ Pruned %d signup_events", deleted)
+        finally:
+            release_lock(LOCK_NAME, db)
+    except Exception as e:  # noqa: BLE001
+        logger.error("❌ signup_events prune failed: %s", str(e))
+        sys.exit(1)
+    finally:
+        db.close()
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/trigger_refresh_disposable_domains_job.py
+++ b/scripts/trigger_refresh_disposable_domains_job.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import logging
+
+# Add the parent directory to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from sqlalchemy.orm import sessionmaker
+from app.db.database import engine
+from app.core.locking import try_acquire_lock, release_lock
+from app.services.disposable_domains import refresh_disposable_domains
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+LOCK_NAME = "refresh_disposable_domains"
+
+
+def main():
+    """Refresh the disposable_domains table from the upstream list + baseline.
+
+    Runs daily via the Lagoon cron. Uses the shared advisory lock so overlapping
+    runs (or a manual trigger) don't clobber each other.
+    """
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = SessionLocal()
+    try:
+        if not try_acquire_lock(LOCK_NAME, db, lock_timeout=10):
+            logger.warning(
+                "Another process holds the %s lock; skipping this run", LOCK_NAME
+            )
+            sys.exit(0)
+        try:
+            logger.info("Refreshing disposable domains...")
+            summary = refresh_disposable_domains(db)
+            logger.info("✅ Disposable domains refreshed: %s", summary)
+        finally:
+            release_lock(LOCK_NAME, db)
+    except Exception as e:  # noqa: BLE001
+        logger.error("❌ Disposable domains refresh failed: %s", str(e))
+        sys.exit(1)
+    finally:
+        db.close()
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,14 @@ os.environ["AMAZEEAI_JWT_SECRET"] = "test-secret-key-for-tests-0123456789abcdef"
 # Swagger route and break tests. Per-test prod checks set settings.ENV_SUFFIX
 # directly (see tests/test_security.py), not this env var.
 os.environ["ENV_SUFFIX"] = "local"
+# Tests must not hit the network on app startup. Empty URL makes the disposable
+# domain service use only the committed baseline (which includes the abuse
+# domains under test) instead of fetching the upstream list.
+os.environ["DISPOSABLE_DOMAINS_URL"] = ""
+# The per-IP signup velocity cap is a global rate limit; leave it off for the
+# suite (like ENABLE_LIMITS) so it can't throttle unrelated tests. Tests that
+# exercise it enable it explicitly via monkeypatch.
+os.environ["ENABLE_SIGNUP_VELOCITY_LIMIT"] = "false"
 
 import pytest
 from fastapi.testclient import TestClient

--- a/tests/test_disposable_domains.py
+++ b/tests/test_disposable_domains.py
@@ -44,9 +44,10 @@ def test_refresh_seeds_baseline_into_db(db):
     summary = refresh_disposable_domains(db)  # URL="" -> baseline only
     assert summary["baseline"] > 0
     rows = {r[0] for r in db.query(DBDisposableDomain.domain).all()}
-    assert "dynv6.net" in rows
-    assert "kozow.com" in rows
-    assert "baileybridge.org" in rows
+    # set-membership, not URL sanitization — use issubset so CodeQL's
+    # py/incomplete-url-substring-sanitization heuristic doesn't misfire on
+    # `"<host>" in rows`.
+    assert {"dynv6.net", "kozow.com", "baileybridge.org"}.issubset(rows)
 
 
 def test_is_blocked_subdomain_matching(db):

--- a/tests/test_disposable_domains.py
+++ b/tests/test_disposable_domains.py
@@ -1,16 +1,24 @@
-"""Tests for disposable / dynamic-DNS email-domain blocking (moad #620, Layer 1)."""
+"""Tests for disposable / dynamic-DNS email-domain blocking (moad #620, Layer 1).
+
+The blocklist lives in the disposable_domains table, populated by
+refresh_disposable_domains() and cross-checked (with subdomain matching) at signup.
+Tests set DISPOSABLE_DOMAINS_URL="" (conftest) so refresh uses only the committed
+baseline unless a test monkeypatches the upstream fetch.
+"""
 
 import pytest
+from fastapi import HTTPException
 
 from app.core.config import settings
+from app.db.models import DBDisposableDomain
+from app.services import disposable_domains as dd
 from app.services.disposable_domains import (
-    DisposableDomainService,
-    _candidate_suffixes,
     assert_email_domain_allowed,
+    candidate_suffixes,
     extract_domain,
-    get_disposable_domain_service,
+    is_blocked,
+    refresh_disposable_domains,
 )
-from fastapi import HTTPException
 
 
 def test_extract_domain():
@@ -22,55 +30,81 @@ def test_extract_domain():
 
 
 def test_candidate_suffixes():
-    assert _candidate_suffixes("a.b.dynv6.net") == [
+    assert candidate_suffixes("a.b.dynv6.net") == [
         "a.b.dynv6.net",
         "b.dynv6.net",
         "dynv6.net",
     ]
-    assert _candidate_suffixes("dynv6.net") == ["dynv6.net"]
-    assert _candidate_suffixes("localhost") == ["localhost"]
-    assert _candidate_suffixes("") == []
+    assert candidate_suffixes("dynv6.net") == ["dynv6.net"]
+    assert candidate_suffixes("localhost") == ["localhost"]
+    assert candidate_suffixes("") == []
 
 
-def test_is_blocked_subdomain_matching():
-    svc = DisposableDomainService()
-    svc._domains = frozenset({"dynv6.net"})
-    # apex and any subdomain depth
-    assert svc.is_blocked("x@dynv6.net")
-    assert svc.is_blocked("x@msn-mail-free-6326.dynv6.net")
-    assert svc.is_blocked("x@a.b.c.dynv6.net")
-    # label-boundary matching: a look-alike apex must NOT match
-    assert not svc.is_blocked("x@notdynv6.net")
-    assert not svc.is_blocked("x@dynv6.net.evil.com")
-    assert not svc.is_blocked("x@example.com")
+def test_refresh_seeds_baseline_into_db(db):
+    summary = refresh_disposable_domains(db)  # URL="" -> baseline only
+    assert summary["baseline"] > 0
+    rows = {r[0] for r in db.query(DBDisposableDomain.domain).all()}
+    assert "dynv6.net" in rows
+    assert "kozow.com" in rows
+    assert "baileybridge.org" in rows
 
 
-def test_committed_baseline_blocks_known_abusers():
-    svc = get_disposable_domain_service()
-    assert svc.is_blocked("bot@sub.dynv6.net")
-    assert svc.is_blocked("bot@vip.baileybridge.org")
-    assert svc.is_blocked("bot@wzry.ntfdhujik.kozow.com")
-    # a normal domain is allowed
-    assert not svc.is_blocked("real.person@gmail.com")
+def test_is_blocked_subdomain_matching(db):
+    refresh_disposable_domains(db)  # seeds baseline (incl. dynv6.net)
+    # apex and any subdomain depth are blocked
+    assert is_blocked(db, "x@dynv6.net")
+    assert is_blocked(db, "x@msn-mail-free-6326.dynv6.net")
+    assert is_blocked(db, "x@a.b.c.dynv6.net")
+    # label-boundary matching: look-alikes must NOT match
+    assert not is_blocked(db, "x@notdynv6.net")
+    assert not is_blocked(db, "x@dynv6.net.evil.com")
+    assert not is_blocked(db, "real.person@gmail.com")
 
 
-def test_blocking_can_be_disabled(monkeypatch):
-    monkeypatch.setattr(settings, "ENABLE_DISPOSABLE_EMAIL_BLOCKING", False)
-    svc = DisposableDomainService()
-    svc._domains = frozenset({"dynv6.net"})
-    assert not svc.is_blocked("x@dynv6.net")
+def test_refresh_merges_upstream(db, monkeypatch):
+    monkeypatch.setattr(settings, "DISPOSABLE_DOMAINS_URL", "http://upstream.test/list")
+    monkeypatch.setattr(
+        dd, "_fetch_upstream_domains", lambda url: {"foo-disposable.test"}
+    )
+    summary = refresh_disposable_domains(db)
+    assert summary["upstream"] == 1
+    # both the upstream entry (and its subdomains) and the baseline are blocked
+    assert is_blocked(db, "a@sub.foo-disposable.test")
+    assert is_blocked(db, "a@dynv6.net")
 
 
-def test_assert_email_domain_allowed_raises_422():
+def test_refresh_preserves_table_on_upstream_failure(db, monkeypatch):
+    refresh_disposable_domains(db)  # seed baseline first
+    before = db.query(DBDisposableDomain).count()
+
+    def boom(url):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(settings, "DISPOSABLE_DOMAINS_URL", "http://upstream.test/list")
+    monkeypatch.setattr(dd, "_fetch_upstream_domains", boom)
+    refresh_disposable_domains(db)  # must not wipe the table
+    assert db.query(DBDisposableDomain).count() >= before
+    assert is_blocked(db, "a@dynv6.net")
+
+
+def test_assert_email_domain_allowed(db):
+    refresh_disposable_domains(db)
     with pytest.raises(HTTPException) as exc:
-        assert_email_domain_allowed("bot@sub.dynv6.net")
+        assert_email_domain_allowed(db, "bot@sub.dynv6.net")
     assert exc.value.status_code == 422
     assert exc.value.detail == "Invalid email domain."
     # allowed domain does not raise
-    assert_email_domain_allowed("real@gmail.com")
+    assert_email_domain_allowed(db, "real@gmail.com")
 
 
-def test_validate_email_endpoint_blocks_disposable_domain(client):
+def test_blocking_can_be_disabled(db, monkeypatch):
+    refresh_disposable_domains(db)
+    monkeypatch.setattr(settings, "ENABLE_DISPOSABLE_EMAIL_BLOCKING", False)
+    assert not is_blocked(db, "x@dynv6.net")
+
+
+def test_validate_email_endpoint_blocks_disposable_domain(client, db):
+    refresh_disposable_domains(db)  # same session the endpoint uses (see conftest)
     resp = client.post(
         "/auth/validate-email",
         json={"email": "bot@msn-mail-free-6326.dynv6.net"},

--- a/tests/test_disposable_domains.py
+++ b/tests/test_disposable_domains.py
@@ -1,0 +1,79 @@
+"""Tests for disposable / dynamic-DNS email-domain blocking (moad #620, Layer 1)."""
+
+import pytest
+
+from app.core.config import settings
+from app.services.disposable_domains import (
+    DisposableDomainService,
+    _candidate_suffixes,
+    assert_email_domain_allowed,
+    extract_domain,
+    get_disposable_domain_service,
+)
+from fastapi import HTTPException
+
+
+def test_extract_domain():
+    assert extract_domain("Alice@B.DYNV6.net") == "b.dynv6.net"
+    assert extract_domain("dynv6.net") == "dynv6.net"
+    assert extract_domain("user+12938@sub.example.com") == "sub.example.com"
+    assert extract_domain("  x@y.com. ") == "y.com"
+    assert extract_domain("") == ""
+
+
+def test_candidate_suffixes():
+    assert _candidate_suffixes("a.b.dynv6.net") == [
+        "a.b.dynv6.net",
+        "b.dynv6.net",
+        "dynv6.net",
+    ]
+    assert _candidate_suffixes("dynv6.net") == ["dynv6.net"]
+    assert _candidate_suffixes("localhost") == ["localhost"]
+    assert _candidate_suffixes("") == []
+
+
+def test_is_blocked_subdomain_matching():
+    svc = DisposableDomainService()
+    svc._domains = frozenset({"dynv6.net"})
+    # apex and any subdomain depth
+    assert svc.is_blocked("x@dynv6.net")
+    assert svc.is_blocked("x@msn-mail-free-6326.dynv6.net")
+    assert svc.is_blocked("x@a.b.c.dynv6.net")
+    # label-boundary matching: a look-alike apex must NOT match
+    assert not svc.is_blocked("x@notdynv6.net")
+    assert not svc.is_blocked("x@dynv6.net.evil.com")
+    assert not svc.is_blocked("x@example.com")
+
+
+def test_committed_baseline_blocks_known_abusers():
+    svc = get_disposable_domain_service()
+    assert svc.is_blocked("bot@sub.dynv6.net")
+    assert svc.is_blocked("bot@vip.baileybridge.org")
+    assert svc.is_blocked("bot@wzry.ntfdhujik.kozow.com")
+    # a normal domain is allowed
+    assert not svc.is_blocked("real.person@gmail.com")
+
+
+def test_blocking_can_be_disabled(monkeypatch):
+    monkeypatch.setattr(settings, "ENABLE_DISPOSABLE_EMAIL_BLOCKING", False)
+    svc = DisposableDomainService()
+    svc._domains = frozenset({"dynv6.net"})
+    assert not svc.is_blocked("x@dynv6.net")
+
+
+def test_assert_email_domain_allowed_raises_422():
+    with pytest.raises(HTTPException) as exc:
+        assert_email_domain_allowed("bot@sub.dynv6.net")
+    assert exc.value.status_code == 422
+    assert exc.value.detail == "Invalid email domain."
+    # allowed domain does not raise
+    assert_email_domain_allowed("real@gmail.com")
+
+
+def test_validate_email_endpoint_blocks_disposable_domain(client):
+    resp = client.post(
+        "/auth/validate-email",
+        json={"email": "bot@msn-mail-free-6326.dynv6.net"},
+    )
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "Invalid email domain."

--- a/tests/test_signup_velocity.py
+++ b/tests/test_signup_velocity.py
@@ -1,0 +1,65 @@
+"""Tests for per-IP signup velocity limiting (moad #620, Layer 2)."""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.core.config import settings
+from app.db.models import DBSignupEvent
+from app.services.signup_velocity import client_ip, enforce_signup_velocity
+
+
+def _req(ip):
+    return SimpleNamespace(client=SimpleNamespace(host=ip) if ip else None)
+
+
+def test_client_ip():
+    assert client_ip(_req("1.2.3.4")) == "1.2.3.4"
+    assert client_ip(_req(None)) is None
+    assert client_ip(None) is None
+
+
+def test_velocity_allows_up_to_cap_then_blocks(db, monkeypatch):
+    monkeypatch.setattr(settings, "ENABLE_SIGNUP_VELOCITY_LIMIT", True)
+    monkeypatch.setattr(settings, "SIGNUP_MAX_PER_IP_PER_WINDOW", 2)
+    monkeypatch.setattr(settings, "SIGNUP_VELOCITY_WINDOW_MINUTES", 60)
+    req = _req("9.9.9.9")
+
+    # cap=2 -> first two pass, third is blocked
+    enforce_signup_velocity(req, db, email="a@x.com", endpoint="t")
+    enforce_signup_velocity(req, db, email="b@x.com", endpoint="t")
+    with pytest.raises(HTTPException) as exc:
+        enforce_signup_velocity(req, db, email="c@x.com", endpoint="t")
+    assert exc.value.status_code == 429
+
+    # all attempts (including the blocked one) are recorded
+    assert db.query(DBSignupEvent).filter(DBSignupEvent.ip_address == "9.9.9.9").count() == 3
+
+
+def test_velocity_is_per_ip(db, monkeypatch):
+    monkeypatch.setattr(settings, "ENABLE_SIGNUP_VELOCITY_LIMIT", True)
+    monkeypatch.setattr(settings, "SIGNUP_MAX_PER_IP_PER_WINDOW", 1)
+    # one IP hits its cap
+    enforce_signup_velocity(_req("10.0.0.1"), db, endpoint="t")
+    with pytest.raises(HTTPException):
+        enforce_signup_velocity(_req("10.0.0.1"), db, endpoint="t")
+    # a different IP is unaffected
+    enforce_signup_velocity(_req("10.0.0.2"), db, endpoint="t")
+
+
+def test_velocity_disabled_is_noop(db, monkeypatch):
+    monkeypatch.setattr(settings, "ENABLE_SIGNUP_VELOCITY_LIMIT", False)
+    monkeypatch.setattr(settings, "SIGNUP_MAX_PER_IP_PER_WINDOW", 1)
+    req = _req("8.8.8.8")
+    for _ in range(5):
+        enforce_signup_velocity(req, db, endpoint="t")  # never raises
+    assert db.query(DBSignupEvent).filter(DBSignupEvent.ip_address == "8.8.8.8").count() == 0
+
+
+def test_velocity_no_ip_is_not_limited(db, monkeypatch):
+    monkeypatch.setattr(settings, "ENABLE_SIGNUP_VELOCITY_LIMIT", True)
+    monkeypatch.setattr(settings, "SIGNUP_MAX_PER_IP_PER_WINDOW", 1)
+    for _ in range(3):
+        enforce_signup_velocity(_req(None), db, endpoint="t")  # unknown IP: skip, never raise
+    assert db.query(DBSignupEvent).count() == 0

--- a/tests/test_signup_velocity.py
+++ b/tests/test_signup_velocity.py
@@ -34,7 +34,10 @@ def test_velocity_allows_up_to_cap_then_blocks(db, monkeypatch):
     assert exc.value.status_code == 429
 
     # all attempts (including the blocked one) are recorded
-    assert db.query(DBSignupEvent).filter(DBSignupEvent.ip_address == "9.9.9.9").count() == 3
+    assert (
+        db.query(DBSignupEvent).filter(DBSignupEvent.ip_address == "9.9.9.9").count()
+        == 3
+    )
 
 
 def test_velocity_is_per_ip(db, monkeypatch):
@@ -54,12 +57,17 @@ def test_velocity_disabled_is_noop(db, monkeypatch):
     req = _req("8.8.8.8")
     for _ in range(5):
         enforce_signup_velocity(req, db, endpoint="t")  # never raises
-    assert db.query(DBSignupEvent).filter(DBSignupEvent.ip_address == "8.8.8.8").count() == 0
+    assert (
+        db.query(DBSignupEvent).filter(DBSignupEvent.ip_address == "8.8.8.8").count()
+        == 0
+    )
 
 
 def test_velocity_no_ip_is_not_limited(db, monkeypatch):
     monkeypatch.setattr(settings, "ENABLE_SIGNUP_VELOCITY_LIMIT", True)
     monkeypatch.setattr(settings, "SIGNUP_MAX_PER_IP_PER_WINDOW", 1)
     for _ in range(3):
-        enforce_signup_velocity(_req(None), db, endpoint="t")  # unknown IP: skip, never raise
+        enforce_signup_velocity(
+            _req(None), db, endpoint="t"
+        )  # unknown IP: skip, never raise
     assert db.query(DBSignupEvent).count() == 0

--- a/tests/test_signup_velocity.py
+++ b/tests/test_signup_velocity.py
@@ -1,5 +1,6 @@
 """Tests for per-IP signup velocity limiting (moad #620, Layer 2)."""
 
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 import pytest
@@ -7,7 +8,11 @@ from fastapi import HTTPException
 
 from app.core.config import settings
 from app.db.models import DBSignupEvent
-from app.services.signup_velocity import client_ip, enforce_signup_velocity
+from app.services.signup_velocity import (
+    client_ip,
+    enforce_signup_velocity,
+    prune_signup_events,
+)
 
 
 def _req(ip):
@@ -71,3 +76,21 @@ def test_velocity_no_ip_is_not_limited(db, monkeypatch):
             _req(None), db, endpoint="t"
         )  # unknown IP: skip, never raise
     assert db.query(DBSignupEvent).count() == 0
+
+
+def test_prune_removes_only_old_rows(db, monkeypatch):
+    monkeypatch.setattr(settings, "SIGNUP_EVENTS_RETENTION_DAYS", 7)
+    now = datetime.now(UTC)
+    fresh = DBSignupEvent(ip_address="1.1.1.1", endpoint="t")
+    fresh.created_at = now - timedelta(days=1)
+    old = DBSignupEvent(ip_address="2.2.2.2", endpoint="t")
+    old.created_at = now - timedelta(days=10)
+    db.add_all([fresh, old])
+    db.commit()
+
+    deleted = prune_signup_events(db)
+
+    assert deleted == 1
+    remaining = db.query(DBSignupEvent).all()
+    assert len(remaining) == 1
+    assert remaining[0].ip_address == "1.1.1.1"

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -848,9 +848,7 @@ def test_remove_user_not_in_team(client, admin_token, test_user):
     assert "User is not a member of any team" in response.json()["detail"]
 
 
-def test_team_admin_can_remove_same_team_user(
-    client, team_admin_token, test_team_user
-):
+def test_team_admin_can_remove_same_team_user(client, team_admin_token, test_team_user):
     """
     Test that a team admin can remove a member of their own team.
 

--- a/tests/test_trial_access.py
+++ b/tests/test_trial_access.py
@@ -130,7 +130,9 @@ async def test_generate_trial_access(mock_auth_deps, db: Session):
     # Mock Response object
     mock_response = Mock(spec=Response)
 
-    result = await generate_trial_access(mock_response, mock_db, mock_limit_service)
+    result = await generate_trial_access(
+        Mock(), mock_response, mock_db, mock_limit_service
+    )
 
     assert result.user.id == 1
     assert result.team_id == 12
@@ -219,7 +221,7 @@ async def test_generate_trial_access_cleanup_on_key_creation_failure(
     mock_response = Mock(spec=Response)
 
     with pytest.raises(HTTPException) as exc_info:
-        await generate_trial_access(mock_response, mock_db, mock_limit_service)
+        await generate_trial_access(Mock(), mock_response, mock_db, mock_limit_service)
 
     assert exc_info.value.status_code == expected_status
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1018,9 +1018,7 @@ def test_admin_update_user_rejects_password_fields(client, admin_token, test_use
     assert response.status_code == 422
 
 
-def test_team_admin_cannot_change_is_active(
-    client, team_admin_token, test_team_user
-):
+def test_team_admin_cannot_change_is_active(client, team_admin_token, test_team_user):
     """
     A team admin may manage their own team members but not toggle activation.
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR implements two layers of trial-account abuse protection: (1) a DB-backed blocklist of disposable/dynamic-DNS email domains checked at every signup path, refreshed daily from an upstream list merged with a committed baseline; and (2) a per-IP rolling-window velocity cap on unauthenticated signup endpoints, backed by the new `signup_events` table with a daily prune cron.

- **Layer 1 — domain blocking**: `assert_email_domain_allowed` is applied at `validate_email`, `register_team`, and `_create_user_in_db` (defense-in-depth), with subdomain suffix-matching so blocking `dynv6.net` also blocks `*.dynv6.net`. Refresh is fail-safe: upstream outage preserves the existing table rather than wiping it.
- **Layer 2 — velocity cap**: `enforce_signup_velocity` guards all four unauthenticated endpoints; the attempt is always recorded so sustained abuse keeps the window saturated. The `signup_events` table now has a daily prune cron, addressing the unbounded-growth concern from the previous review.
- **Minor ordering inconsistency**: `validate_email` checks the domain before recording a velocity event (correct); `register` records the velocity event first, then the domain check fires inside `_create_user_in_db`. This means a disposable-domain attempt directly to `register` consumes a velocity slot before being rejected — see inline comment.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both abuse-protection layers are well-structured, migrations chain correctly, and the prune cron addresses the previously-flagged unbounded table growth.

The domain blocking and velocity limiting are independently correct, with clear fail-safe behavior on upstream outage. The only substantive finding is a minor ordering inconsistency in the `register` endpoint (velocity recorded before domain check), which does not create a security hole but is worth fixing for consistency with `validate_email`.

app/api/auth.py — the `register` endpoint records a velocity event before the domain check fires; the inline suggestion covers the fix.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/services/disposable_domains.py | New service: domain extraction, subdomain-suffix matching, DB-backed blocklist refresh with fail-safe on upstream outage, and assert_email_domain_allowed guard. Logic is correct; refresh uses a single transaction so readers never see an empty table. |
| app/services/signup_velocity.py | New service: per-IP rolling-window velocity cap backed by signup_events table, plus daily prune helper. TOCTOU softness and table-growth risks are documented in code; prune cron now addresses the unbounded-growth concern from previous review. |
| app/api/auth.py | Added velocity limiting to register, sign-in auto-provision, validate-email, and generate-trial-access. validate-email correctly checks domain before recording velocity; register/sign-in record velocity before the domain check (inside _create_user_in_db), a minor ordering inconsistency. |
| app/api/teams.py | Added assert_email_domain_allowed on admin_email at the register_team entry point; correctly placed before team-already-exists check. |
| app/api/users.py | Added assert_email_domain_allowed at the top of _create_user_in_db, the narrowest user-creation choke point, covering all creation paths. |
| app/migrations/versions/20260720_100000_b5c6d7e8f9a0_add_signup_events.py | Creates signup_events table with individual and composite (ip_address, created_at) indexes; down_revision correctly chains off a3f2b1c0d9e8. |
| app/migrations/versions/20260720_110000_c6d7e8f9a0b1_add_disposable_domains.py | Creates disposable_domains table and seeds the committed baseline, ensuring blocks are active immediately after deploy before the first cron run. |
| app/db/models.py | Added DBSignupEvent and DBDisposableDomain ORM models. DBSignupEvent uses default=func.now() (SQL expression) while migration uses server_default=func.now(); both resolve server-side and behave consistently. |
| app/core/config.py | Added feature-flag settings for both abuse-protection layers with safe defaults (enabled in prod, both overridable via env). |
| .lagoon.yml | Added refresh-disposable-domains (02:00 daily) and prune-signup-events (02:30 daily) crons to both environments; correct staggering avoids overlapping runs. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Client
    participant VE as validate-email
    participant R as register
    participant DD as DisposableDomains
    participant SV as SignupVelocity
    participant DB as Database

    Note over C,DB: validate-email flow (domain first, then velocity)
    C->>VE: POST /auth/validate-email
    VE->>DD: assert_email_domain_allowed()
    DD->>DB: SELECT disposable_domains IN(suffixes)
    alt domain blocked
        DD-->>C: 422 Invalid email domain
    else domain OK
        VE->>SV: enforce_signup_velocity()
        SV->>DB: COUNT signup_events (ip, window)
        SV->>DB: INSERT signup_event + COMMIT
        alt over cap
            SV-->>C: 429 Too many attempts
        else under cap
            VE->>C: OTP sent
        end
    end

    Note over C,DB: register flow (velocity first, domain check inside _create_user_in_db)
    C->>R: POST /auth/register
    R->>SV: enforce_signup_velocity()
    SV->>DB: COUNT + INSERT signup_event + COMMIT
    alt over cap
        SV-->>C: 429 Too many attempts
    else under cap
        R->>DD: assert_email_domain_allowed() [inside _create_user_in_db]
        alt domain blocked
            DD-->>C: 422 Invalid email domain
        else domain OK
            R->>DB: INSERT user
            R-->>C: 201 user created
        end
    end

    Note over C,DB: daily cron jobs
    DB->>DB: refresh_disposable_domains() — DELETE + bulk INSERT domains
    DB->>DB: prune_signup_events() — DELETE events older than retention window
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Client
    participant VE as validate-email
    participant R as register
    participant DD as DisposableDomains
    participant SV as SignupVelocity
    participant DB as Database

    Note over C,DB: validate-email flow (domain first, then velocity)
    C->>VE: POST /auth/validate-email
    VE->>DD: assert_email_domain_allowed()
    DD->>DB: SELECT disposable_domains IN(suffixes)
    alt domain blocked
        DD-->>C: 422 Invalid email domain
    else domain OK
        VE->>SV: enforce_signup_velocity()
        SV->>DB: COUNT signup_events (ip, window)
        SV->>DB: INSERT signup_event + COMMIT
        alt over cap
            SV-->>C: 429 Too many attempts
        else under cap
            VE->>C: OTP sent
        end
    end

    Note over C,DB: register flow (velocity first, domain check inside _create_user_in_db)
    C->>R: POST /auth/register
    R->>SV: enforce_signup_velocity()
    SV->>DB: COUNT + INSERT signup_event + COMMIT
    alt over cap
        SV-->>C: 429 Too many attempts
    else under cap
        R->>DD: assert_email_domain_allowed() [inside _create_user_in_db]
        alt domain blocked
            DD-->>C: 422 Invalid email domain
        else domain OK
            R->>DB: INSERT user
            R-->>C: 201 user created
        end
    end

    Note over C,DB: daily cron jobs
    DB->>DB: refresh_disposable_domains() — DELETE + bulk INSERT domains
    DB->>DB: prune_signup_events() — DELETE events older than retention window
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/services/signup_velocity.py`, line 58-84 ([link](https://github.com/amazeeio/amazee.ai/blob/72dd4d2e54b4cfe64939ab13ca91619185eee018/app/services/signup_velocity.py#L58-L84)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **signup_events table grows unboundedly**

   The `signup_events` table accumulates one row per signup attempt with no pruning job. The velocity query is efficient (composite index on `ip_address, created_at`), but the table itself is never trimmed. Under sustained abuse — the exact scenario this feature targets — the table could accumulate millions of rows, driving up storage costs and index maintenance overhead over weeks of operation. A background cleanup (e.g., periodically deleting rows older than a few velocity windows) should be added alongside the daily disposable-domain refresh cron.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["chore: address Greptile PR #625 review f..."](https://github.com/amazeeio/amazee.ai/commit/72a9f1b4d554e0b613ebd847baffba116dfbde16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45583217)</sub>

<!-- /greptile_comment -->