### PR TITLE
fix(billing): recover from LiteLLM sync failures in top-up & /cycle (#617)

### DIFF
--- a/app/api/budgets.py
+++ b/app/api/budgets.py
@@ -376,7 +376,24 @@ async def purchase_pool_budget(
                 detail="A purchase with this stripe_payment_id already exists",
             )
         # Prior attempt was sync_failed — clean up the stale records so the
-        # full purchase flow runs fresh and commits atomically.
+        # full purchase flow runs fresh and commits atomically. Also remove any
+        # lingering topup ledger entry for this stripe_payment_id: deleting the
+        # payment only SET NULLs the ledger's source_payment_id (FK ondelete),
+        # so the ledger row would otherwise survive and block the retry via the
+        # duplicate guard / unique constraint (issue #617A).
+        stale_ledger_entries = (
+            db.query(DBPeriodicBudgetLedgerEntry)
+            .filter(
+                DBPeriodicBudgetLedgerEntry.team_id == team_id,
+                DBPeriodicBudgetLedgerEntry.region_id == region_id,
+                DBPeriodicBudgetLedgerEntry.entry_type == "topup",
+                DBPeriodicBudgetLedgerEntry.stripe_payment_id
+                == purchase.stripe_payment_id,
+            )
+            .all()
+        )
+        for stale_entry in stale_ledger_entries:
+            db.delete(stale_entry)
         db.delete(matching_payment)
         db.delete(existing_purchase)
         db.flush()
@@ -647,14 +664,17 @@ async def purchase_periodic_topup(
                     region_id,
                     str(rollback_exc),
                 )
-        # Top-up purchase failed to reach LiteLLM; do not keep allocatable
-        # balance in the periodic ledger for this failed API purchase.
+        # Top-up purchase failed to reach LiteLLM. Delete the ledger entry
+        # rather than deactivating it (issue #617A): a leftover row — even
+        # inactive — permanently blocks a retry with the same
+        # stripe_payment_id, because the duplicate guards above and in
+        # add_topup_entry match on stripe_payment_id with no is_active filter,
+        # and the unique constraint (team_id, region_id, entry_type,
+        # stripe_payment_id) would reject a fresh insert anyway. Audit
+        # visibility of the failed attempt is preserved on payment_record
+        # (sync_failed + error_log), which the retry paths reuse.
         if topup_entry is not None:
-            # Keep audit visibility but ensure failed top-up cannot contribute
-            # to future allocatable balance.
-            topup_entry.is_active = False
-            topup_entry.consumed_cents = topup_entry.amount_cents
-            db.add(topup_entry)
+            db.delete(topup_entry)
             db.flush()
         payment_record.sync_status = "sync_failed"
         payment_record.error_log = (

--- a/app/api/subscription.py
+++ b/app/api/subscription.py
@@ -209,10 +209,10 @@ async def subscription_cycle(
                 },
             )
             logger.error(
-                "subscription.cycle sync failed: team_id=%s transaction_id=%s errors=%s",
+                "subscription.cycle sync failed: team_id=%s transaction_id=%s sync_error_count=%s",
                 team.id,
                 request.transaction_id,
-                sync_errors,
+                len(sync_errors) if hasattr(sync_errors, "__len__") else 1,
             )
             raise HTTPException(
                 status_code=502,

--- a/app/api/subscription.py
+++ b/app/api/subscription.py
@@ -183,6 +183,42 @@ async def subscription_cycle(
             source_payment_id=payment_id,
         )
 
+        # A LiteLLM sync failure is collected into sync_errors rather than
+        # raised (see apply_billing_cycle_for_team), and the payment is stamped
+        # sync_failed. If we returned 200 here the caller (MOAD's Stripe webhook)
+        # would treat the cycle as applied and never retry, silently leaving the
+        # team's budget un-provisioned until the next monthly cycle (issue
+        # #617B). Return a non-2xx so MOAD retries; the payment stays in a
+        # resubmittable sync_failed state (the idempotency guard only
+        # short-circuits on sync_status == "success"), so a re-driven cycle
+        # re-applies the budget.
+        if sync_errors:
+            _write_audit_log(
+                db,
+                "subscription.cycle",
+                "cycle",
+                str(team.id),
+                502,
+                {
+                    "transaction_id": request.transaction_id,
+                    "budget_cents": request.budget_cents,
+                    "region_id": request.region_id,
+                    "is_first_cycle": is_first_cycle,
+                    "sync_errors": sync_errors,
+                    "outcome": "sync_failed",
+                },
+            )
+            logger.error(
+                "subscription.cycle sync failed: team_id=%s transaction_id=%s errors=%s",
+                team.id,
+                request.transaction_id,
+                sync_errors,
+            )
+            raise HTTPException(
+                status_code=502,
+                detail="LiteLLM sync failed during subscription cycle; retry",
+            )
+
         _write_audit_log(
             db,
             "subscription.cycle",

--- a/tests/test_periodic_payments.py
+++ b/tests/test_periodic_payments.py
@@ -373,6 +373,46 @@ def test_subscription_cycle_endpoint_first_cycle(
     "app.api.subscription.capture_periodic_team_spend_for_period",
     new_callable=AsyncMock,
 )
+def test_subscription_cycle_endpoint_returns_5xx_on_sync_errors(
+    mock_capture,
+    mock_sync_ledger,
+    mock_apply_cycle,
+    mock_record_payment,
+    client,
+    admin_token,
+    test_team,
+    test_region,
+):
+    """Issue #617B: when apply_billing_cycle_for_team reports LiteLLM sync
+    errors, /cycle must return a non-2xx so MOAD's Stripe webhook retries —
+    not a silent 200 that strands the team's budget until the next cycle."""
+    mock_apply_cycle.return_value = [
+        "Failed to update team 1 budget in region test: LiteLLM down"
+    ]
+    mock_record_payment.return_value = 789
+
+    response = client.post(
+        "/billing/subscription/cycle",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "transaction_id": "txn_cycle_sync_fail",
+            "budget_cents": 10000,
+            "team_id": test_team.id,
+            "region_id": test_region.id,
+        },
+    )
+
+    assert response.status_code == 502
+    mock_apply_cycle.assert_awaited_once()
+
+
+@patch("app.api.subscription._record_periodic_payment_direct", new_callable=AsyncMock)
+@patch("app.api.subscription.apply_billing_cycle_for_team", new_callable=AsyncMock)
+@patch("app.api.subscription._sync_periodic_ledger_for_period", new_callable=AsyncMock)
+@patch(
+    "app.api.subscription.capture_periodic_team_spend_for_period",
+    new_callable=AsyncMock,
+)
 def test_subscription_cycle_endpoint_existing_cycle_runs_snapshot_and_ledger(
     mock_capture,
     mock_sync_ledger,

--- a/tests/test_pool_purchases.py
+++ b/tests/test_pool_purchases.py
@@ -414,6 +414,157 @@ def test_create_periodic_topup_marks_sync_failed_on_litellm_error(
     assert "failed" in (payment.error_log or "").lower()
 
 
+def test_create_periodic_topup_retry_after_sync_failure_succeeds(
+    client, admin_token, db, test_team, test_region
+):
+    """Issue #617A: a top-up whose LiteLLM sync failed must be resubmittable
+    with the same stripe_payment_id. The failed attempt must not leave a ledger
+    entry behind (which would block the retry with a permanent 409)."""
+    test_team.budget_type = "periodic"
+    db.commit()
+
+    stripe_id = f"cs_periodic_retry_{int(time.time() * 1000000)}"
+    payload = {
+        "amount_cents": 5000,
+        "currency": "usd",
+        "purchased_at": "2026-03-13T10:00:00Z",
+        "stripe_payment_id": stripe_id,
+    }
+    url = f"/budgets/region/{test_region.id}/teams/{test_team.id}/purchase/periodic"
+    headers = {"Authorization": f"Bearer {admin_token}"}
+
+    # First attempt: LiteLLM sync fails -> 502, payment stamped sync_failed.
+    with patch("app.api.budgets.LiteLLMService") as mock_litellm:
+        mock_instance = mock_litellm.return_value
+        mock_instance.get_team_info = AsyncMock(side_effect=Exception("region down"))
+        mock_instance.update_team_budget = AsyncMock()
+        first = client.post(url, json=payload, headers=headers)
+    assert first.status_code == 502
+
+    # The failed ledger entry must not linger — it would otherwise trip the
+    # duplicate guard / unique constraint on the retry.
+    leftover = (
+        db.query(DBPeriodicBudgetLedgerEntry)
+        .filter(
+            DBPeriodicBudgetLedgerEntry.stripe_payment_id == stripe_id,
+            DBPeriodicBudgetLedgerEntry.entry_type == "topup",
+        )
+        .all()
+    )
+    assert leftover == []
+
+    # Second attempt with the SAME stripe_payment_id: LiteLLM healthy -> applied.
+    with patch("app.api.budgets.LiteLLMService") as mock_litellm:
+        mock_instance = mock_litellm.return_value
+        mock_instance.get_team_info = AsyncMock(
+            return_value={"team_info": {"spend": 0.0}}
+        )
+        mock_instance.update_team_budget = AsyncMock()
+        second = client.post(url, json=payload, headers=headers)
+    assert second.status_code == 201, second.text
+
+    entry = (
+        db.query(DBPeriodicBudgetLedgerEntry)
+        .filter(
+            DBPeriodicBudgetLedgerEntry.stripe_payment_id == stripe_id,
+            DBPeriodicBudgetLedgerEntry.entry_type == "topup",
+        )
+        .one()
+    )
+    assert entry.is_active is True
+    assert entry.amount_cents == 5000
+    payment = (
+        db.query(DBPeriodicPayment)
+        .filter(DBPeriodicPayment.stripe_payment_id == stripe_id)
+        .first()
+    )
+    assert payment.sync_status == "success"
+
+
+def test_pool_purchase_retry_removes_lingering_ledger_entry(
+    client, admin_token, db, test_team, test_region
+):
+    """Issue #617A: purchase_pool_budget's retry cleanup must delete a lingering
+    topup ledger entry from a prior sync_failed attempt. Deleting the payment
+    only SET NULLs the ledger's source_payment_id (FK ondelete), so without
+    explicit cleanup the ledger row survives and blocks the retry (permanent
+    409)."""
+    test_team.budget_type = "pool"
+    db.commit()
+
+    stripe_id = f"pi_pool_stale_{int(time.time() * 1000000)}"
+
+    # Simulate the rows a prior sync_failed pool purchase would leave behind.
+    payment = DBPeriodicPayment(
+        team_id=test_team.id,
+        stripe_payment_id=stripe_id,
+        amount_cents=5000,
+        currency="usd",
+        payment_type="topup",
+        status="completed",
+        sync_status="sync_failed",
+        payment_date=datetime.now(UTC),
+    )
+    db.add(payment)
+    db.flush()
+    db.add(
+        DBPoolPurchase(
+            team_id=test_team.id,
+            region_id=test_region.id,
+            amount_cents=5000,
+            currency="usd",
+            purchased_at=datetime.now(UTC),
+            stripe_payment_id=stripe_id,
+            created_at=datetime.now(UTC),
+        )
+    )
+    db.add(
+        DBPeriodicBudgetLedgerEntry(
+            team_id=test_team.id,
+            region_id=test_region.id,
+            entry_type="topup",
+            source_payment_id=payment.id,
+            stripe_payment_id=stripe_id,
+            amount_cents=5000,
+            consumed_cents=5000,
+            purchased_at=datetime.now(UTC),
+            is_active=False,
+        )
+    )
+    db.commit()
+
+    with patch("app.api.budgets.LiteLLMService") as mock_litellm:
+        mock_instance = mock_litellm.return_value
+        mock_instance.get_team_info = AsyncMock(
+            return_value={"team_info": {"spend": 0.0}}
+        )
+        mock_instance.update_team_budget = AsyncMock()
+        response = client.post(
+            f"/budgets/region/{test_region.id}/teams/{test_team.id}/purchase",
+            json={
+                "amount_cents": 5000,
+                "currency": "usd",
+                "purchased_at": "2026-03-13T10:00:00Z",
+                "stripe_payment_id": stripe_id,
+            },
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+    assert response.status_code == 201, response.text
+
+    entries = (
+        db.query(DBPeriodicBudgetLedgerEntry)
+        .filter(
+            DBPeriodicBudgetLedgerEntry.stripe_payment_id == stripe_id,
+            DBPeriodicBudgetLedgerEntry.entry_type == "topup",
+        )
+        .all()
+    )
+    # The stale row is gone; exactly one active entry from the fresh run remains.
+    assert len(entries) == 1
+    assert entries[0].is_active is True
+
+
 def test_create_periodic_topup_expiry_anchors_to_last_topup_date(
     client, admin_token, db, test_team, test_region
 ):


### PR DESCRIPTION
## What & why

Fixes the two billing-correctness defects tracked in amazeeio/moad#617. Both live in this repo (amazee.ai) but the affected endpoints are driven live by MOAD's Stripe webhook. In both cases a transient LiteLLM outage during a paid flow left the customer's budget un-provisioned with no automatic recovery.

### Issue A — paid top-up / pool purchase permanently unrecoverable (409)

On a LiteLLM sync failure, `purchase_periodic_topup` marked the top-up ledger entry `is_active=False` but **kept** it and committed. On retry with the same `stripe_payment_id`, the duplicate guards (in `purchase_periodic_topup` and `add_topup_entry`) and the `UniqueConstraint(team_id, region_id, entry_type, stripe_payment_id)` all match with **no `is_active` filter** → permanent `409`. Stripe captured the payment, LiteLLM never got the budget, and the API could never re-apply it. This also contradicted the endpoint's own documented promise that a `sync_failed` purchase is resubmittable.

**Fix:**
- Delete the failed ledger entry instead of deactivating it, so a retry runs fresh. Audit visibility is preserved on the `sync_failed` `DBPeriodicPayment` (`error_log`), which the retry paths reuse.
- Extend `purchase_pool_budget`'s retry cleanup to also remove any lingering ledger entry — deleting the payment only `SET NULL`s the ledger's `source_payment_id` FK, leaving the row to block the retry.

### Issue B — `/cycle` silently returned 200 on sync failure

`apply_billing_cycle_for_team` collects LiteLLM errors into a `sync_errors` list and stamps the payment `sync_failed` rather than raising. But `/cycle` never inspected `sync_errors` — it always returned `200 "outcome": "success"`. MOAD treats 200 as success and never retries, so the team's budget silently stayed un-provisioned until the next monthly cycle (or the 31-day budget-duration expiry). State was already retry-safe; nothing re-drove it.

**Fix:** return `502` from `/cycle` when `sync_errors` is non-empty so MOAD retries. The payment stays in a resubmittable `sync_failed` state (the idempotency guard only short-circuits on `sync_status == "success"`).

## Tests

New regression tests (all green; full `test_pool_purchases` + `test_periodic_payments` suites pass — 88 passed, 2 pre-existing skips):
- `test_create_periodic_topup_retry_after_sync_failure_succeeds` — periodic top-up: sync failure → retry applies the budget, no leftover ledger row.
- `test_pool_purchase_retry_removes_lingering_ledger_entry` — pool path: a lingering `sync_failed` ledger entry is cleaned up so the retry succeeds.
- `test_subscription_cycle_endpoint_returns_5xx_on_sync_errors` — `/cycle` returns 502 (not 200) when sync errors are reported.

## Acceptance criteria (from moad#617)

- [x] **A:** retry with same `stripe_payment_id` re-runs the full flow instead of 409 — both `create_periodic_topup` and `purchase_pool_budget`.
- [x] **A:** duplicate guard no longer blocks on a failed entry; `purchase_pool_budget` cleanup removes the associated ledger entry.
- [x] **B:** `/cycle` returns non-2xx when `sync_errors` is non-empty; payment stays resubmittable `sync_failed`.
- [x] Behaviour matches the documented `sync_failed`-is-resubmittable intent.
- [x] Regression tests for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two billing-correctness bugs where a transient LiteLLM outage during a paid flow left the customer's budget un-provisioned with no automatic recovery path.

- **Issue A (top-up/pool purchase permanently unrecoverable):** `purchase_periodic_topup` now **deletes** the failed ledger entry on sync failure (instead of deactivating it) so a retry with the same `stripe_payment_id` finds no blocking row. `purchase_pool_budget`'s retry cleanup is extended to also remove any lingering ledger entry before flushing, since the FK `ondelete=SET NULL` only NULLs `source_payment_id` and leaves the row intact.
- **Issue B (`/cycle` silently returned 200 on sync failure):** after `apply_billing_cycle_for_team` returns `sync_errors`, the `/cycle` endpoint now writes a 502 audit log entry and raises `HTTPException(502)` so MOAD retries, rather than returning a silent 200 that left the team's budget unprovisioned until the next monthly cycle.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. Both billing fixes are precise and well-bounded: the ledger entry delete-vs-deactivate swap in purchase_periodic_topup, the complementary cleanup in purchase_pool_budget, and the 502 propagation in /cycle are all idempotent and leave the DB in a clean, retry-safe state.

The changes are surgical, each touching only the failure path of its respective function. The retry logic was already correct in design; this PR closes the two gaps (a lingering ledger row and a swallowed sync error) that prevented it from working. All three new regression tests exercise the concrete failure scenarios end-to-end and assert the correct post-conditions. _write_audit_log self-commits, so the 502 audit log survives the HTTPException raised immediately after. No new DB schema changes or migration concerns.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/budgets.py | Two targeted fixes: (1) deletes the ledger entry on LiteLLM sync failure in purchase_periodic_topup instead of deactivating it, and (2) explicitly removes stale ledger entries for the same stripe_payment_id in purchase_pool_budget's retry cleanup path. Both changes are correct and well-commented. |
| app/api/subscription.py | Adds a sync_errors check after apply_billing_cycle_for_team; on non-empty errors, writes a 502 audit log (self-committed by _write_audit_log) and raises HTTPException(502) so MOAD retries. The existing except HTTPException: raise guard correctly re-propagates the 502. |
| tests/test_periodic_payments.py | Adds test_subscription_cycle_endpoint_returns_5xx_on_sync_errors, which mocks apply_billing_cycle_for_team to return a non-empty error list and asserts the endpoint returns 502. Test correctly uses AsyncMock for all async collaborators. |
| tests/test_pool_purchases.py | Adds two integration-style regression tests: retry-after-sync-failure for the periodic topup path (verifies no leftover ledger row), and pool purchase retry that seeds a stale ledger entry and verifies it is cleaned up so the retry succeeds with exactly one active entry. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant MOAD as MOAD (Stripe webhook)
    participant API as amazee.ai API
    participant DB as PostgreSQL
    participant LLM as LiteLLM

    note over MOAD,LLM: First attempt — LiteLLM is down

    MOAD->>API: POST /cycle OR purchase topup
    API->>DB: flush payment record (sync_failed), flush ledger entry
    API->>LLM: update_team_budget()
    LLM-->>API: ❌ Exception
    API->>DB: DELETE ledger entry (not deactivate)
    API->>DB: COMMIT payment (sync_failed + error_log)
    API-->>MOAD: 502 Bad Gateway

    note over MOAD,LLM: LiteLLM recovers — MOAD retries

    MOAD->>API: POST /cycle OR purchase topup (same stripe_payment_id)
    API->>DB: lookup existing_topup → None (was deleted) ✓
    API->>DB: reuse sync_failed payment record
    API->>DB: flush new ledger entry
    API->>LLM: update_team_budget()
    LLM-->>API: ✅ Success
    API->>DB: COMMIT payment (success) + new ledger entry
    API-->>MOAD: 201 / 200 OK
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant MOAD as MOAD (Stripe webhook)
    participant API as amazee.ai API
    participant DB as PostgreSQL
    participant LLM as LiteLLM

    note over MOAD,LLM: First attempt — LiteLLM is down

    MOAD->>API: POST /cycle OR purchase topup
    API->>DB: flush payment record (sync_failed), flush ledger entry
    API->>LLM: update_team_budget()
    LLM-->>API: ❌ Exception
    API->>DB: DELETE ledger entry (not deactivate)
    API->>DB: COMMIT payment (sync_failed + error_log)
    API-->>MOAD: 502 Bad Gateway

    note over MOAD,LLM: LiteLLM recovers — MOAD retries

    MOAD->>API: POST /cycle OR purchase topup (same stripe_payment_id)
    API->>DB: lookup existing_topup → None (was deleted) ✓
    API->>DB: reuse sync_failed payment record
    API->>DB: flush new ledger entry
    API->>LLM: update_team_budget()
    LLM-->>API: ✅ Success
    API->>DB: COMMIT payment (success) + new ledger entry
    API-->>MOAD: 201 / 200 OK
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Potential fix for pull request finding &#39;..."](https://github.com/amazeeio/amazee.ai/commit/479c5403e006f94e6f05c79012ba42c398abaa05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45594233)</sub>

<!-- /greptile_comment -->