### PR TITLE
Admin UI: audit log date filters, show-deleted toggles, region edit fixes

### DIFF
--- a/app/api/audit.py
+++ b/app/api/audit.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, Query, HTTPException, status
 from sqlalchemy.orm import Session
 from typing import Optional
-from datetime import datetime
+from datetime import datetime, UTC
 from sqlalchemy import distinct, cast, String, or_
 from app.db.database import get_db
 from app.api.auth import get_current_user_from_auth
@@ -16,6 +16,12 @@ import logging
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["audit"])
+
+
+def _as_naive_utc(dt: datetime) -> datetime:
+    # DBAuditLog.timestamp is stored as naive UTC; normalize tz-aware
+    # query params so comparisons don't depend on the server timezone.
+    return dt.astimezone(UTC).replace(tzinfo=None) if dt.tzinfo else dt
 
 
 @router.get("/logs", response_model=PaginatedAuditLogResponse)
@@ -63,9 +69,9 @@ async def get_audit_logs(
         if user_email:
             query = query.filter(DBUser.email.ilike(f"%{user_email}%"))
         if from_date:
-            query = query.filter(DBAuditLog.timestamp >= from_date)
+            query = query.filter(DBAuditLog.timestamp >= _as_naive_utc(from_date))
         if to_date:
-            query = query.filter(DBAuditLog.timestamp <= to_date)
+            query = query.filter(DBAuditLog.timestamp <= _as_naive_utc(to_date))
         if status_code:
             status_codes = [sc.strip() for sc in status_code.split(",")]
             query = query.filter(

--- a/app/api/regions.py
+++ b/app/api/regions.py
@@ -9,7 +9,7 @@ from app.db.database import get_db
 from app.api.auth import get_current_user_from_auth
 from app.core.roles import UserRole
 from app.schemas.models import (
-    Region,
+    RegionAdminResponse,
     RegionCreate,
     RegionResponse,
     User,
@@ -123,10 +123,14 @@ async def validate_database_connection(
 
 
 @router.post(
-    "", response_model=Region, dependencies=[Depends(get_role_min_system_admin)]
+    "",
+    response_model=RegionAdminResponse,
+    dependencies=[Depends(get_role_min_system_admin)],
 )
 @router.post(
-    "/", response_model=Region, dependencies=[Depends(get_role_min_system_admin)]
+    "/",
+    response_model=RegionAdminResponse,
+    dependencies=[Depends(get_role_min_system_admin)],
 )
 async def create_region(region: RegionCreate, db: Session = Depends(get_db)):
     # Check if region with this name already exists
@@ -194,7 +198,7 @@ async def list_regions(
 
 @router.get(
     "/admin",
-    response_model=List[Region],
+    response_model=List[RegionAdminResponse],
     dependencies=[Depends(get_role_min_system_admin)],
 )
 async def list_admin_regions(db: Session = Depends(get_db)):
@@ -248,7 +252,7 @@ async def delete_region(region_id: int, db: Session = Depends(get_db)):
 
 @router.put(
     "/{region_id}",
-    response_model=Region,
+    response_model=RegionAdminResponse,
     dependencies=[Depends(get_role_min_system_admin)],
 )
 async def update_region(

--- a/app/api/regions.py
+++ b/app/api/regions.py
@@ -291,6 +291,10 @@ async def update_region(
 
     # Update the region fields
     update_data = region.model_dump(exclude_unset=True)
+    # Blank or null credentials mean "keep current" — never wipe stored secrets.
+    for secret_field in ("postgres_admin_password", "litellm_api_key"):
+        if not update_data.get(secret_field):
+            update_data.pop(secret_field, None)
     for field, value in update_data.items():
         setattr(db_region, field, value)
 

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -713,24 +713,27 @@ async def remove_user_admin_region(
 async def list_users(
     current_user: DBUser = Depends(get_current_user_from_auth),
     search: Optional[str] = None,
+    include_inactive: bool = False,
     db: Session = Depends(get_db),
 ):
     """
     List users. Accessible by admin users or team admins for their team members.
     Users from soft-deleted teams and inactive users are excluded from the results.
+    System admins can pass include_inactive=true to also see inactive users.
     Optionally filter by search term (partial email match).
     """
     if current_user.is_admin:
         # Use LEFT JOIN to get all users and their team information in a single query
-        # Exclude users from soft-deleted teams and inactive users
+        # Exclude users from soft-deleted teams
         query = (
             db.query(DBUser, DBTeam.name.label("team_name"))
             .outerjoin(DBTeam, DBUser.team_id == DBTeam.id)
             .filter(
-                DBUser.is_active.is_(True),
                 (DBUser.team_id.is_(None)) | (DBTeam.deleted_at.is_(None)),
             )
         )
+        if not include_inactive:
+            query = query.filter(DBUser.is_active.is_(True))
 
         if search:
             query = query.filter(DBUser.email.ilike(f"%{search}%"))

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -268,6 +268,13 @@ class RegionResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class RegionAdminResponse(RegionResponse):
+    # Admin view: includes DB connection identity but never secrets
+    # (postgres_admin_password / litellm_api_key stay server-side).
+    postgres_port: int
+    postgres_admin_user: str
+
+
 class RegionSummaryResponse(BaseModel):
     id: int
     name: str

--- a/frontend/src/app/admin/audit-logs/_components/audit-log-filters.test.tsx
+++ b/frontend/src/app/admin/audit-logs/_components/audit-log-filters.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { AuditLogFilters as IFilters } from "@/types/audit-log";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { AuditLogFilters } from "./audit-log-filters";
@@ -105,6 +105,32 @@ describe("AuditLogFilters", () => {
     expect(mockOnFilterChange).toHaveBeenCalledWith(
       "user_email",
       "new@example.com",
+    );
+  });
+
+  it("calls onFilterChange when date range changes", () => {
+    render(
+      <AuditLogFilters
+        filters={defaultFilters}
+        onFilterChange={mockOnFilterChange}
+        metadata={defaultMetadata}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("From date"), {
+      target: { value: "2026-07-21T10:00" },
+    });
+    expect(mockOnFilterChange).toHaveBeenCalledWith(
+      "from_date",
+      "2026-07-21T10:00",
+    );
+
+    fireEvent.change(screen.getByLabelText("To date"), {
+      target: { value: "2026-07-21T11:00" },
+    });
+    expect(mockOnFilterChange).toHaveBeenCalledWith(
+      "to_date",
+      "2026-07-21T11:00",
     );
   });
 });

--- a/frontend/src/app/admin/audit-logs/_components/audit-log-filters.tsx
+++ b/frontend/src/app/admin/audit-logs/_components/audit-log-filters.tsx
@@ -66,6 +66,26 @@ export function AuditLogFilters({
           </div>
 
           <div className="space-y-2">
+            <label className="text-sm font-medium">From</label>
+            <Input
+              type="datetime-local"
+              aria-label="From date"
+              value={filters.from_date || ""}
+              onChange={(e) => onFilterChange("from_date", e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">To</label>
+            <Input
+              type="datetime-local"
+              aria-label="To date"
+              value={filters.to_date || ""}
+              onChange={(e) => onFilterChange("to_date", e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
             <label className="text-sm font-medium">Referer</label>
             <Input
               type="text"

--- a/frontend/src/app/admin/audit-logs/page.tsx
+++ b/frontend/src/app/admin/audit-logs/page.tsx
@@ -26,6 +26,8 @@ export default function AuditLogsPage() {
     status_code: [],
     user_email: "",
     referer: "",
+    from_date: "",
+    to_date: "",
   });
 
   const {
@@ -53,6 +55,12 @@ export default function AuditLogsPage() {
       params.append("status_code", filters.status_code.join(","));
     if (filters.user_email) params.append("user_email", filters.user_email);
     if (filters.referer) params.append("referer", filters.referer);
+    // datetime-local values are local time; send UTC so the backend
+    // compares against its UTC-stored timestamps correctly.
+    if (filters.from_date)
+      params.append("from_date", new Date(filters.from_date).toISOString());
+    if (filters.to_date)
+      params.append("to_date", new Date(filters.to_date).toISOString());
     return params.toString();
   }, [currentPage, filters]);
 

--- a/frontend/src/app/admin/regions/_components/edit-region-dialog.tsx
+++ b/frontend/src/app/admin/regions/_components/edit-region-dialog.tsx
@@ -202,7 +202,7 @@ export function EditRegionDialog({
                     postgres_admin_password: e.target.value,
                   })
                 }
-                placeholder="••••••••"
+                placeholder="Leave blank to keep current"
               />
             </div>
             <div className="space-y-2">
@@ -230,7 +230,7 @@ export function EditRegionDialog({
                     litellm_api_key: e.target.value,
                   })
                 }
-                placeholder="••••••••"
+                placeholder="Leave blank to keep current"
               />
             </div>
           </div>

--- a/frontend/src/app/admin/regions/page.tsx
+++ b/frontend/src/app/admin/regions/page.tsx
@@ -10,6 +10,7 @@ import {
 import { useState, Fragment, useMemo } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
 import {
   Table,
   TableBody,
@@ -46,6 +47,7 @@ export default function RegionsPage() {
   // Sorting state
   const [sortField, setSortField] = useState<SortField>("id");
   const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
+  const [showDeleted, setShowDeleted] = useState(false);
 
   // Queries
   const { data: regions = [], isLoading: isLoadingRegions } = useQuery<
@@ -90,7 +92,7 @@ export default function RegionsPage() {
 
   // Memoized sorted regions
   const sortedRegions = useMemo(() => {
-    const sorted = [...regions];
+    const sorted = regions.filter((r) => showDeleted || r.is_active);
     if (sortField) {
       sorted.sort((a, b) => {
         let aValue: string | number;
@@ -121,7 +123,7 @@ export default function RegionsPage() {
       });
     }
     return sorted;
-  }, [regions, sortField, sortDirection]);
+  }, [regions, sortField, sortDirection, showDeleted]);
 
   // Mutations
   const deleteRegionMutation = useMutation({
@@ -175,10 +177,25 @@ export default function RegionsPage() {
         <>
           <div className="flex items-center justify-between">
             <h1 className="text-3xl font-bold">Regions</h1>
-            <CreateRegionDialog
-              open={isAddingRegion}
-              onOpenChange={setIsAddingRegion}
-            />
+            <div className="flex items-center gap-4">
+              <div className="flex items-center gap-2">
+                <Switch
+                  id="show-deleted-regions"
+                  checked={showDeleted}
+                  onCheckedChange={setShowDeleted}
+                />
+                <label
+                  htmlFor="show-deleted-regions"
+                  className="text-sm font-medium"
+                >
+                  Show deleted
+                </label>
+              </div>
+              <CreateRegionDialog
+                open={isAddingRegion}
+                onOpenChange={setIsAddingRegion}
+              />
+            </div>
           </div>
           <div className="rounded-md border">
             <Table>
@@ -226,7 +243,12 @@ export default function RegionsPage() {
                       <TableCell>{region.id}</TableCell>
                       <TableCell>{region.name}</TableCell>
                       <TableCell>{region.label}</TableCell>
-                      <TableCell>{region.postgres_host}</TableCell>
+                      <TableCell>
+                        {region.postgres_host}:{region.postgres_port}
+                        <div className="text-xs text-muted-foreground">
+                          user: {region.postgres_admin_user}
+                        </div>
+                      </TableCell>
                       <TableCell>{region.litellm_api_url}</TableCell>
                       <TableCell>
                         <Badge

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { useState, useMemo, Fragment } from "react";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
 import {
   Table,
   TableBody,
@@ -49,12 +50,15 @@ export default function UsersPage() {
   const [roleFilter, setRoleFilter] = useState("all");
   const [sortField, setSortField] = useState<SortField>(null);
   const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
+  const [showDeleted, setShowDeleted] = useState(false);
 
   // Queries
   const { data: users = [], isLoading: isLoadingUsers } = useQuery<User[]>({
-    queryKey: ["users"],
+    queryKey: ["users", showDeleted],
     queryFn: async () => {
-      const response = await get("/users");
+      const response = await get(
+        showDeleted ? "/users?include_inactive=true" : "/users",
+      );
       return response.json();
     },
   });
@@ -268,11 +272,23 @@ export default function UsersPage() {
     <div className="space-y-4">
       <div className="flex justify-between items-center">
         <h1 className="text-3xl font-bold">Users</h1>
-        <CreateUserDialog
-          open={isAddingUser}
-          onOpenChange={setIsAddingUser}
-          teams={teams}
-        />
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2">
+            <Switch
+              id="show-deleted-users"
+              checked={showDeleted}
+              onCheckedChange={setShowDeleted}
+            />
+            <label htmlFor="show-deleted-users" className="text-sm font-medium">
+              Show deleted
+            </label>
+          </div>
+          <CreateUserDialog
+            open={isAddingUser}
+            onOpenChange={setIsAddingUser}
+            teams={teams}
+          />
+        </div>
       </div>
 
       <TableFilters

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -613,6 +613,12 @@ def test_list_admin_regions(client, admin_token, db, test_region):
     region_names = [r["name"] for r in regions]
     assert test_region.name in region_names
     assert "inactive-region" in region_names
+    # Admin listing exposes connection identity but never secrets
+    for r in regions:
+        assert "postgres_port" in r
+        assert "postgres_admin_user" in r
+        assert "postgres_admin_password" not in r
+        assert "litellm_api_key" not in r
 
 
 def test_list_admin_regions_non_admin(client, test_token):

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -283,6 +283,41 @@ def test_update_region(client, admin_token, test_region):
     assert data["postgres_port"] == update_data["postgres_port"]
 
 
+def test_update_region_blank_secrets_keep_current(client, admin_token, test_region, db):
+    """
+    Given an existing region
+    When it is updated with explicitly blank/null credential fields
+    Then the stored credentials should remain unchanged
+    """
+    original_password = test_region.postgres_admin_password
+    original_key = test_region.litellm_api_key
+
+    update_data = {
+        "name": test_region.name,
+        "label": test_region.label,
+        "description": "updated description only",
+        "postgres_host": test_region.postgres_host,
+        "postgres_port": test_region.postgres_port,
+        "postgres_admin_user": test_region.postgres_admin_user,
+        "postgres_admin_password": "",
+        "litellm_api_url": test_region.litellm_api_url,
+        "litellm_api_key": None,
+        "is_active": True,
+        "is_dedicated": test_region.is_dedicated,
+    }
+
+    response = client.put(
+        f"/regions/{test_region.id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json=update_data,
+    )
+
+    assert response.status_code == 200
+    db.refresh(test_region)
+    assert test_region.postgres_admin_password == original_password
+    assert test_region.litellm_api_key == original_key
+
+
 def test_update_region_legacy_http_url_grandfathered(
     client, admin_token, test_region, db
 ):

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -57,6 +57,27 @@ def test_get_users(client, admin_token, test_user):
     assert any(user["email"] == test_user.email for user in users)
 
 
+def test_get_users_include_inactive(client, admin_token, db):
+    inactive = DBUser(
+        email="inactive-list@example.com",
+        hashed_password=get_password_hash("password"),
+        is_active=False,
+    )
+    db.add(inactive)
+    db.commit()
+
+    response = client.get("/users/", headers={"Authorization": f"Bearer {admin_token}"})
+    assert response.status_code == 200
+    assert "inactive-list@example.com" not in [u["email"] for u in response.json()]
+
+    response = client.get(
+        "/users/?include_inactive=true",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    assert "inactive-list@example.com" in [u["email"] for u in response.json()]
+
+
 def test_get_user_by_id(client, admin_token, test_user):
     response = client.get(
         f"/users/{test_user.id}", headers={"Authorization": f"Bearer {admin_token}"}


### PR DESCRIPTION
- Audit logs: from/to date-time filters
- Regions: show-deleted toggle, show DB user/port, secrets no longer returned to the browser; blank password/key on edit keeps current values
- Users: show-deleted toggle (new `include_inactive` param on GET /users)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR expands the admin UI and API controls for audit logs, regions, and users. The main changes are:

- Adds audit-log date and time filters with UTC normalization.
- Adds controls for showing inactive users and deleted regions.
- Shows database connection identity in the region admin view without returning secrets.
- Preserves stored region credentials when updates contain blank or null secrets.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The blank-secret update now preserves both stored credential fields.
- Tests cover empty and null credential values.
- No blocking issue remains in the updated fix.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/regions.py | Preserves credentials on blank updates and uses a secret-free admin response model. |
| app/schemas/models.py | Adds an admin region response with connection identity fields but no secrets. |
| tests/test_region.py | Covers blank credential updates and verifies that admin responses omit secrets. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Ignore explicitly blank credential field..."](https://github.com/amazeeio/amazee.ai/commit/7eb1c033cef13922b6d60711cf9e881b8a10038b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46266353)</sub>

<!-- /greptile_comment -->