### PR TITLE
ci: pin ruff lint rules to pre-0.16 defaults

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,5 @@
+# Pin lint rules to ruff's pre-0.16 defaults. The lint workflow installs the
+# latest ruff release, and 0.16.0 expanded the default rule set, which fails
+# the whole repo. Widen this selection deliberately, not via toolchain drift.
+[lint]
+select = ["E4", "E7", "E9", "F"]


### PR DESCRIPTION
ruff-action installs the latest ruff release; 0.16.0 expanded the default rule set and started failing lint repo-wide (1424 errors in files untouched by any open PR). Pin the previous default selection in `ruff.toml` so lint behavior no longer drifts with the toolchain.

Extracted from #576 so the lint fix can land independently.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Pins Ruff linting to its pre-0.16 default rule families.
- Adds a root `ruff.toml`.
- Explicitly selects `E4`, `E7`, `E9`, and `F` rules to prevent CI behavior from drifting as Ruff defaults change.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The existing Ruff workflow runs from the repository root without overriding rule selection, so the new configuration is discovered and applies the explicitly intended lint rules.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ruff.toml | Adds a valid root-level Ruff configuration that is discovered by the existing lint workflow and preserves the intended pre-0.16 lint selection. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: pin ruff lint rules to pre-0.16 defa..."](https://github.com/amazeeio/amazee.ai/commit/97605bf2d7249d4fb79d9c9cdb6f7f34dd7bb81f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47512320)</sub>

<!-- /greptile_comment -->