### PR TITLE
feat(teams): add region selection to create team dialog

### DIFF
--- a/frontend/src/app/admin/teams/_components/create-team-dialog.tsx
+++ b/frontend/src/app/admin/teams/_components/create-team-dialog.tsx
@@ -11,33 +11,54 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useTeams } from "@/hooks/use-teams";
+import { Region } from "@/types/region";
 
 interface CreateTeamDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  regions: Region[];
 }
 
 export function CreateTeamDialog({
   open,
   onOpenChange,
+  regions,
 }: CreateTeamDialogProps) {
   const [newTeamName, setNewTeamName] = useState("");
   const [newTeamAdminEmail, setNewTeamAdminEmail] = useState("");
+  const [newTeamRegionId, setNewTeamRegionId] = useState("");
   const { createTeam, isCreating } = useTeams();
+
+  // A team is locked to a single region on creation, and the backend rejects
+  // inactive or dedicated regions — only offer the ones it will accept.
+  const selectableRegions = regions.filter(
+    (r) => r.is_active && !r.is_dedicated,
+  );
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    const regionId = Number(newTeamRegionId);
+    if (!Number.isFinite(regionId) || regionId <= 0) return;
     createTeam(
       {
         name: newTeamName,
         admin_email: newTeamAdminEmail,
+        region_id: regionId,
       },
       {
         onSuccess: () => {
           onOpenChange(false);
           setNewTeamName("");
           setNewTeamAdminEmail("");
+          setNewTeamRegionId("");
         },
       },
     );
@@ -72,7 +93,10 @@ export function CreateTeamDialog({
             />
           </div>
           <div className="space-y-2">
-            <label htmlFor="new-team-admin-email" className="text-sm font-medium">
+            <label
+              htmlFor="new-team-admin-email"
+              className="text-sm font-medium"
+            >
               Admin Email
             </label>
             <Input
@@ -84,8 +108,36 @@ export function CreateTeamDialog({
               required
             />
           </div>
+          <div className="space-y-2">
+            <label htmlFor="new-team-region" className="text-sm font-medium">
+              Region
+            </label>
+            <Select
+              value={newTeamRegionId}
+              onValueChange={setNewTeamRegionId}
+              required
+            >
+              <SelectTrigger id="new-team-region">
+                <SelectValue placeholder="Select a region" />
+              </SelectTrigger>
+              <SelectContent>
+                {selectableRegions.map((region) => (
+                  <SelectItem key={region.id} value={region.id.toString()}>
+                    {region.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              The team is permanently created in this region. Dedicated regions
+              must be assigned afterwards from the Regions page.
+            </p>
+          </div>
           <DialogFooter>
-            <Button type="submit" disabled={isCreating}>
+            <Button
+              type="submit"
+              disabled={isCreating || newTeamRegionId === ""}
+            >
               {isCreating ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/frontend/src/app/admin/teams/page.tsx
+++ b/frontend/src/app/admin/teams/page.tsx
@@ -236,6 +236,7 @@ export default function TeamsPage() {
             <CreateTeamDialog
               open={isAddingTeam}
               onOpenChange={setIsAddingTeam}
+              regions={regions}
             />
           </div>
         </div>

--- a/frontend/src/hooks/use-teams.ts
+++ b/frontend/src/hooks/use-teams.ts
@@ -18,7 +18,11 @@ export function useTeams(includeDeleted: boolean = false) {
 
   // Mutations
   const createTeamMutation = useMutation({
-    mutationFn: async (data: { name: string; admin_email: string }) => {
+    mutationFn: async (data: {
+      name: string;
+      admin_email: string;
+      region_id: number;
+    }) => {
       const response = await post("/teams", data);
       return response.json();
     },


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds mandatory primary-region selection to administrative team creation.
- Filters the selector to active, non-dedicated regions.
- Includes the selected numeric region ID in the team-creation request.
- Passes region data from the teams page into the creation dialog.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking usability issue when region data is loading or unavailable.

Team creation sends an eligible numeric region ID correctly, but the regions query collapses pending and failed requests into an unexplained empty selector that prevents submission.

**Files Needing Attention:** frontend/src/app/admin/teams/page.tsx
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/app/admin/teams/_components/create-team-dialog.tsx | Adds a required region selector, eligibility filtering, payload conversion, and successful-submission reset. |
| frontend/src/app/admin/teams/page.tsx | Supplies queried regions to the creation dialog, but does not expose query loading or failure state. |
| frontend/src/hooks/use-teams.ts | Extends the typed create-team mutation payload with the backend-required numeric region ID. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `frontend/src/app/admin/teams/page.tsx`, line 65-71 ([link](https://github.com/amazeeio/amazee.ai/blob/bfab782f3a0f0a6c0d377310c990d4281550b364/frontend/src/app/admin/teams/page.tsx#L65-L71)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Region query states look empty**

   The query defaults pending and failed requests to an empty region array without exposing either state to the dialog, so administrators see an empty selector and disabled submit button with no explanation or retry guidance.

   **Knowledge Base Used:**
   - [Frontend App](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/frontend-app.md)
   - [Teams and Users](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/teams-users.md)
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(teams): add region selection to cre..."](https://github.com/amazeeio/amazee.ai/commit/bfab782f3a0f0a6c0d377310c990d4281550b364) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47846942)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Frontend App](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/frontend-app.md)
- Knowledge Base — [Teams and Users](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/teams-users.md)
- Knowledge Base — [Public Models API, Regions, and Pricing Tables](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/regions-public-pricing.md)
</details>


<!-- /greptile_comment -->