### PR TITLE
fix(migration): handle region assignment for teams without regions

### DIFF
--- a/app/migrations/versions/20260527_120000_6c201dbaea6e_add_region_id_to_teams.py
+++ b/app/migrations/versions/20260527_120000_6c201dbaea6e_add_region_id_to_teams.py
@@ -67,37 +67,56 @@ def upgrade():
     # 3. For teams that still have no region (zero team_regions rows),
     #    assign the first active non-dedicated region as a safe fallback
     #    and insert a matching team_regions association row.
+    #
+    #    Only look for a fallback region when a team actually still needs one.
+    #    This check used to run unconditionally, which aborted the migration on
+    #    any database with no active public region — even one with nothing left
+    #    to backfill. That failed the `main` environment (2 teams, 0 regions):
+    #    the RuntimeError rolled the migration back, backend-start.sh exited
+    #    under `set -e`, and the rollout timed out at applyingDeployments.
     bind = op.get_bind()
-    fallback_row = bind.execute(
-        sa.text(
-            "SELECT id FROM regions"
-            " WHERE is_active = true AND is_dedicated = false"
-            " ORDER BY id ASC LIMIT 1"
-        )
-    ).fetchone()
-    if fallback_row is None:
-        raise RuntimeError(
-            "No active non-dedicated region found; cannot backfill teams.region_id. "
-            "Create at least one active non-dedicated region before running this migration."
-        )
-    fallback_id = fallback_row[0]
-    # Insert team_regions rows for teams that have no association yet.
-    op.execute(
-        sa.text(
-            """
-            INSERT INTO team_regions (team_id, region_id, created_at)
-            SELECT id, :fallback_id, NOW()
-            FROM teams
-            WHERE region_id IS NULL
-            ON CONFLICT DO NOTHING
-            """
-        ).bindparams(fallback_id=fallback_id)
+    teams_without_region = (
+        bind.execute(
+            sa.text("SELECT count(*) FROM teams WHERE region_id IS NULL")
+        ).scalar()
+        or 0
     )
-    op.execute(
-        sa.text(
-            "UPDATE teams SET region_id = :fallback_id WHERE region_id IS NULL"
-        ).bindparams(fallback_id=fallback_id)
-    )
+    if teams_without_region:
+        fallback_row = bind.execute(
+            sa.text(
+                "SELECT id FROM regions"
+                " WHERE is_active = true AND is_dedicated = false"
+                " ORDER BY id ASC LIMIT 1"
+            )
+        ).fetchone()
+        # Still fail loudly when there IS data to backfill and nowhere to put
+        # it — leaving those teams region-less would silently break their
+        # LiteLLM member sync and hide their region from GET /regions/.
+        if fallback_row is None:
+            raise RuntimeError(
+                f"{teams_without_region} team(s) have no region and no active "
+                "non-dedicated region exists to fall back on; cannot backfill "
+                "teams.region_id. Create at least one active non-dedicated "
+                "region before running this migration."
+            )
+        fallback_id = fallback_row[0]
+        # Insert team_regions rows for teams that have no association yet.
+        op.execute(
+            sa.text(
+                """
+                INSERT INTO team_regions (team_id, region_id, created_at)
+                SELECT id, :fallback_id, NOW()
+                FROM teams
+                WHERE region_id IS NULL
+                ON CONFLICT DO NOTHING
+                """
+            ).bindparams(fallback_id=fallback_id)
+        )
+        op.execute(
+            sa.text(
+                "UPDATE teams SET region_id = :fallback_id WHERE region_id IS NULL"
+            ).bindparams(fallback_id=fallback_id)
+        )
 
     # 4. Create index for region_id lookups
     op.create_index("ix_teams_region_id", "teams", ["region_id"])

--- a/app/migrations/versions/20260527_120000_6c201dbaea6e_add_region_id_to_teams.py
+++ b/app/migrations/versions/20260527_120000_6c201dbaea6e_add_region_id_to_teams.py
@@ -68,12 +68,20 @@ def upgrade():
     #    assign the first active non-dedicated region as a safe fallback
     #    and insert a matching team_regions association row.
     #
-    #    Only look for a fallback region when a team actually still needs one.
-    #    This check used to run unconditionally, which aborted the migration on
-    #    any database with no active public region — even one with nothing left
-    #    to backfill. That failed the `main` environment (2 teams, 0 regions):
-    #    the RuntimeError rolled the migration back, backend-start.sh exited
-    #    under `set -e`, and the rollout timed out at applyingDeployments.
+    #    Only look for a fallback region when a team actually still needs one,
+    #    and never abort when there is nowhere to put them. This step used to
+    #    raise RuntimeError whenever no active public region existed, which
+    #    rolled the whole migration back; backend-start.sh then exited under
+    #    `set -e` and the rollout timed out at applyingDeployments. That is how
+    #    the `main` environment (2 teams, 0 regions) failed to deploy.
+    #
+    #    region_id is nullable by design (see step 5), and every read path
+    #    tolerates NULL: get_team_region() returns None, the LiteLLM member sync
+    #    skips with reason=no_active_region, and GET /regions/ returns []. An
+    #    environment with no active public region cannot serve AI keys at all,
+    #    so leaving its teams region-less is not a regression — whereas blocking
+    #    the rollout is. Warn instead, and let the environment be fixed by
+    #    creating a region.
     bind = op.get_bind()
     teams_without_region = (
         bind.execute(
@@ -89,34 +97,33 @@ def upgrade():
                 " ORDER BY id ASC LIMIT 1"
             )
         ).fetchone()
-        # Still fail loudly when there IS data to backfill and nowhere to put
-        # it — leaving those teams region-less would silently break their
-        # LiteLLM member sync and hide their region from GET /regions/.
         if fallback_row is None:
-            raise RuntimeError(
-                f"{teams_without_region} team(s) have no region and no active "
-                "non-dedicated region exists to fall back on; cannot backfill "
-                "teams.region_id. Create at least one active non-dedicated "
-                "region before running this migration."
+            print(
+                f"WARNING: {teams_without_region} team(s) have no region and no "
+                "active non-dedicated region exists to fall back on. Leaving "
+                "teams.region_id NULL for them. Create an active non-dedicated "
+                "region, then re-run the backfill for these teams.",
+                flush=True,
             )
-        fallback_id = fallback_row[0]
-        # Insert team_regions rows for teams that have no association yet.
-        op.execute(
-            sa.text(
-                """
-                INSERT INTO team_regions (team_id, region_id, created_at)
-                SELECT id, :fallback_id, NOW()
-                FROM teams
-                WHERE region_id IS NULL
-                ON CONFLICT DO NOTHING
-                """
-            ).bindparams(fallback_id=fallback_id)
-        )
-        op.execute(
-            sa.text(
-                "UPDATE teams SET region_id = :fallback_id WHERE region_id IS NULL"
-            ).bindparams(fallback_id=fallback_id)
-        )
+        else:
+            fallback_id = fallback_row[0]
+            # Insert team_regions rows for teams that have no association yet.
+            op.execute(
+                sa.text(
+                    """
+                    INSERT INTO team_regions (team_id, region_id, created_at)
+                    SELECT id, :fallback_id, NOW()
+                    FROM teams
+                    WHERE region_id IS NULL
+                    ON CONFLICT DO NOTHING
+                    """
+                ).bindparams(fallback_id=fallback_id)
+            )
+            op.execute(
+                sa.text(
+                    "UPDATE teams SET region_id = :fallback_id WHERE region_id IS NULL"
+                ).bindparams(fallback_id=fallback_id)
+            )
 
     # 4. Create index for region_id lookups
     op.create_index("ix_teams_region_id", "teams", ["region_id"])


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The migration now allows deployments with teams but no available fallback region to complete.
- Counts teams whose `region_id` remains unset before attempting fallback assignment.
- Assigns an active non-dedicated region when one exists.
- Otherwise emits an operational warning and preserves the nullable `region_id`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The previously reported migration failure is resolved: the nullable schema permits teams without regions, migration startup does not reject that state, and the relevant region lookup and synchronization paths handle it without failing.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/migrations/versions/20260527_120000_6c201dbaea6e_add_region_id_to_teams.py | The revised fallback handles zero-region environments without aborting, while retaining assignment behavior when a suitable region exists. |

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(migrations): update migration l..."](https://github.com/amazeeio/amazee.ai/commit/146fa654d32b2edc224bc6a93a6daf675207bd3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47875026)</sub>

**Context used:**

- Knowledge Base — [Database models, session, and migrations](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/database-models.md)

<!-- /greptile_comment -->