### PR TITLE
feat(worker): implement bulk key listing with caching for efficiency

### DIFF
--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -1,5 +1,7 @@
+import asyncio
 import os
 from datetime import UTC, datetime, timedelta
+from functools import partial
 from sqlalchemy.orm import Session
 from sqlalchemy import select, func, and_, or_, update as sa_update
 from app.db.models import (
@@ -23,7 +25,7 @@ from app.db.models import (
     DBUserSpendCache,
 )
 from app.schemas.models import BudgetType
-from app.services.litellm import LiteLLMService
+from app.services.litellm import LiteLLMService, hash_litellm_token
 from app.services.ses import SESService
 from app.core.team_service import (
     get_team_keys_by_region,
@@ -51,7 +53,7 @@ from app.services.stripe import (
     INVOICE_FAILURE_EVENTS,
 )
 from prometheus_client import Gauge, Counter, Summary
-from typing import Dict, List, Optional
+from typing import Awaitable, Callable, Dict, List, Optional
 from app.core.security import create_access_token
 from app.core.config import settings
 from urllib.parse import urljoin
@@ -103,6 +105,37 @@ key_spend_percentage = Gauge(
     "Percentage of budget used for each key",
     ["team_id", "team_name", "key_alias"],
 )
+
+# Bulk key-listing metrics. A snapshot failure silently degrades the
+# reconciliation job back to one HTTP call per key, which is ~40 minutes at
+# 13.5k keys, so it must be observable rather than just logged.
+region_key_snapshot_failed_total = Counter(
+    "region_key_snapshot_failed_total",
+    "Total number of failed bulk /key/list snapshots, by region",
+    ["region_name"],
+)
+
+region_key_snapshot_keys = Gauge(
+    "region_key_snapshot_keys",
+    "Number of keys returned by the last bulk /key/list snapshot, by region",
+    ["region_name"],
+)
+
+key_state_fallback_total = Counter(
+    "key_state_fallback_total",
+    "Total number of keys that fell back to a per-key /key/info lookup",
+    ["region_name"],
+)
+
+key_write_failed_total = Counter(
+    "key_write_failed_total",
+    "Total number of per-key LiteLLM write calls that failed during reconciliation",
+    ["region_name"],
+)
+
+# Concurrent per-key LiteLLM writes during reconciliation. Bounds load on the
+# proxy while keeping the daily expiry run off the ~34 minute sequential path.
+KEY_WRITE_CONCURRENCY = max(1, int(os.getenv("KEY_WRITE_CONCURRENCY", "10")))
 
 # Retention metrics
 team_retention_warning_sent_total = Counter(
@@ -1746,6 +1779,120 @@ async def apply_product_for_team(
     return sync_errors
 
 
+class RegionKeyStateCache:
+    """Per-run cache of bulk ``/key/list`` snapshots, keyed by region id.
+
+    ``monitor_teams`` reconciles ~1.1k teams that share a handful of regions, so
+    the snapshot must be fetched once per region per run and reused across every
+    team in it. Fetching per team would re-paginate the same region up to 1.1k
+    times and be far worse than the per-key loop it replaces.
+
+    A failed snapshot is cached as an empty mapping so one broken region is
+    retried once per run, not once per team.
+    """
+
+    def __init__(self) -> None:
+        self._snapshots: Dict[int, Dict[str, dict]] = {}
+
+    async def get(
+        self, region: DBRegion, litellm_service: LiteLLMService
+    ) -> Dict[str, dict]:
+        if region.id in self._snapshots:
+            return self._snapshots[region.id]
+
+        snapshot: Dict[str, dict] = {}
+        try:
+            listed = await litellm_service.list_all_keys()
+            # Guard the shape rather than trusting it: anything other than a
+            # mapping must degrade to the per-key path instead of being indexed
+            # into and yielding nonsense spend values.
+            if not isinstance(listed, dict):
+                raise TypeError(
+                    f"expected dict from list_all_keys, got {type(listed).__name__}"
+                )
+            snapshot = listed
+            region_key_snapshot_keys.labels(region_name=region.name).set(len(snapshot))
+        except Exception as e:
+            # Degrade rather than abort: callers fall back to per-key lookups.
+            # Loud, because the fallback is ~200x slower.
+            region_key_snapshot_failed_total.labels(region_name=region.name).inc()
+            logger.error(
+                "Bulk key snapshot failed for region %s, falling back to per-key "
+                "/key/info lookups (much slower): %s",
+                region.name,
+                str(e),
+            )
+            snapshot = {}
+
+        self._snapshots[region.id] = snapshot
+        return snapshot
+
+
+async def _run_key_writes(
+    pending_writes: list[tuple[int, Callable[[], Awaitable[None]]]],
+    region_name: str,
+) -> int:
+    """Run queued per-key LiteLLM writes concurrently, bounded by a semaphore.
+
+    Returns the number that failed. A failing write is logged and counted but
+    never aborts the region, matching the previous per-key behaviour.
+    """
+    if not pending_writes:
+        return 0
+
+    semaphore = asyncio.Semaphore(KEY_WRITE_CONCURRENCY)
+
+    async def _run(key_id: int, write: Callable[[], Awaitable[None]]) -> Optional[str]:
+        try:
+            async with semaphore:
+                await write()
+            return None
+        except Exception as exc:
+            return f"Key {key_id}: {str(exc)}"
+
+    errors = [
+        error
+        for error in await asyncio.gather(
+            *[_run(key_id, write) for key_id, write in pending_writes]
+        )
+        if error is not None
+    ]
+    for error in errors:
+        logger.error("Key write failed in region %s: %s", region_name, error)
+    if errors:
+        key_write_failed_total.labels(region_name=region_name).inc(len(errors))
+    logger.info(
+        "Applied %d key write(s) in region %s (%d failed)",
+        len(pending_writes) - len(errors),
+        region_name,
+        len(errors),
+    )
+    return len(errors)
+
+
+async def _resolve_key_state(
+    key: DBPrivateAIKey,
+    region: DBRegion,
+    litellm_service: LiteLLMService,
+    snapshot: Dict[str, dict],
+) -> dict:
+    """Return LiteLLM state for ``key`` as a flat dict.
+
+    Prefers the bulk snapshot. Falls back to a single ``/key/info`` call when the
+    key is absent - it may have been created after the snapshot was taken, or the
+    snapshot may have failed entirely.
+    """
+    if snapshot:
+        info = snapshot.get(hash_litellm_token(key.litellm_token))
+        # Only trust a real mapping; anything else falls through to /key/info.
+        if isinstance(info, dict):
+            return info
+
+    key_state_fallback_total.labels(region_name=region.name).inc()
+    key_info = await litellm_service.get_key_info(key.litellm_token)
+    return key_info.get("info", {}) or {}
+
+
 async def reconcile_team_keys(
     db: Session,
     team: DBTeam,
@@ -1753,9 +1900,15 @@ async def reconcile_team_keys(
     expire_keys: bool,
     renewal_period_days: Optional[int] = None,
     max_budget_amount: Optional[float] = None,
+    key_state_cache: Optional["RegionKeyStateCache"] = None,
 ) -> float:
     """
     Monitor spend for all keys in a team across different regions and optionally update keys after renewal period.
+
+    Key state is read from a bulk ``/key/list`` snapshot rather than one
+    ``/key/info`` call per key. Every key is still visited and every existing
+    budget/duration/expiry correction still applies - only the reads are
+    batched, and writes are issued exactly as before for keys that drifted.
 
     Args:
         team: The team to monitor keys for
@@ -1763,10 +1916,15 @@ async def reconcile_team_keys(
         expire_keys: Whether to expire keys (set duration to 0)
         renewal_period_days: Optional renewal period in days. If provided, will check for and update keys renewed within the last hour.
         max_budget_amount: Optional maximum budget amount. If provided, will update the budget amount for the keys.
+        key_state_cache: Shared per-run snapshot cache. Callers reconciling more
+            than one team must pass a single instance so each region is listed
+            once per run; when omitted a private cache is used.
 
     Returns:
         float: Total spend across all keys for the team
     """
+    if key_state_cache is None:
+        key_state_cache = RegionKeyStateCache()
     team_total = 0
     total_by_user = defaultdict(float)
     service_key_total = 0
@@ -1780,12 +1938,21 @@ async def reconcile_team_keys(
                 api_url=region.litellm_api_url, api_key=region.litellm_api_key
             )
 
+            # One bulk listing per region, shared across every team in this run
+            snapshot = await key_state_cache.get(region, litellm_service)
+
+            # Writes are queued here and executed concurrently after the loop.
+            # Issuing them inline costs one round-trip per key, which is ~34
+            # minutes for the 11.5k-key trial team on the daily expiry run.
+            pending_writes: list[tuple[int, Callable[[], Awaitable[None]]]] = []
+
             # Check spend for each key in this region
             for key in keys:
                 try:
-                    # Get current spend using get_key_info
-                    key_info = await litellm_service.get_key_info(key.litellm_token)
-                    info = key_info.get("info", {})
+                    # Read state from the bulk snapshot, falling back per key
+                    info = await _resolve_key_state(
+                        key, region, litellm_service, snapshot
+                    )
                     # Ensure that even if LiteLLM returns `None` we have a value
                     current_spend = info.get("spend", 0) or 0.0
                     budget = info.get("max_budget", 0) or 0.0
@@ -1809,8 +1976,15 @@ async def reconcile_team_keys(
                         logger.info(
                             f"Key {key.id} expiring, setting duration to 0 days"
                         )
-                        await litellm_service.update_key_duration(
-                            key.litellm_token, "0d"
+                        pending_writes.append(
+                            (
+                                key.id,
+                                partial(
+                                    litellm_service.update_key_duration,
+                                    key.litellm_token,
+                                    "0d",
+                                ),
+                            )
                         )
                     else:
                         update_data = {"litellm_token": key.litellm_token}
@@ -1880,12 +2054,18 @@ async def reconcile_team_keys(
 
                             # Call update_budget with correct parameter order
                             # Always pass budget_duration as second positional argument (can be None)
-                            await litellm_service.update_budget(
-                                litellm_token,
-                                budget_duration,
-                                budget_amount=budget_amount,
+                            pending_writes.append(
+                                (
+                                    key.id,
+                                    partial(
+                                        litellm_service.update_budget,
+                                        litellm_token,
+                                        budget_duration,
+                                        budget_amount=budget_amount,
+                                    ),
+                                )
                             )
-                            logger.info(f"Updated key {key.id} budget settings")
+                            logger.info(f"Queued key {key.id} budget update")
                         else:
                             logger.info(
                                 f"Key {key.id} budget settings already match the expected values, no update needed"
@@ -1920,6 +2100,9 @@ async def reconcile_team_keys(
                 except Exception as e:
                     logger.error(f"Error monitoring key {key.id} spend: {str(e)}")
                     continue
+
+            # Execute the queued key writes for this region concurrently
+            await _run_key_writes(pending_writes, region.name)
 
         except Exception as e:
             logger.error(
@@ -2375,6 +2558,8 @@ async def monitor_teams(db: Session):
 
         logger.info(f"Found {len(teams)} teams to track")
         limit_service = LimitService(db)
+        # Shared across every team so each region is bulk-listed once per run
+        key_state_cache = RegionKeyStateCache()
         for team in teams:
             try:
                 team_label = (str(team.id), team.name)
@@ -2480,6 +2665,7 @@ async def monitor_teams(db: Session):
                     expire_keys,
                     renewal_period_days,
                     max_budget_amount,
+                    key_state_cache=key_state_cache,
                 )
 
                 # Set the total spend metric for the team (always emit metrics)
@@ -2546,6 +2732,13 @@ async def monitor_teams(db: Session):
         # Update active team labels for next run
         active_team_labels.clear()
         active_team_labels.update(current_team_labels)
+
+        # Log wall-clock so an overrun of the hourly interval is visible in logs,
+        # not just in the monitor_teams_duration_seconds metric.
+        elapsed = (datetime.now(UTC) - current_time).total_seconds()
+        logger.info(
+            "Team monitoring completed in %.1fs for %d teams", elapsed, len(teams)
+        )
 
     except Exception as e:
         logger.error(f"Error in team monitoring task: {str(e)}")

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -145,6 +145,12 @@ key_write_failed_total = Counter(
 # proxy while keeping the daily expiry run off the ~34 minute sequential path.
 KEY_WRITE_CONCURRENCY = max(1, int(os.getenv("KEY_WRITE_CONCURRENCY", "10")))
 
+# Queued writes are flushed once this many pile up, rather than only at the end
+# of a region. Without a cap, an expiring key stays usable until every key in
+# the region has been read; when the bulk snapshot is unavailable each read
+# costs a round-trip, so that wait grows with the region's key count.
+KEY_WRITE_BATCH = max(1, int(os.getenv("KEY_WRITE_BATCH", "500")))
+
 # Retention metrics
 team_retention_warning_sent_total = Counter(
     "team_retention_warning_sent_total",
@@ -1949,9 +1955,10 @@ async def reconcile_team_keys(
             # One bulk listing per region, shared across every team in this run
             snapshot = await key_state_cache.get(region, litellm_service)
 
-            # Writes are queued here and executed concurrently after the loop.
-            # Issuing them inline costs one round-trip per key, which is ~34
-            # minutes for the 11.5k-key trial team on the daily expiry run.
+            # Writes are queued here and run concurrently in batches of
+            # KEY_WRITE_BATCH. Issuing them inline costs one round-trip per key,
+            # which is ~34 minutes for the 11.5k-key trial team on the daily
+            # expiry run.
             pending_writes: list[tuple[int, Callable[[], Awaitable[None]]]] = []
 
             # Check spend for each key in this region
@@ -2127,7 +2134,13 @@ async def reconcile_team_keys(
                     logger.error(f"Error monitoring key {key.id} spend: {str(e)}")
                     continue
 
-            # Execute the queued key writes for this region concurrently
+                # Flush early so an expiring key does not stay usable until the
+                # whole region has been read.
+                if len(pending_writes) >= KEY_WRITE_BATCH:
+                    await _run_key_writes(pending_writes, region.name)
+                    pending_writes = []
+
+            # Execute any writes left over from the last partial batch
             await _run_key_writes(pending_writes, region.name)
 
         except Exception as e:

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -1987,15 +1987,23 @@ async def reconcile_team_keys(
                             )
                         )
                     else:
-                        update_data = {"litellm_token": key.litellm_token}
+                        # Each drifted field is tracked on its own so the write
+                        # carries only what actually drifted. Reads come from a
+                        # snapshot that can be minutes old, so a write that also
+                        # sends unrelated fields could overwrite a change made
+                        # after the snapshot was taken.
                         needs_update = False
+                        new_budget_amount: Optional[float] = None
+                        new_budget_duration: Optional[str] = None
+                        extend_key_life = False
+
                         current_max_budget = info.get("max_budget")
                         # If the budget amount mis-matches, always update that field
                         if (
                             max_budget_amount is not None
                             and current_max_budget != max_budget_amount
                         ):
-                            update_data["budget_amount"] = max_budget_amount
+                            new_budget_amount = max_budget_amount
                             needs_update = True
                             logger.info(
                                 f"Key {key.id} has incorrect budget of {current_max_budget}, will change to {max_budget_amount}"
@@ -2007,7 +2015,7 @@ async def reconcile_team_keys(
                             current_budget_duration is None
                             and renewal_period_days is not None
                         ):
-                            update_data["budget_duration"] = f"{renewal_period_days}d"
+                            new_budget_duration = f"{renewal_period_days}d"
                             needs_update = True
                             logger.info(
                                 f"Key {key.id} budget update triggered by None budget_duration"
@@ -2017,7 +2025,7 @@ async def reconcile_team_keys(
                             current_budget_duration == "0d"
                             and renewal_period_days is not None
                         ):
-                            update_data["budget_duration"] = f"{renewal_period_days}d"
+                            new_budget_duration = f"{renewal_period_days}d"
                             needs_update = True
                             logger.info(
                                 f"Key {key.id} budget update triggered by 0d duration (expired key fix)"
@@ -2030,41 +2038,51 @@ async def reconcile_team_keys(
                             )
                             this_month = current_time + timedelta(days=30)
                             if parsed_expiry_date <= this_month:
-                                update_data["budget_duration"] = (
-                                    f"{renewal_period_days}d"
-                                )
+                                new_budget_duration = f"{renewal_period_days}d"
+                                extend_key_life = True
                                 needs_update = True
                                 logger.info(
                                     f"Key {key.id} expires at {expiry_date}, updating to extend life."
                                 )
 
                         if needs_update:
-                            # Determine what the new budget_duration will be for logging
-                            new_budget_duration = update_data.get(
-                                "budget_duration", current_budget_duration
-                            )
                             logger.info(
-                                f"Key {key.id} budget update triggered: changing from {current_budget_duration}, {current_max_budget} to {new_budget_duration}, {max_budget_amount}"
+                                f"Key {key.id} budget update triggered: changing from {current_budget_duration}, {current_max_budget} to {new_budget_duration or current_budget_duration}, {max_budget_amount}"
                             )
 
-                            # Extract litellm_token and other parameters for update_budget call
-                            litellm_token = update_data.pop("litellm_token")
-                            budget_duration = update_data.get("budget_duration")
-                            budget_amount = update_data.get("budget_amount")
-
-                            # Call update_budget with correct parameter order
-                            # Always pass budget_duration as second positional argument (can be None)
-                            pending_writes.append(
-                                (
-                                    key.id,
-                                    partial(
-                                        litellm_service.update_budget,
-                                        litellm_token,
-                                        budget_duration,
-                                        budget_amount=budget_amount,
-                                    ),
+                            if extend_key_life:
+                                # update_budget also resets the key's duration to
+                                # 365d, which is the whole point when the key is
+                                # close to expiring. budget_duration is always set
+                                # on this path, so nothing is sent as null.
+                                pending_writes.append(
+                                    (
+                                        key.id,
+                                        partial(
+                                            litellm_service.update_budget,
+                                            key.litellm_token,
+                                            new_budget_duration,
+                                            budget_amount=new_budget_amount,
+                                        ),
+                                    )
                                 )
-                            )
+                            else:
+                                # Budget-only drift: leave duration/expiry alone and
+                                # send no field we did not mean to change. LiteLLM
+                                # reads a null budget_duration as "clear it", so
+                                # passing None here would wipe the reset period and
+                                # the next run would write it back - a flap.
+                                pending_writes.append(
+                                    (
+                                        key.id,
+                                        partial(
+                                            litellm_service.update_key_budget,
+                                            key.litellm_token,
+                                            budget_duration=new_budget_duration,
+                                            max_budget=new_budget_amount,
+                                        ),
+                                    )
+                                )
                             logger.info(f"Queued key {key.id} budget update")
                         else:
                             logger.info(

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -1,8 +1,10 @@
+import asyncio
 import hashlib
 import httpx
 from datetime import datetime, timedelta, timezone
 from fastapi import HTTPException, status
 import logging
+import os
 import re
 from app.core.limit_service import (
     DEFAULT_KEY_DURATION,
@@ -13,6 +15,28 @@ from app.core.config import settings
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+# Concurrent /key/list page fetches per region sweep. Pages are independent
+# read-only requests, so this only bounds load on the LiteLLM proxy.
+LIST_KEYS_PAGE_CONCURRENCY = max(1, int(os.getenv("LIST_KEYS_PAGE_CONCURRENCY", "8")))
+
+
+def hash_litellm_token(litellm_token: str) -> str:
+    """Hash a LiteLLM key the way LiteLLM stores it internally.
+
+    LiteLLM persists ``sk-`` keys as their SHA-256 hexdigest (e.g. in the
+    ``LiteLLM_SpendLogs`` table queried by ``/spend/logs/v2`` and the
+    daily-spend tables that back ``/user/daily/activity``). Any other token
+    is stored verbatim. Mirrors LiteLLM's ``_hash_token_if_needed``.
+
+    Exposed as a module-level function, not only as
+    :meth:`LiteLLMService.hash_token`, so callers can hash without holding a
+    service instance and without depending on the class symbol - which tests
+    routinely patch, silently breaking hash-keyed lookups.
+    """
+    if litellm_token.startswith("sk-"):
+        return hashlib.sha256(litellm_token.encode()).hexdigest()
+    return litellm_token
 
 
 class LiteLLMService:
@@ -34,14 +58,9 @@ class LiteLLMService:
     def hash_token(litellm_token: str) -> str:
         """Hash a LiteLLM key the way LiteLLM stores it internally.
 
-        LiteLLM persists ``sk-`` keys as their SHA-256 hexdigest (e.g. in the
-        ``LiteLLM_SpendLogs`` table queried by ``/spend/logs/v2`` and the
-        daily-spend tables that back ``/user/daily/activity``). Any other token
-        is stored verbatim. Mirrors LiteLLM's ``_hash_token_if_needed``.
+        Thin wrapper over :func:`hash_litellm_token`, kept for existing callers.
         """
-        if litellm_token.startswith("sk-"):
-            return hashlib.sha256(litellm_token.encode()).hexdigest()
-        return litellm_token
+        return hash_litellm_token(litellm_token)
 
     @staticmethod
     def sanitize_alias(alias: str) -> str:
@@ -268,6 +287,113 @@ class LiteLLMService:
             raise HTTPException(
                 status_code=status_code,
                 detail=f"Failed to get LiteLLM key information: {error_msg}",
+            )
+
+    async def _fetch_key_page(
+        self, client: httpx.AsyncClient, page: int, page_size: int
+    ) -> dict:
+        """Fetch a single ``/key/list`` page and return the decoded payload."""
+        response = await client.get(
+            f"{self.api_url}/key/list",
+            headers={"Authorization": f"Bearer {self.master_key}"},
+            params={
+                "page": page,
+                "size": page_size,
+                "return_full_object": True,
+                "include_team_keys": True,
+            },
+            timeout=60.0,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    @staticmethod
+    def _collect_key_page(payload: dict, keys: dict[str, dict]) -> list:
+        """Merge one page's keys into ``keys``. Returns the raw batch."""
+        batch = payload.get("keys") or []
+        for entry in batch:
+            # With return_full_object=true entries are objects; be defensive in
+            # case LiteLLM returns bare token strings.
+            if not isinstance(entry, dict):
+                continue
+            token = entry.get("token")
+            if token:
+                keys[token] = entry
+        return batch
+
+    async def list_all_keys(self, page_size: int = 100) -> dict[str, dict]:
+        """Return every key in this region, keyed by LiteLLM's hashed token.
+
+        Bulk replacement for calling :meth:`get_key_info` once per key. The
+        reconciliation job needs the state of every key in a region, which as a
+        per-key loop costs one HTTP round-trip each (~0.18s), i.e. ~40 minutes
+        at 13.5k keys. ``/key/list`` returns the same full key objects 100 at a
+        time, so the same sweep costs ``ceil(n / 100)`` requests instead of n.
+
+        ``page_size`` is capped at 100 by LiteLLM (values above that are
+        rejected with a 422), so it is clamped rather than passed through.
+
+        The returned mapping is keyed the way LiteLLM stores tokens - the
+        SHA-256 hexdigest of an ``sk-`` key - so look values up via
+        :meth:`hash_token`. Values are the flat key objects, matching the
+        ``info`` sub-dict that :meth:`get_key_info` returns.
+        """
+        page_size = max(1, min(int(page_size), 100))
+        keys: dict[str, dict] = {}
+        try:
+            async with httpx.AsyncClient() as client:
+                first = await self._fetch_key_page(client, 1, page_size)
+                batch = self._collect_key_page(first, keys)
+                pages_fetched = 1
+
+                # A short or empty first page is the only page.
+                if batch and len(batch) >= page_size:
+                    total_pages = first.get("total_pages") or 0
+                    if total_pages and total_pages > 1:
+                        # Page count known: fetch the rest concurrently. Pages
+                        # are independent reads, so this turns a 119-page walk
+                        # from minutes into seconds.
+                        semaphore = asyncio.Semaphore(LIST_KEYS_PAGE_CONCURRENCY)
+
+                        async def _page(page_number: int) -> dict:
+                            async with semaphore:
+                                return await self._fetch_key_page(
+                                    client, page_number, page_size
+                                )
+
+                        payloads = await asyncio.gather(
+                            *[_page(p) for p in range(2, total_pages + 1)]
+                        )
+                        for payload in payloads:
+                            self._collect_key_page(payload, keys)
+                        pages_fetched = total_pages
+                    else:
+                        # total_pages absent: fall back to a sequential walk,
+                        # since we cannot know how many pages to request.
+                        page = 2
+                        while True:
+                            payload = await self._fetch_key_page(
+                                client, page, page_size
+                            )
+                            batch = self._collect_key_page(payload, keys)
+                            pages_fetched = page
+                            if not batch or len(batch) < page_size:
+                                break
+                            page += 1
+
+            logger.info(
+                "Listed %d LiteLLM keys from %s across %d page(s)",
+                len(keys),
+                self.api_url,
+                pages_fetched,
+            )
+            return keys
+        except httpx.HTTPStatusError as e:
+            status_code, error_msg, _ = self._parse_http_error(e)
+            logger.error("Error listing LiteLLM keys: %s", error_msg)
+            raise HTTPException(
+                status_code=status_code,
+                detail=f"Failed to list LiteLLM keys: {error_msg}",
             )
 
     async def get_key_last_used(self, litellm_token: str) -> Optional[datetime]:

--- a/scripts/trigger_recon_job.py
+++ b/scripts/trigger_recon_job.py
@@ -20,6 +20,10 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
+# EX_TEMPFAIL. Signals "did not run, try later" - distinct from success (0) and
+# from a hard failure (1) so an overrunning previous run can be alerted on.
+EXIT_LOCK_CONTENTION = 75
+
 
 async def trigger_recon_job():
     """Manually trigger the recon job (monitor_teams) in the background scheduler thread"""
@@ -47,10 +51,15 @@ async def trigger_recon_job():
                 release_lock(lock_name, db)
                 logger.info("Released monitor_teams lock")
         else:
-            logger.warning(
-                "Another process has the monitor_teams lock, cannot execute recon job"
+            # Lock contention on an hourly schedule almost always means the
+            # previous run is still going, i.e. monitor_teams is overrunning its
+            # window. Log at ERROR (not INFO) so it surfaces, and signal it
+            # distinctly via the exit code - see main().
+            logger.error(
+                "Another process has the monitor_teams lock, cannot execute recon job. "
+                "If this is the scheduled run, the previous run is overrunning its "
+                "interval and monitoring is being skipped."
             )
-            logger.info("This is normal if the scheduled job is currently running")
             return False
 
     except Exception as e:
@@ -72,11 +81,13 @@ def main():
             logger.info("✅ Recon job completed successfully")
             sys.exit(0)
         else:
-            logger.info(
-                "⚠️  Recon job could not be executed (lock held by another process)"
+            logger.error(
+                "⚠️  Recon job skipped: lock held by another process (likely an "
+                "overrunning previous run)"
             )
-            # Exiting with status 0 because this is a normal, expected condition (lock held)
-            sys.exit(0)
+            # EX_TEMPFAIL: distinguishable from success (0) and from a hard
+            # failure (1), so a skipped run is alertable instead of silent.
+            sys.exit(EXIT_LOCK_CONTENTION)
 
     except Exception as e:
         logger.error(f"❌ Script failed: {str(e)}")

--- a/tests/test_litellm_service.py
+++ b/tests/test_litellm_service.py
@@ -1178,3 +1178,273 @@ def test_get_team_daily_activity_filters_by_team_ids(mock_client_class, test_reg
     assert first_call.kwargs["params"]["team_ids"] == "Test_Region_7"
     assert first_call.kwargs["params"]["start_date"] == "2025-06-01"
     assert first_call.kwargs["params"]["end_date"] == "2025-06-02"
+
+
+def _key_list_client(pages):
+    """Build a mocked httpx client that returns ``pages`` in order from /key/list."""
+    responses = []
+    for payload in pages:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = payload
+        mock_response.raise_for_status.return_value = None
+        responses.append(mock_response)
+
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = responses
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+    return mock_client
+
+
+@patch("httpx.AsyncClient")
+def test_list_all_keys_paginates_and_keys_by_token(mock_client_class, test_region):
+    """Multi-page listing walks every page and keys results by hashed token."""
+    page_1 = {
+        "keys": [{"token": f"hash-{i}", "spend": float(i)} for i in range(100)],
+        "total_count": 150,
+        "total_pages": 2,
+    }
+    page_2 = {
+        "keys": [{"token": f"hash-{i}", "spend": float(i)} for i in range(100, 150)],
+        "total_count": 150,
+        "total_pages": 2,
+    }
+    mock_client = _key_list_client([page_1, page_2])
+    mock_client_class.return_value = mock_client
+
+    service = LiteLLMService(
+        api_url=test_region.litellm_api_url, api_key=test_region.litellm_api_key
+    )
+
+    result = asyncio.run(service.list_all_keys())
+
+    # Every key from both pages is present, keyed by its token
+    assert len(result) == 150
+    assert result["hash-0"]["spend"] == 0.0
+    assert result["hash-149"]["spend"] == 149.0
+
+    # Two requests, with the expected pagination params
+    assert mock_client.get.call_count == 2
+    first, second = mock_client.get.call_args_list
+    assert first.args[0].endswith("/key/list")
+    assert first.kwargs["params"]["page"] == 1
+    assert first.kwargs["params"]["size"] == 100
+    assert first.kwargs["params"]["return_full_object"] is True
+    assert first.kwargs["params"]["include_team_keys"] is True
+    assert second.kwargs["params"]["page"] == 2
+
+
+@patch("httpx.AsyncClient")
+def test_list_all_keys_partial_last_page(mock_client_class, test_region):
+    """A short final page ends pagination without an extra request."""
+    page_1 = {
+        "keys": [{"token": f"hash-{i}"} for i in range(100)],
+        "total_pages": 2,
+    }
+    page_2 = {"keys": [{"token": "hash-100"}], "total_pages": 2}
+    mock_client = _key_list_client([page_1, page_2])
+    mock_client_class.return_value = mock_client
+
+    service = LiteLLMService(
+        api_url=test_region.litellm_api_url, api_key=test_region.litellm_api_key
+    )
+
+    result = asyncio.run(service.list_all_keys())
+
+    assert len(result) == 101
+    assert mock_client.get.call_count == 2
+
+
+@patch("httpx.AsyncClient")
+def test_list_all_keys_empty_region(mock_client_class, test_region):
+    """A region with no keys returns an empty mapping after one request."""
+    mock_client = _key_list_client([{"keys": [], "total_count": 0, "total_pages": 0}])
+    mock_client_class.return_value = mock_client
+
+    service = LiteLLMService(
+        api_url=test_region.litellm_api_url, api_key=test_region.litellm_api_key
+    )
+
+    result = asyncio.run(service.list_all_keys())
+
+    assert result == {}
+    assert mock_client.get.call_count == 1
+
+
+@patch("httpx.AsyncClient")
+def test_list_all_keys_stops_without_total_pages(mock_client_class, test_region):
+    """A missing total_pages must not loop forever - an empty page ends it."""
+    page_1 = {"keys": [{"token": f"hash-{i}"} for i in range(100)]}
+    page_2 = {"keys": []}
+    mock_client = _key_list_client([page_1, page_2])
+    mock_client_class.return_value = mock_client
+
+    service = LiteLLMService(
+        api_url=test_region.litellm_api_url, api_key=test_region.litellm_api_key
+    )
+
+    result = asyncio.run(service.list_all_keys())
+
+    assert len(result) == 100
+    assert mock_client.get.call_count == 2
+
+
+@patch("httpx.AsyncClient")
+def test_list_all_keys_clamps_page_size_to_100(mock_client_class, test_region):
+    """LiteLLM rejects size > 100 with a 422, so the value is clamped."""
+    mock_client = _key_list_client([{"keys": [], "total_pages": 0}])
+    mock_client_class.return_value = mock_client
+
+    service = LiteLLMService(
+        api_url=test_region.litellm_api_url, api_key=test_region.litellm_api_key
+    )
+
+    asyncio.run(service.list_all_keys(page_size=5000))
+
+    assert mock_client.get.call_args_list[0].kwargs["params"]["size"] == 100
+
+
+@patch("httpx.AsyncClient")
+def test_list_all_keys_skips_non_dict_entries(mock_client_class, test_region):
+    """Bare token strings are ignored rather than breaking the sweep."""
+    page_1 = {
+        "keys": ["sk-bare-string", {"token": "hash-1", "spend": 1.0}, {"spend": 2.0}],
+        "total_pages": 1,
+    }
+    mock_client = _key_list_client([page_1])
+    mock_client_class.return_value = mock_client
+
+    service = LiteLLMService(
+        api_url=test_region.litellm_api_url, api_key=test_region.litellm_api_key
+    )
+
+    result = asyncio.run(service.list_all_keys())
+
+    # Only the entry that is a dict AND has a token is kept
+    assert result == {"hash-1": {"token": "hash-1", "spend": 1.0}}
+
+
+@patch("httpx.AsyncClient")
+def test_list_all_keys_failure_raises(mock_client_class, test_region):
+    """A non-2xx response surfaces as an HTTPException."""
+    request = httpx.Request("GET", f"{test_region.litellm_api_url}/key/list")
+    response = httpx.Response(status_code=500, request=request, text="boom")
+    mock_response = Mock()
+    mock_response.status_code = 500
+    mock_response.raise_for_status.side_effect = HTTPStatusError(
+        "boom", request=request, response=response
+    )
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+    mock_client_class.return_value = mock_client
+
+    service = LiteLLMService(
+        api_url=test_region.litellm_api_url, api_key=test_region.litellm_api_key
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(service.list_all_keys())
+
+    assert exc_info.value.status_code == 500
+
+
+def _key_list_client_by_page(pages_by_number, record=None):
+    """Mock client that answers /key/list from a {page_number: payload} map.
+
+    Page-keyed rather than call-ordered, because pages after the first are
+    fetched concurrently and may arrive in any order.
+    """
+
+    async def _get(url, headers=None, params=None, timeout=None):
+        page = params["page"]
+        if record is not None:
+            record.append(page)
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = pages_by_number[page]
+        mock_response.raise_for_status.return_value = None
+        return mock_response
+
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = _get
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+    return mock_client
+
+
+@patch("httpx.AsyncClient")
+def test_list_all_keys_fetches_later_pages_concurrently(mock_client_class, test_region):
+    """With total_pages known, pages 2..N are requested and all keys merged."""
+    pages = {
+        n: {
+            "keys": [
+                {"token": f"hash-{(n - 1) * 100 + i}"}
+                for i in range(100 if n < 4 else 25)
+            ],
+            "total_pages": 4,
+        }
+        for n in (1, 2, 3, 4)
+    }
+    requested = []
+    mock_client = _key_list_client_by_page(pages, record=requested)
+    mock_client_class.return_value = mock_client
+
+    service = LiteLLMService(
+        api_url=test_region.litellm_api_url, api_key=test_region.litellm_api_key
+    )
+
+    result = asyncio.run(service.list_all_keys())
+
+    # 3 full pages + a 25-key final page
+    assert len(result) == 325
+    # Every page requested exactly once, order-independent
+    assert sorted(requested) == [1, 2, 3, 4]
+
+
+@patch("httpx.AsyncClient")
+def test_list_all_keys_concurrency_is_bounded(mock_client_class, test_region):
+    """No more than LIST_KEYS_PAGE_CONCURRENCY page requests run at once."""
+    from app.services import litellm as litellm_module
+
+    total = 30
+    pages = {
+        n: {
+            "keys": [{"token": f"h-{n}-{i}"} for i in range(100 if n < total else 5)],
+            "total_pages": total,
+        }
+        for n in range(1, total + 1)
+    }
+
+    in_flight = 0
+    peak = 0
+
+    async def _get(url, headers=None, params=None, timeout=None):
+        nonlocal in_flight, peak
+        in_flight += 1
+        peak = max(peak, in_flight)
+        await asyncio.sleep(0)  # let other tasks interleave
+        in_flight -= 1
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = pages[params["page"]]
+        mock_response.raise_for_status.return_value = None
+        return mock_response
+
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = _get
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+    mock_client_class.return_value = mock_client
+
+    service = LiteLLMService(
+        api_url=test_region.litellm_api_url, api_key=test_region.litellm_api_key
+    )
+
+    result = asyncio.run(service.list_all_keys())
+
+    assert len(result) == 29 * 100 + 5
+    assert peak <= litellm_module.LIST_KEYS_PAGE_CONCURRENCY

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1558,6 +1558,7 @@ async def test_reconcile_team_keys_with_renewal_period_updates(
     mock_instance = mock_litellm.return_value
     mock_instance.get_key_info = AsyncMock()
     mock_instance.update_budget = AsyncMock()
+    mock_instance.update_key_budget = AsyncMock()
 
     # Mock key info responses - both keys have different budget amounts, triggering updates
     mock_instance.get_key_info.side_effect = [
@@ -1604,24 +1605,28 @@ async def test_reconcile_team_keys_with_renewal_period_updates(
     # Verify get_key_info was called for both keys
     assert mock_instance.get_key_info.call_count == 2
 
-    # Verify update_budget was called for both keys since they have different settings
-    assert mock_instance.update_budget.call_count == 2
+    # Only the budget amount drifted, so the write must go through
+    # update_key_budget, which leaves duration/expiry alone.
+    assert mock_instance.update_key_budget.call_count == 2
+    mock_instance.update_budget.assert_not_called()
 
     # Check the first call (team key)
-    first_call = mock_instance.update_budget.call_args_list[0]
+    first_call = mock_instance.update_key_budget.call_args_list[0]
     assert (
         first_call[0][0] == "team_token_123"
     )  # First positional argument should be litellm_token
-    assert first_call[1]["budget_amount"] == test_product.max_budget_per_key
-    # budget_duration should not be updated since it's not None and no other conditions trigger an update
+    assert first_call[1]["max_budget"] == test_product.max_budget_per_key
+    # budget_duration is not None and nothing else drifted, so it must not be sent
+    assert first_call[1]["budget_duration"] is None
 
     # Check the second call (user key)
-    second_call = mock_instance.update_budget.call_args_list[1]
+    second_call = mock_instance.update_key_budget.call_args_list[1]
     assert (
         second_call[0][0] == "user_token_456"
     )  # First positional argument should be litellm_token
-    assert second_call[1]["budget_amount"] == test_product.max_budget_per_key
-    # budget_duration should not be updated since it's not None and no other conditions trigger an update
+    assert second_call[1]["max_budget"] == test_product.max_budget_per_key
+    # budget_duration is not None and nothing else drifted, so it must not be sent
+    assert second_call[1]["budget_duration"] is None
 
     # Verify team total spend is calculated correctly
     assert team_total == 5.0  # 0.0 + 5.0
@@ -1668,6 +1673,7 @@ async def test_reconcile_team_keys_with_renewal_period_updates_no_products(
     mock_instance = mock_litellm.return_value
     mock_instance.get_key_info = AsyncMock()
     mock_instance.update_budget = AsyncMock()
+    mock_instance.update_key_budget = AsyncMock()
 
     # Mock key info responses - both keys have None budget_duration, triggering updates
     mock_instance.get_key_info.side_effect = [
@@ -1709,30 +1715,27 @@ async def test_reconcile_team_keys_with_renewal_period_updates_no_products(
     # Verify get_key_info was called for both keys
     assert mock_instance.get_key_info.call_count == 2
 
-    # Verify update_budget was called for both keys since they have None budget_duration
-    assert mock_instance.update_budget.call_count == 2
+    # Only budget_duration drifted, so the key's expiry must not be touched
+    assert mock_instance.update_key_budget.call_count == 2
+    mock_instance.update_budget.assert_not_called()
 
     # Check the first call (team key)
-    first_call = mock_instance.update_budget.call_args_list[0]
+    first_call = mock_instance.update_key_budget.call_args_list[0]
     assert (
         first_call[0][0] == "team_token_123"
     )  # First positional argument should be litellm_token
-    assert (
-        first_call[0][1] == "30d"
-    )  # Second positional argument should be budget_duration
-    # Should not have budget_amount since no products were found
-    assert first_call[1]["budget_amount"] is None
+    assert first_call[1]["budget_duration"] == "30d"
+    # Should not have a budget amount since no products were found
+    assert first_call[1]["max_budget"] is None
 
     # Check the second call (user key)
-    second_call = mock_instance.update_budget.call_args_list[1]
+    second_call = mock_instance.update_key_budget.call_args_list[1]
     assert (
         second_call[0][0] == "user_token_456"
     )  # First positional argument should be litellm_token
-    assert (
-        second_call[0][1] == "30d"
-    )  # Second positional argument should be budget_duration
-    # Should not have budget_amount since no products were found
-    assert second_call[1]["budget_amount"] is None
+    assert second_call[1]["budget_duration"] == "30d"
+    # Should not have a budget amount since no products were found
+    assert second_call[1]["max_budget"] is None
 
     # Verify team total spend is calculated correctly
     assert team_total == 5.0  # 0.0 + 5.0
@@ -1780,6 +1783,7 @@ async def test_reconcile_team_keys_none_budget_duration_handled(
     mock_instance = mock_litellm.return_value
     mock_instance.get_key_info = AsyncMock()
     mock_instance.update_budget = AsyncMock()
+    mock_instance.update_key_budget = AsyncMock()
 
     current_time = datetime.now(UTC)
 
@@ -1807,16 +1811,15 @@ async def test_reconcile_team_keys_none_budget_duration_handled(
         test_product.max_budget_per_key,
     )
 
-    # Verify update_budget was called because budget_duration is None (forces update)
-    assert mock_instance.update_budget.call_count == 1
-    update_call = mock_instance.update_budget.call_args
+    # Verify a write was issued because budget_duration is None (forces update)
+    assert mock_instance.update_key_budget.call_count == 1
+    mock_instance.update_budget.assert_not_called()
+    update_call = mock_instance.update_key_budget.call_args
     assert (
         update_call[0][0] == "team_token_123"
     )  # First positional argument should be litellm_token
-    assert (
-        update_call[0][1] == f"{test_product.renewal_period_days}d"
-    )  # Second positional argument should be budget_duration
-    assert update_call[1]["budget_amount"] == test_product.max_budget_per_key
+    assert update_call[1]["budget_duration"] == f"{test_product.renewal_period_days}d"
+    assert update_call[1]["max_budget"] == test_product.max_budget_per_key
 
     # Verify team total spend is calculated correctly
     assert team_total == 10.0
@@ -1864,6 +1867,7 @@ async def test_reconcile_team_keys_zero_duration_renewal(
     mock_instance = mock_litellm.return_value
     mock_instance.get_key_info = AsyncMock()
     mock_instance.update_budget = AsyncMock()
+    mock_instance.update_key_budget = AsyncMock()
 
     current_time = datetime.now(UTC)
 
@@ -1893,16 +1897,15 @@ async def test_reconcile_team_keys_zero_duration_renewal(
         test_product.max_budget_per_key,
     )
 
-    # Verify update_budget was called to fix the "0d" duration
-    assert mock_instance.update_budget.call_count == 1
-    update_call = mock_instance.update_budget.call_args
+    # Verify a write was issued to fix the "0d" duration
+    assert mock_instance.update_key_budget.call_count == 1
+    mock_instance.update_budget.assert_not_called()
+    update_call = mock_instance.update_key_budget.call_args
     assert (
         update_call[0][0] == "team_token_123"
     )  # First positional argument should be litellm_token
-    assert (
-        update_call[0][1] == f"{test_product.renewal_period_days}d"
-    )  # Second positional argument should be budget_duration
-    assert update_call[1]["budget_amount"] == test_product.max_budget_per_key
+    assert update_call[1]["budget_duration"] == f"{test_product.renewal_period_days}d"
+    assert update_call[1]["max_budget"] == test_product.max_budget_per_key
 
     # Verify team total spend is calculated correctly
     assert team_total == 10.0
@@ -1924,7 +1927,7 @@ async def test_reconcile_team_keys_update_budget_parameter_issue(
 
     GIVEN: A team with a product and keys that have different budget amounts
     WHEN: reconcile_team_keys is called with renewal period and budget amount
-    THEN: update_budget should be called with litellm_token as first positional argument, not as keyword argument
+    THEN: the write should be called with litellm_token as first positional argument, not as keyword argument
     """
     # Set up team-product association
     team_product = DBTeamProduct(team_id=test_team.id, product_id=test_product.id)
@@ -1944,6 +1947,7 @@ async def test_reconcile_team_keys_update_budget_parameter_issue(
     mock_instance = mock_litellm.return_value
     mock_instance.get_key_info = AsyncMock()
     mock_instance.update_budget = AsyncMock()
+    mock_instance.update_key_budget = AsyncMock()
 
     # Mock key info response - different budget amount triggers update
     mock_instance.get_key_info.return_value = {
@@ -1969,18 +1973,21 @@ async def test_reconcile_team_keys_update_budget_parameter_issue(
         test_product.max_budget_per_key,
     )
 
-    # Verify update_budget was called with correct parameters
-    assert mock_instance.update_budget.call_count == 1
+    # Only the budget amount drifted, so duration/expiry must be left alone
+    assert mock_instance.update_key_budget.call_count == 1
+    mock_instance.update_budget.assert_not_called()
 
     # Check that litellm_token is passed as first positional argument, not as keyword
-    call_args = mock_instance.update_budget.call_args
+    call_args = mock_instance.update_key_budget.call_args
     # After the fix, litellm_token should be the first positional argument
     assert (
         call_args[0][0] == "team_token_123"
     )  # First positional argument should be litellm_token
     assert (
-        call_args[1]["budget_amount"] == test_product.max_budget_per_key
-    )  # budget_amount as keyword argument
+        call_args[1]["max_budget"] == test_product.max_budget_per_key
+    )  # max_budget as keyword argument
+    # A healthy budget_duration must not be sent, since null clears it in LiteLLM
+    assert call_args[1]["budget_duration"] is None
 
 
 @pytest.mark.asyncio
@@ -2025,6 +2032,7 @@ async def test_reconcile_team_keys_expiry_within_next_month(
     mock_instance = mock_litellm.return_value
     mock_instance.get_key_info = AsyncMock()
     mock_instance.update_budget = AsyncMock()
+    mock_instance.update_key_budget = AsyncMock()
 
     current_time = datetime.now(UTC)
     # Set expiry date to 15 days from now (within the 30-day window)
@@ -2113,6 +2121,7 @@ async def test_reconcile_team_keys_expired_key(
     mock_instance = mock_litellm.return_value
     mock_instance.get_key_info = AsyncMock()
     mock_instance.update_budget = AsyncMock()
+    mock_instance.update_key_budget = AsyncMock()
 
     current_time = datetime.now(UTC)
     # Set expiry date to 5 days ago (already expired)
@@ -2201,6 +2210,7 @@ async def test_reconcile_team_keys_expiry_beyond_next_month(
     mock_instance = mock_litellm.return_value
     mock_instance.get_key_info = AsyncMock()
     mock_instance.update_budget = AsyncMock()
+    mock_instance.update_key_budget = AsyncMock()
 
     current_time = datetime.now(UTC)
     # Set expiry date to 45 days from now (beyond the 30-day window)
@@ -2231,8 +2241,9 @@ async def test_reconcile_team_keys_expiry_beyond_next_month(
         test_product.max_budget_per_key,
     )
 
-    # Verify update_budget was not called for expiry reasons
+    # Verify no write was issued for expiry reasons, on either path
     assert mock_instance.update_budget.call_count == 0
+    assert mock_instance.update_key_budget.call_count == 0
 
     # Verify team total spend is calculated correctly
     assert team_total == 10.0
@@ -3756,6 +3767,7 @@ async def test_reconcile_team_keys_uses_snapshot_not_per_key_info(
     mock_instance = mock_litellm.return_value
     mock_instance.get_key_info = AsyncMock()
     mock_instance.update_budget = AsyncMock()
+    mock_instance.update_key_budget = AsyncMock()
     mock_instance.list_all_keys = AsyncMock(
         return_value={
             _Svc.hash_token("sk-team-1"): {
@@ -3814,6 +3826,7 @@ async def test_reconcile_team_keys_shares_cache_across_teams(
     mock_instance = mock_litellm.return_value
     mock_instance.get_key_info = AsyncMock()
     mock_instance.update_budget = AsyncMock()
+    mock_instance.update_key_budget = AsyncMock()
     mock_instance.list_all_keys = AsyncMock(
         return_value={
             _Svc.hash_token("sk-team-1"): {"spend": 1.0, "max_budget": 10.0},
@@ -3866,6 +3879,7 @@ async def test_reconcile_team_keys_still_writes_from_snapshot_state(
     mock_instance = mock_litellm.return_value
     mock_instance.get_key_info = AsyncMock()
     mock_instance.update_budget = AsyncMock()
+    mock_instance.update_key_budget = AsyncMock()
     mock_instance.list_all_keys = AsyncMock(
         return_value={
             _Svc.hash_token("sk-team-1"): {
@@ -3880,10 +3894,64 @@ async def test_reconcile_team_keys_still_writes_from_snapshot_state(
     keys_by_region = get_team_keys_by_region(db, test_team.id)
     await reconcile_team_keys(db, test_team, keys_by_region, False, 30, 50.0)
 
+    mock_instance.update_key_budget.assert_awaited_once()
+    mock_instance.update_budget.assert_not_awaited()
+    args = mock_instance.update_key_budget.await_args
+    assert args.args[0] == "sk-team-1"
+    assert args.kwargs["max_budget"] == 50.0
+    # Only the amount drifted in the snapshot, so the healthy budget_duration
+    # must not be sent along - LiteLLM reads a null as "clear it".
+    assert args.kwargs["budget_duration"] is None
+
+
+@pytest.mark.asyncio
+@patch("app.core.worker.LiteLLMService")
+async def test_reconcile_team_keys_near_expiry_still_resets_duration(
+    mock_litellm, db, test_team, test_region
+):
+    """
+    Given: A snapshot key that expires within the next month
+    When: reconcile_team_keys runs off the snapshot
+    Then: The write goes through update_budget, which resets the key duration -
+          the narrow write path must not swallow the expiry extension
+    """
+    from app.services.litellm import LiteLLMService as _Svc
+
+    key = DBPrivateAIKey(
+        name="Team Key",
+        litellm_token="sk-team-1",
+        region=test_region,
+        team_id=test_team.id,
+    )
+    db.add(key)
+    db.commit()
+
+    mock_instance = mock_litellm.return_value
+    mock_instance.get_key_info = AsyncMock()
+    mock_instance.update_budget = AsyncMock()
+    mock_instance.update_key_budget = AsyncMock()
+    mock_instance.list_all_keys = AsyncMock(
+        return_value={
+            _Svc.hash_token("sk-team-1"): {
+                "spend": 1.0,
+                "max_budget": 50.0,  # matches, so only the expiry drifts
+                "key_alias": "team_key",
+                "budget_duration": "30d",
+                "expires": (datetime.now(UTC) + timedelta(days=5)).isoformat(),
+            }
+        }
+    )
+
+    keys_by_region = get_team_keys_by_region(db, test_team.id)
+    await reconcile_team_keys(db, test_team, keys_by_region, False, 30, 50.0)
+
     mock_instance.update_budget.assert_awaited_once()
+    mock_instance.update_key_budget.assert_not_awaited()
     args = mock_instance.update_budget.await_args
     assert args.args[0] == "sk-team-1"
-    assert args.kwargs["budget_amount"] == 50.0
+    assert args.args[1] == "30d"
+    # Budget matched, so no amount is sent and the existing one is left in place
+    assert args.kwargs["budget_amount"] is None
 
 
 # ---------------------------------------------------------------------------
@@ -3994,6 +4062,7 @@ async def test_reconcile_team_keys_expire_writes_are_batched(
     mock_instance = mock_litellm.return_value
     mock_instance.get_key_info = AsyncMock()
     mock_instance.update_budget = AsyncMock()
+    mock_instance.update_key_budget = AsyncMock()
     mock_instance.update_key_duration = AsyncMock()
     mock_instance.list_all_keys = AsyncMock(
         return_value={
@@ -4042,6 +4111,7 @@ async def test_reconcile_team_keys_write_failure_does_not_lose_spend(
     mock_instance = mock_litellm.return_value
     mock_instance.get_key_info = AsyncMock()
     mock_instance.update_budget = AsyncMock()
+    mock_instance.update_key_budget = AsyncMock()
     mock_instance.update_key_duration = AsyncMock(side_effect=_maybe_fail)
     mock_instance.list_all_keys = AsyncMock(
         return_value={

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4085,6 +4085,64 @@ async def test_reconcile_team_keys_expire_writes_are_batched(
 
 
 @pytest.mark.asyncio
+@patch("app.core.worker.KEY_WRITE_BATCH", 2)
+@patch("app.core.worker.LiteLLMService")
+async def test_reconcile_team_keys_flushes_writes_before_region_ends(
+    mock_litellm, db, test_team, test_region
+):
+    """
+    Given: More keys than KEY_WRITE_BATCH, and no usable bulk snapshot
+    When: reconcile_team_keys runs with expire_keys=True
+    Then: Expiry writes start landing before the last key has been read
+
+    Without batching, every key stays usable until the whole region is read.
+    That wait is worst on the fallback path, where each read is a round-trip.
+    """
+    tokens = [f"sk-flush-{i}" for i in range(5)]
+    for i, tok in enumerate(tokens):
+        db.add(
+            DBPrivateAIKey(
+                name=f"Key {i}",
+                litellm_token=tok,
+                region=test_region,
+                team_id=test_team.id,
+            )
+        )
+    db.commit()
+
+    events = []
+
+    async def _read(token):
+        events.append(("read", token))
+        return {"info": {"spend": 1.0, "max_budget": 10.0}}
+
+    async def _write(token, duration):
+        events.append(("write", token))
+
+    mock_instance = mock_litellm.return_value
+    mock_instance.get_key_info = AsyncMock(side_effect=_read)
+    mock_instance.update_budget = AsyncMock()
+    mock_instance.update_key_budget = AsyncMock()
+    mock_instance.update_key_duration = AsyncMock(side_effect=_write)
+    # Empty snapshot forces the per-key fallback read for every key
+    mock_instance.list_all_keys = AsyncMock(return_value={})
+
+    keys_by_region = get_team_keys_by_region(db, test_team.id)
+    team_total = await reconcile_team_keys(db, test_team, keys_by_region, True)
+
+    assert team_total == 5.0
+    # Every key still expired, and spend still counted
+    assert mock_instance.update_key_duration.await_count == 5
+
+    kinds = [kind for kind, _ in events]
+    first_write = kinds.index("write")
+    last_read = len(kinds) - 1 - kinds[::-1].index("read")
+    assert first_write < last_read, (
+        f"writes only ran after every read finished: {events}"
+    )
+
+
+@pytest.mark.asyncio
 @patch("app.core.worker.LiteLLMService")
 async def test_reconcile_team_keys_write_failure_does_not_lose_spend(
     mock_litellm, db, test_team, test_region

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 import stripe
 from app.db.models import (
@@ -23,6 +24,8 @@ from app.core.worker import (
     team_total_spend,
     active_team_labels,
     reconcile_team_keys,
+    RegionKeyStateCache,
+    _resolve_key_state,
     _sync_periodic_ledger_for_invoice,
     _get_snapshot_remaining_cents,
     _parse_client_reference_ids,
@@ -3631,3 +3634,424 @@ async def test_invoice_ledger_duplicate_invoice_id_is_idempotent(
         f"Double-allocation detected: consumed_cents={topup_entry.consumed_cents}, "
         "expected at most 100¢ from a single FIFO run"
     )
+
+
+# ---------------------------------------------------------------------------
+# Bulk /key/list snapshot behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_region_key_state_cache_lists_region_once(test_region):
+    """The snapshot is fetched once per region and reused for later teams."""
+    service = AsyncMock()
+    service.list_all_keys.return_value = {"hash-1": {"spend": 1.0}}
+
+    cache = RegionKeyStateCache()
+    first = await cache.get(test_region, service)
+    second = await cache.get(test_region, service)
+
+    assert first == {"hash-1": {"spend": 1.0}}
+    assert second is first
+    # Reused, not re-listed: this is what keeps ~1.1k teams from re-paginating
+    assert service.list_all_keys.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_region_key_state_cache_caches_failure(test_region):
+    """A failing region degrades to an empty snapshot and is not retried per team."""
+    service = AsyncMock()
+    service.list_all_keys.side_effect = Exception("litellm down")
+
+    cache = RegionKeyStateCache()
+    first = await cache.get(test_region, service)
+    second = await cache.get(test_region, service)
+
+    assert first == {}
+    assert second == {}
+    assert service.list_all_keys.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_region_key_state_cache_rejects_non_dict(test_region):
+    """A non-mapping response degrades instead of being indexed into."""
+    service = AsyncMock()
+    service.list_all_keys.return_value = ["not", "a", "dict"]
+
+    cache = RegionKeyStateCache()
+    result = await cache.get(test_region, service)
+
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_resolve_key_state_prefers_snapshot(test_region):
+    """A key present in the snapshot must not trigger a /key/info call."""
+    key = DBPrivateAIKey(name="k", litellm_token="sk-abc", region_id=test_region.id)
+    from app.services.litellm import LiteLLMService as _Svc
+
+    snapshot = {_Svc.hash_token("sk-abc"): {"spend": 3.0, "max_budget": 10.0}}
+    service = AsyncMock()
+
+    info = await _resolve_key_state(key, test_region, service, snapshot)
+
+    assert info == {"spend": 3.0, "max_budget": 10.0}
+    service.get_key_info.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_key_state_falls_back_when_key_missing(test_region):
+    """A key created after the snapshot still resolves, via /key/info."""
+    key = DBPrivateAIKey(name="k", litellm_token="sk-new", region_id=test_region.id)
+    snapshot = {"some-other-hash": {"spend": 1.0}}
+    service = AsyncMock()
+    service.get_key_info.return_value = {"info": {"spend": 7.0}}
+
+    info = await _resolve_key_state(key, test_region, service, snapshot)
+
+    assert info == {"spend": 7.0}
+    service.get_key_info.assert_awaited_once_with("sk-new")
+
+
+@pytest.mark.asyncio
+async def test_resolve_key_state_falls_back_on_empty_snapshot(test_region):
+    """An empty snapshot (failed listing) falls back for every key."""
+    key = DBPrivateAIKey(name="k", litellm_token="sk-abc", region_id=test_region.id)
+    service = AsyncMock()
+    service.get_key_info.return_value = {"info": {"spend": 2.0}}
+
+    info = await _resolve_key_state(key, test_region, service, {})
+
+    assert info == {"spend": 2.0}
+    service.get_key_info.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("app.core.worker.LiteLLMService")
+async def test_reconcile_team_keys_uses_snapshot_not_per_key_info(
+    mock_litellm, db, test_team, test_region, test_team_user
+):
+    """
+    Given: A team whose keys are all present in the bulk snapshot
+    When: reconcile_team_keys runs
+    Then: Spend comes from the snapshot and no per-key /key/info call is made
+    """
+    from app.services.litellm import LiteLLMService as _Svc
+
+    team_key = DBPrivateAIKey(
+        name="Team Key",
+        litellm_token="sk-team-1",
+        region=test_region,
+        team_id=test_team.id,
+    )
+    user_key = DBPrivateAIKey(
+        name="User Key",
+        litellm_token="sk-user-1",
+        region=test_region,
+        owner_id=test_team_user.id,
+    )
+    db.add_all([team_key, user_key])
+    db.commit()
+
+    mock_instance = mock_litellm.return_value
+    mock_instance.get_key_info = AsyncMock()
+    mock_instance.update_budget = AsyncMock()
+    mock_instance.list_all_keys = AsyncMock(
+        return_value={
+            _Svc.hash_token("sk-team-1"): {
+                "spend": 4.0,
+                "max_budget": 50.0,
+                "key_alias": "team_key",
+                "budget_duration": "30d",
+            },
+            _Svc.hash_token("sk-user-1"): {
+                "spend": 6.0,
+                "max_budget": 50.0,
+                "key_alias": "user_key",
+                "budget_duration": "30d",
+            },
+        }
+    )
+
+    keys_by_region = get_team_keys_by_region(db, test_team.id)
+    team_total = await reconcile_team_keys(db, test_team, keys_by_region, False)
+
+    assert team_total == 10.0
+    # The whole point of the change: one bulk listing, zero per-key lookups
+    assert mock_instance.list_all_keys.await_count == 1
+    mock_instance.get_key_info.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("app.core.worker.LiteLLMService")
+async def test_reconcile_team_keys_shares_cache_across_teams(
+    mock_litellm, db, test_team, test_region
+):
+    """A shared cache means a second team in the same region does not re-list."""
+    from app.services.litellm import LiteLLMService as _Svc
+
+    key = DBPrivateAIKey(
+        name="Team Key",
+        litellm_token="sk-team-1",
+        region=test_region,
+        team_id=test_team.id,
+    )
+    db.add(key)
+
+    other_team = DBTeam(name="Other Team", admin_email="other@example.com")
+    db.add(other_team)
+    db.commit()
+
+    other_key = DBPrivateAIKey(
+        name="Other Key",
+        litellm_token="sk-other-1",
+        region=test_region,
+        team_id=other_team.id,
+    )
+    db.add(other_key)
+    db.commit()
+
+    mock_instance = mock_litellm.return_value
+    mock_instance.get_key_info = AsyncMock()
+    mock_instance.update_budget = AsyncMock()
+    mock_instance.list_all_keys = AsyncMock(
+        return_value={
+            _Svc.hash_token("sk-team-1"): {"spend": 1.0, "max_budget": 10.0},
+            _Svc.hash_token("sk-other-1"): {"spend": 2.0, "max_budget": 10.0},
+        }
+    )
+
+    cache = RegionKeyStateCache()
+    total_a = await reconcile_team_keys(
+        db,
+        test_team,
+        get_team_keys_by_region(db, test_team.id),
+        False,
+        key_state_cache=cache,
+    )
+    total_b = await reconcile_team_keys(
+        db,
+        other_team,
+        get_team_keys_by_region(db, other_team.id),
+        False,
+        key_state_cache=cache,
+    )
+
+    assert total_a == 1.0
+    assert total_b == 2.0
+    assert mock_instance.list_all_keys.await_count == 1
+
+
+@pytest.mark.asyncio
+@patch("app.core.worker.LiteLLMService")
+async def test_reconcile_team_keys_still_writes_from_snapshot_state(
+    mock_litellm, db, test_team, test_region
+):
+    """
+    Given: A key whose snapshot budget differs from the expected budget
+    When: reconcile_team_keys runs off the snapshot
+    Then: The budget correction is still issued (writes are unchanged)
+    """
+    from app.services.litellm import LiteLLMService as _Svc
+
+    key = DBPrivateAIKey(
+        name="Team Key",
+        litellm_token="sk-team-1",
+        region=test_region,
+        team_id=test_team.id,
+    )
+    db.add(key)
+    db.commit()
+
+    mock_instance = mock_litellm.return_value
+    mock_instance.get_key_info = AsyncMock()
+    mock_instance.update_budget = AsyncMock()
+    mock_instance.list_all_keys = AsyncMock(
+        return_value={
+            _Svc.hash_token("sk-team-1"): {
+                "spend": 1.0,
+                "max_budget": 25.0,  # differs from the 50.0 we pass in
+                "key_alias": "team_key",
+                "budget_duration": "30d",
+            }
+        }
+    )
+
+    keys_by_region = get_team_keys_by_region(db, test_team.id)
+    await reconcile_team_keys(db, test_team, keys_by_region, False, 30, 50.0)
+
+    mock_instance.update_budget.assert_awaited_once()
+    args = mock_instance.update_budget.await_args
+    assert args.args[0] == "sk-team-1"
+    assert args.kwargs["budget_amount"] == 50.0
+
+
+# ---------------------------------------------------------------------------
+# Bounded-concurrency key writes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_key_writes_executes_all_and_returns_zero_failures():
+    """Every queued write runs; no failures reported on the happy path."""
+    from app.core.worker import _run_key_writes
+
+    called = []
+
+    def _make(i):
+        async def _write():
+            called.append(i)
+
+        return _write
+
+    pending = [(i, _make(i)) for i in range(25)]
+    failures = await _run_key_writes(pending, "test-region")
+
+    assert failures == 0
+    assert sorted(called) == list(range(25))
+
+
+@pytest.mark.asyncio
+async def test_run_key_writes_isolates_failures():
+    """A failing write is counted but does not stop the others."""
+    from app.core.worker import _run_key_writes
+
+    done = []
+
+    def _ok(i):
+        async def _write():
+            done.append(i)
+
+        return _write
+
+    async def _boom():
+        raise RuntimeError("litellm rejected the update")
+
+    pending = [(1, _ok(1)), (2, _boom), (3, _ok(3))]
+    failures = await _run_key_writes(pending, "test-region")
+
+    assert failures == 1
+    assert sorted(done) == [1, 3]
+
+
+@pytest.mark.asyncio
+async def test_run_key_writes_is_bounded():
+    """No more than KEY_WRITE_CONCURRENCY writes are in flight at once."""
+    from app.core import worker as worker_module
+    from app.core.worker import _run_key_writes
+
+    in_flight = 0
+    peak = 0
+
+    def _make():
+        async def _write():
+            nonlocal in_flight, peak
+            in_flight += 1
+            peak = max(peak, in_flight)
+            await asyncio.sleep(0)
+            in_flight -= 1
+
+        return _write
+
+    pending = [(i, _make()) for i in range(50)]
+    await _run_key_writes(pending, "test-region")
+
+    assert peak <= worker_module.KEY_WRITE_CONCURRENCY
+
+
+@pytest.mark.asyncio
+async def test_run_key_writes_empty_is_noop():
+    """An empty queue short-circuits."""
+    from app.core.worker import _run_key_writes
+
+    assert await _run_key_writes([], "test-region") == 0
+
+
+@pytest.mark.asyncio
+@patch("app.core.worker.LiteLLMService")
+async def test_reconcile_team_keys_expire_writes_are_batched(
+    mock_litellm, db, test_team, test_region
+):
+    """
+    Given: A team with several keys and expire_keys=True
+    When: reconcile_team_keys runs
+    Then: Every key gets an expiry write, issued through the batched path
+    """
+    from app.services.litellm import LiteLLMService as _Svc
+
+    tokens = [f"sk-expire-{i}" for i in range(5)]
+    for i, tok in enumerate(tokens):
+        db.add(
+            DBPrivateAIKey(
+                name=f"Key {i}",
+                litellm_token=tok,
+                region=test_region,
+                team_id=test_team.id,
+            )
+        )
+    db.commit()
+
+    mock_instance = mock_litellm.return_value
+    mock_instance.get_key_info = AsyncMock()
+    mock_instance.update_budget = AsyncMock()
+    mock_instance.update_key_duration = AsyncMock()
+    mock_instance.list_all_keys = AsyncMock(
+        return_value={
+            _Svc.hash_token(tok): {"spend": 1.0, "max_budget": 10.0} for tok in tokens
+        }
+    )
+
+    keys_by_region = get_team_keys_by_region(db, test_team.id)
+    team_total = await reconcile_team_keys(db, test_team, keys_by_region, True)
+
+    # Spend still accumulated for every key
+    assert team_total == 5.0
+    # One expiry write per key, and no budget writes on the expire path
+    assert mock_instance.update_key_duration.await_count == 5
+    assert mock_instance.update_budget.await_count == 0
+    expired = sorted(
+        c.args[0] for c in mock_instance.update_key_duration.await_args_list
+    )
+    assert expired == sorted(tokens)
+
+
+@pytest.mark.asyncio
+@patch("app.core.worker.LiteLLMService")
+async def test_reconcile_team_keys_write_failure_does_not_lose_spend(
+    mock_litellm, db, test_team, test_region
+):
+    """A failed expiry write must not stop the other keys being processed."""
+    from app.services.litellm import LiteLLMService as _Svc
+
+    tokens = ["sk-a", "sk-b", "sk-c"]
+    for i, tok in enumerate(tokens):
+        db.add(
+            DBPrivateAIKey(
+                name=f"Key {i}",
+                litellm_token=tok,
+                region=test_region,
+                team_id=test_team.id,
+            )
+        )
+    db.commit()
+
+    async def _maybe_fail(token, duration):
+        if token == "sk-b":
+            raise RuntimeError("litellm 500")
+
+    mock_instance = mock_litellm.return_value
+    mock_instance.get_key_info = AsyncMock()
+    mock_instance.update_budget = AsyncMock()
+    mock_instance.update_key_duration = AsyncMock(side_effect=_maybe_fail)
+    mock_instance.list_all_keys = AsyncMock(
+        return_value={
+            _Svc.hash_token(tok): {"spend": 2.0, "max_budget": 10.0} for tok in tokens
+        }
+    )
+
+    keys_by_region = get_team_keys_by_region(db, test_team.id)
+    team_total = await reconcile_team_keys(db, test_team, keys_by_region, True)
+
+    # All three attempted, and spend counted for all three
+    assert mock_instance.update_key_duration.await_count == 3
+    assert team_total == 6.0


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces per-key reconciliation reads with cached regional key snapshots and batches LiteLLM writes.
- Adds paginated, concurrency-limited `/key/list` retrieval and token-hash lookup.
- Adds regional snapshot caching with per-key fallback reads and reconciliation metrics.
- Splits narrow budget updates from expiry-extension updates and executes writes in bounded batches.
- Makes skipped reconciliation runs observable through logs and a temporary-failure exit code.
- Adds coverage for pagination, cache reuse, fallback behavior, narrow writes, and batching.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because previously reported snapshot staleness and delayed key expiration remain reachable.

The shared cache still persists one regional snapshot across all teams in a run, allowing later teams to receive older spend values, while expiration updates remain queued until 500 writes accumulate or the region finishes processing, delaying revocation for expired keys.

**Files Needing Attention:** app/core/worker.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/core/worker.py | Adds per-run regional key snapshots, fallback reads, field-specific reconciliation writes, bounded write batching, and operational metrics. |
| app/services/litellm.py | Adds shared token hashing and complete paginated `/key/list` retrieval with bounded page concurrency. |
| scripts/trigger_recon_job.py | Reports lock contention as an error and exits with EX_TEMPFAIL when reconciliation is skipped. |
| tests/test_litellm_service.py | Covers key-list pagination, malformed entries, failures, page-size clamping, and concurrency limits. |
| tests/test_worker.py | Covers snapshot resolution and sharing, fallback behavior, narrow updates, write batching, and write-failure isolation. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Job as monitor_teams
    participant Cache as RegionKeyStateCache
    participant LLM as LiteLLM
    participant Recon as reconcile_team_keys
    Job->>Cache: get(region)
    Cache->>LLM: GET /key/list pages
    LLM-->>Cache: regional key snapshot
    loop Each team and key
        Job->>Recon: reconcile with shared cache
        Recon->>Cache: resolve hashed token
        alt Key absent or snapshot failed
            Recon->>LLM: GET /key/info
        end
        Recon->>Recon: queue drift or expiration write
        opt Batch threshold or region end
            Recon->>LLM: concurrent /key/update writes
        end
    end
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(worker): flush queued key writes in ..."](https://github.com/amazeeio/amazee.ai/commit/eba45741149ead1d0735d795f9a7f303a95e4384) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48607138)</sub>

**Context used:**

- Knowledge Base — [Background/Periodic Jobs (worker + internal trigger API)](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/worker-background-jobs.md)
- Knowledge Base — [Private AI Keys and LiteLLM Integration](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/private-ai-keys-litellm.md)

<!-- /greptile_comment -->