### PR TITLE
fix(admin): make Audit Logs, Users, and Teams pages scale on prod

### DIFF
--- a/app/api/audit.py
+++ b/app/api/audit.py
@@ -1,8 +1,8 @@
 from fastapi import APIRouter, Depends, Query, HTTPException, status
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from typing import Optional
 from datetime import datetime, UTC
-from sqlalchemy import distinct, cast, String, or_
+from sqlalchemy import distinct, or_
 from app.db.database import get_db
 from app.api.auth import get_current_user_from_auth
 from app.schemas.models import (
@@ -22,6 +22,11 @@ def _as_naive_utc(dt: datetime) -> datetime:
     # DBAuditLog.timestamp is stored as naive UTC; normalize tz-aware
     # query params so comparisons don't depend on the server timezone.
     return dt.astimezone(UTC).replace(tzinfo=None) if dt.tzinfo else dt
+
+
+# Renders as (details ->> 'status_code') on PostgreSQL; must match the
+# expression index ix_audit_logs_status_code.
+_status_code_expr = DBAuditLog.details["status_code"].as_string()
 
 
 @router.get("/logs", response_model=PaginatedAuditLogResponse)
@@ -55,8 +60,13 @@ async def get_audit_logs(
         )
 
     try:
-        # Use the correct model
-        query = db.query(DBAuditLog).outerjoin(DBUser, DBAuditLog.user_id == DBUser.id)
+        query = db.query(DBAuditLog)
+        # Only join users when filtering by email; an unconditional join
+        # makes the count() below scan far more than it needs to.
+        if user_email:
+            query = query.join(DBUser, DBAuditLog.user_id == DBUser.id).filter(
+                DBUser.email.ilike(f"%{user_email}%")
+            )
 
         if event_type:
             event_types = [et.strip() for et in event_type.split(",")]
@@ -66,17 +76,13 @@ async def get_audit_logs(
             query = query.filter(DBAuditLog.resource_type.in_(resource_types))
         if user_id:
             query = query.filter(DBAuditLog.user_id == user_id)
-        if user_email:
-            query = query.filter(DBUser.email.ilike(f"%{user_email}%"))
         if from_date:
             query = query.filter(DBAuditLog.timestamp >= _as_naive_utc(from_date))
         if to_date:
             query = query.filter(DBAuditLog.timestamp <= _as_naive_utc(to_date))
         if status_code:
             status_codes = [sc.strip() for sc in status_code.split(",")]
-            query = query.filter(
-                cast(DBAuditLog.details["status_code"], String).in_(status_codes)
-            )
+            query = query.filter(_status_code_expr.in_(status_codes))
         if referer:
             # Escape LIKE wildcards so a literal % or _ in the search term
             # doesn't act as a match-all pattern.
@@ -94,9 +100,14 @@ async def get_audit_logs(
         # Get total count
         total = query.count()
 
-        # Execute the query with pagination
+        # Execute the query with pagination; eager-load user to avoid a
+        # lazy-load query per row when building the response.
         results = (
-            query.order_by(DBAuditLog.timestamp.desc()).offset(skip).limit(limit).all()
+            query.options(joinedload(DBAuditLog.user))
+            .order_by(DBAuditLog.timestamp.desc())
+            .offset(skip)
+            .limit(limit)
+            .all()
         )
 
         response_data = [
@@ -167,11 +178,9 @@ async def get_audit_logs_metadata(
         # Get distinct status codes from the details JSON field
         status_codes = [
             sc[0]
-            for sc in db.query(
-                distinct(cast(DBAuditLog.details["status_code"], String))
-            )
-            .filter(cast(DBAuditLog.details["status_code"], String).isnot(None))
-            .filter(cast(DBAuditLog.details["status_code"], String) != "")
+            for sc in db.query(distinct(_status_code_expr))
+            .filter(_status_code_expr.isnot(None))
+            .filter(_status_code_expr != "")
             .all()
         ]
 

--- a/app/api/teams.py
+++ b/app/api/teams.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import UTC, datetime
-from typing import List
+from typing import List, Optional
 
 from app.api.private_ai_keys import delete_private_ai_key
 from app.core.config import settings
@@ -50,7 +50,7 @@ from app.schemas.models import (
 from app.services.disposable_domains import assert_email_domain_allowed
 from app.services.litellm import LiteLLMService
 from app.services.ses import SESService
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload, selectinload
 
@@ -203,22 +203,67 @@ async def register_team(
 @router.get(
     "/", response_model=List[Team], dependencies=[Depends(get_role_min_system_admin)]
 )
-async def list_teams(include_deleted: bool = False, db: Session = Depends(get_db)):
+async def list_teams(
+    response: Response,
+    include_deleted: bool = False,
+    name: Optional[str] = None,
+    admin_email: Optional[str] = None,
+    is_active: Optional[bool] = None,
+    skip: int = Query(0, ge=0),
+    limit: Optional[int] = Query(None, ge=1, le=1000),
+    sort_by: Optional[str] = Query(
+        None, pattern="^(name|admin_email|is_active|created_at)$"
+    ),
+    sort_order: str = Query("asc", pattern="^(asc|desc)$"),
+    db: Session = Depends(get_db),
+):
     """
     List all teams. Only accessible by admin users.
 
     Args:
         include_deleted: If True, include soft-deleted teams in the results. Defaults to False.
+        name / admin_email: partial-match filters.
+        is_active: filter by active status.
+        skip / limit: pagination (unpaginated when limit is omitted, for
+            backwards compatibility). The total match count is returned in
+            the X-Total-Count response header.
     """
-    query = db.query(DBTeam).options(
+    query = db.query(DBTeam)
+
+    if not include_deleted:
+        query = query.filter(DBTeam.deleted_at.is_(None))
+    if name:
+        query = query.filter(DBTeam.name.ilike(f"%{name}%"))
+    if admin_email:
+        query = query.filter(DBTeam.admin_email.ilike(f"%{admin_email}%"))
+    if is_active is not None:
+        query = query.filter(DBTeam.is_active.is_(is_active))
+
+    total = query.count()
+    response.headers["X-Total-Count"] = str(total)
+
+    sort_columns = {
+        "name": func.lower(DBTeam.name),
+        "admin_email": func.lower(DBTeam.admin_email),
+        "is_active": DBTeam.is_active,
+        "created_at": DBTeam.created_at,
+    }
+    order_by = []
+    if sort_by:
+        column = sort_columns[sort_by]
+        order_by.append(column.desc() if sort_order == "desc" else column.asc())
+    # Stable ordering so skip/limit pagination is deterministic
+    order_by.append(DBTeam.id)
+
+    query = query.options(
         joinedload(DBTeam.active_products).joinedload(DBTeamProduct.product),
         selectinload(DBTeam.allowed_region_associations).joinedload(
             DBTeamRegion.region
         ),
-    )
+    ).order_by(*order_by)
 
-    if not include_deleted:
-        query = query.filter(DBTeam.deleted_at.is_(None))
+    if limit is not None:
+        query = query.offset(skip).limit(limit)
 
     return query.all()
 

--- a/app/api/teams.py
+++ b/app/api/teams.py
@@ -233,9 +233,13 @@ async def list_teams(
     if not include_deleted:
         query = query.filter(DBTeam.deleted_at.is_(None))
     if name:
-        query = query.filter(DBTeam.name.ilike(f"%{name}%"))
+        escaped = name.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        query = query.filter(DBTeam.name.ilike(f"%{escaped}%", escape="\\"))
     if admin_email:
-        query = query.filter(DBTeam.admin_email.ilike(f"%{admin_email}%"))
+        escaped = (
+            admin_email.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        )
+        query = query.filter(DBTeam.admin_email.ilike(f"%{escaped}%", escape="\\"))
     if is_active is not None:
         query = query.filter(DBTeam.is_active.is_(is_active))
 

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -759,9 +759,13 @@ async def list_users(
         )
 
     if search:
-        query = query.filter(DBUser.email.ilike(f"%{search}%"))
+        escaped = (
+            search.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        )
+        query = query.filter(DBUser.email.ilike(f"%{escaped}%", escape="\\"))
     if team:
-        query = query.filter(DBTeam.name.ilike(f"%{team}%"))
+        escaped = team.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        query = query.filter(DBTeam.name.ilike(f"%{escaped}%", escape="\\"))
     if role:
         query = query.filter(DBUser.role == role)
 

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session, contains_eager
 
 from sqlalchemy import func, or_
@@ -711,16 +711,27 @@ async def remove_user_admin_region(
     "/", response_model=List[User], dependencies=[Depends(get_role_min_team_admin)]
 )
 async def list_users(
+    response: Response,
     current_user: DBUser = Depends(get_current_user_from_auth),
     search: Optional[str] = None,
+    team: Optional[str] = None,
+    role: Optional[str] = None,
     include_inactive: bool = False,
+    skip: int = Query(0, ge=0),
+    limit: Optional[int] = Query(None, ge=1, le=1000),
+    sort_by: Optional[str] = Query(None, pattern="^(email|team_name|role)$"),
+    sort_order: str = Query("asc", pattern="^(asc|desc)$"),
     db: Session = Depends(get_db),
 ):
     """
     List users. Accessible by admin users or team admins for their team members.
     Users from soft-deleted teams and inactive users are excluded from the results.
     System admins can pass include_inactive=true to also see inactive users.
-    Optionally filter by search term (partial email match).
+    Optionally filter by search term (partial email match), team (partial team
+    name match), and role (exact match).
+    Supports pagination via skip/limit (unpaginated when limit is omitted, for
+    backwards compatibility); the total match count is returned in the
+    X-Total-Count response header.
     """
     if current_user.is_admin:
         # Use LEFT JOIN to get all users and their team information in a single query
@@ -734,11 +745,6 @@ async def list_users(
         )
         if not include_inactive:
             query = query.filter(DBUser.is_active.is_(True))
-
-        if search:
-            query = query.filter(DBUser.email.ilike(f"%{search}%"))
-
-        users = query.all()
     else:
         # Return only users in the team admin's team with team information
         # Exclude if team is soft-deleted or user is inactive
@@ -752,14 +758,35 @@ async def list_users(
             )
         )
 
-        if search:
-            query = query.filter(DBUser.email.ilike(f"%{search}%"))
+    if search:
+        query = query.filter(DBUser.email.ilike(f"%{search}%"))
+    if team:
+        query = query.filter(DBTeam.name.ilike(f"%{team}%"))
+    if role:
+        query = query.filter(DBUser.role == role)
 
-        users = query.all()
+    total = query.count()
+    response.headers["X-Total-Count"] = str(total)
+
+    sort_columns = {
+        "email": func.lower(DBUser.email),
+        "team_name": func.lower(DBTeam.name),
+        "role": func.lower(DBUser.role),
+    }
+    order_by = []
+    if sort_by:
+        column = sort_columns[sort_by]
+        order_by.append(column.desc() if sort_order == "desc" else column.asc())
+    # Stable ordering so skip/limit pagination is deterministic
+    order_by.append(DBUser.id)
+    query = query.order_by(*order_by)
+
+    if limit is not None:
+        query = query.offset(skip).limit(limit)
 
     # Map the results to DBUser objects with team_name
     result = []
-    for user, team_name in users:
+    for user, team_name in query.all():
         user.team_name = team_name
         result.append(user)
     return result

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -452,10 +452,12 @@ class DBAuditLog(Base):
     __tablename__ = "audit_logs"
 
     id = Column(Integer, primary_key=True, index=True)
-    timestamp = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC))
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
-    event_type = Column(String, nullable=False)
-    resource_type = Column(String, nullable=False)
+    timestamp = Column(
+        DateTime, nullable=False, default=lambda: datetime.now(UTC), index=True
+    )
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True, index=True)
+    event_type = Column(String, nullable=False, index=True)
+    resource_type = Column(String, nullable=False, index=True)
     resource_id = Column(String, nullable=True)
     action = Column(String, nullable=False)
     details = Column(JSON, nullable=True)

--- a/app/main.py
+++ b/app/main.py
@@ -156,6 +156,7 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    expose_headers=["X-Total-Count"],
 )
 
 # Add trusted host middleware

--- a/app/migrations/versions/20260728_120000_e5b8c7d2a941_add_audit_log_indexes.py
+++ b/app/migrations/versions/20260728_120000_e5b8c7d2a941_add_audit_log_indexes.py
@@ -1,0 +1,62 @@
+"""add indexes to audit_logs
+
+The audit_logs table has no indexes beyond the primary key, so the admin
+Audit Logs page (ORDER BY timestamp, count(), and the three DISTINCT
+metadata queries) does full-table scans on every load and times out on
+large production tables.
+
+Indexes are created CONCURRENTLY because audit_logs receives an insert on
+every API request; a blocking build would stall all traffic for the
+duration. if_not_exists makes a retry after a failed concurrent build a
+no-op instead of an error (drop any INVALID index manually before
+retrying).
+
+Revision ID: e5b8c7d2a941
+Revises: 6c201dbaea6e
+Create Date: 2026-07-28 12:00:00.000000+00:00
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "e5b8c7d2a941"
+down_revision: Union[str, None] = "6c201dbaea6e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+INDEXES = [
+    ("ix_audit_logs_timestamp", ["timestamp"]),
+    ("ix_audit_logs_event_type", ["event_type"]),
+    ("ix_audit_logs_resource_type", ["resource_type"]),
+    ("ix_audit_logs_user_id", ["user_id"]),
+    # Expression index matching details ->> 'status_code' as emitted by
+    # DBAuditLog.details["status_code"].as_string() in app/api/audit.py.
+    ("ix_audit_logs_status_code", [sa.text("(details ->> 'status_code')")]),
+]
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        for name, columns in INDEXES:
+            op.create_index(
+                name,
+                "audit_logs",
+                columns,
+                postgresql_concurrently=True,
+                if_not_exists=True,
+            )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        for name, _ in INDEXES:
+            op.drop_index(
+                name,
+                table_name="audit_logs",
+                postgresql_concurrently=True,
+                if_exists=True,
+            )

--- a/frontend/src/app/admin/teams/_components/add-user-to-team-dialog.tsx
+++ b/frontend/src/app/admin/teams/_components/add-user-to-team-dialog.tsx
@@ -40,7 +40,7 @@ export function AddUserToTeamDialog({
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<User[]>([]);
   const [isSearching, setIsSearching] = useState(false);
-  const { addUserToTeam, isAddingUser } = useTeams();
+  const { addUserToTeam, isAddingUser } = useTeams(false, { enabled: false });
 
   const searchUsersMutation = useMutation({
     mutationFn: async (query: string) => {

--- a/frontend/src/app/admin/teams/_components/create-team-dialog.tsx
+++ b/frontend/src/app/admin/teams/_components/create-team-dialog.tsx
@@ -35,7 +35,7 @@ export function CreateTeamDialog({
   const [newTeamName, setNewTeamName] = useState("");
   const [newTeamAdminEmail, setNewTeamAdminEmail] = useState("");
   const [newTeamRegionId, setNewTeamRegionId] = useState("");
-  const { createTeam, isCreating } = useTeams();
+  const { createTeam, isCreating } = useTeams(false, { enabled: false });
 
   // A team is locked to a single region on creation, and the backend rejects
   // inactive or dedicated regions — only offer the ones it will accept.

--- a/frontend/src/app/admin/teams/_components/edit-team-dialog.tsx
+++ b/frontend/src/app/admin/teams/_components/edit-team-dialog.tsx
@@ -26,7 +26,7 @@ export function EditTeamDialog({
   open,
   onOpenChange,
 }: EditTeamDialogProps) {
-  const { updateTeam, isUpdating } = useTeams();
+  const { updateTeam, isUpdating } = useTeams(false, { enabled: false });
   const [form, setForm] = useState({
     name: "",
     phone: "",

--- a/frontend/src/app/admin/teams/_components/merge-teams-dialog.tsx
+++ b/frontend/src/app/admin/teams/_components/merge-teams-dialog.tsx
@@ -21,26 +21,21 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useTeams } from "@/hooks/use-teams";
-import { Team } from "@/types/team";
 
 interface MergeTeamsDialogProps {
-  teams: Team[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
-export function MergeTeamsDialog({
-  teams,
-  open,
-  onOpenChange,
-}: MergeTeamsDialogProps) {
+export function MergeTeamsDialog({ open, onOpenChange }: MergeTeamsDialogProps) {
   const [targetTeamId, setTargetTeamId] = useState("");
   const [sourceTeamId, setSourceTeamId] = useState("");
   const [conflictResolutionStrategy, setConflictResolutionStrategy] = useState<
     "delete" | "rename" | "cancel"
   >("rename");
   const [renameSuffix, setRenameSuffix] = useState("_merged");
-  const { mergeTeams, isMerging } = useTeams();
+  // Full team list is only fetched once the dialog is opened
+  const { teams, mergeTeams, isMerging } = useTeams(false, { enabled: open });
 
   const handleMerge = (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/app/admin/teams/_components/subscribe-to-product-dialog.tsx
+++ b/frontend/src/app/admin/teams/_components/subscribe-to-product-dialog.tsx
@@ -37,7 +37,7 @@ export function SubscribeToProductDialog({
 }: SubscribeToProductDialogProps) {
   const [selectedProductId, setSelectedProductId] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
-  const { subscribeToProduct, isSubscribing } = useTeams();
+  const { subscribeToProduct, isSubscribing } = useTeams(false, { enabled: false });
 
   const { data: allProducts = [], isLoading: isLoadingAllProducts } = useQuery<
     Product[]

--- a/frontend/src/app/admin/teams/_components/team-expansion-row.tsx
+++ b/frontend/src/app/admin/teams/_components/team-expansion-row.tsx
@@ -72,7 +72,7 @@ export function TeamExpansionRow({
     isCancelingSubscription,
     resetLimits,
     isResettingLimits,
-  } = useTeams();
+  } = useTeams(false, { enabled: false });
 
   const { data: expandedTeam, isLoading: isLoadingTeamDetails } =
     useQuery<Team>({

--- a/frontend/src/app/admin/teams/page.tsx
+++ b/frontend/src/app/admin/teams/page.tsx
@@ -127,6 +127,11 @@ export default function TeamsPage() {
     pageSize,
   ]);
 
+  // Clamp when mutations shrink the result set below the current page
+  useEffect(() => {
+    if (currentPage > totalPages) setCurrentPage(totalPages);
+  }, [currentPage, totalPages]);
+
   const { data: regions = [] } = useQuery<Region[]>({
     queryKey: ["regions"],
     queryFn: async () => {

--- a/frontend/src/app/admin/teams/page.tsx
+++ b/frontend/src/app/admin/teams/page.tsx
@@ -7,7 +7,7 @@ import {
   ChevronUp,
   ChevronsUpDown,
 } from "lucide-react";
-import { useState, useMemo, Fragment } from "react";
+import { useState, useMemo, useEffect, Fragment } from "react";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import {
@@ -18,14 +18,13 @@ import {
   TableHeader,
   TableRow,
   TablePagination,
-  useTablePagination,
 } from "@/components/ui/table";
 import { TableFilters, FilterField } from "@/components/ui/table-filters";
-import { useTeams } from "@/hooks/use-teams";
+import { useDebounce } from "@/hooks/use-debounce";
 import { Region } from "@/types/region";
 import { Team } from "@/types/team";
 import { get } from "@/utils/api";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import { AddUserToTeamDialog } from "./_components/add-user-to-team-dialog";
 import { CreateTeamDialog } from "./_components/create-team-dialog";
 import { CreateUserInTeamDialog } from "./_components/create-user-in-team-dialog";
@@ -59,8 +58,74 @@ export default function TeamsPage() {
   const [sortField, setSortField] = useState<SortField>(null);
   const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
 
-  // Use centralized hook
-  const { teams, isLoading: isLoadingTeams } = useTeams(includeDeleted);
+  // Server-side pagination state
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+  const debouncedNameFilter = useDebounce(nameFilter, 300);
+  const debouncedAdminEmailFilter = useDebounce(adminEmailFilter, 300);
+
+  // Filtering, sorting, and pagination happen server-side; loading every
+  // team into the browser doesn't scale on production.
+  const queryParams = useMemo(() => {
+    const params = new URLSearchParams({
+      include_deleted: includeDeleted.toString(),
+      skip: ((currentPage - 1) * pageSize).toString(),
+      limit: pageSize.toString(),
+    });
+    if (debouncedNameFilter) params.set("name", debouncedNameFilter);
+    if (debouncedAdminEmailFilter)
+      params.set("admin_email", debouncedAdminEmailFilter);
+    if (statusFilter !== "all")
+      params.set("is_active", (statusFilter === "active").toString());
+    if (sortField) {
+      params.set("sort_by", sortField);
+      params.set("sort_order", sortDirection);
+    }
+    return params.toString();
+  }, [
+    includeDeleted,
+    currentPage,
+    pageSize,
+    debouncedNameFilter,
+    debouncedAdminEmailFilter,
+    statusFilter,
+    sortField,
+    sortDirection,
+  ]);
+
+  // Keyed under ["teams", ...] so the useTeams mutations' invalidation
+  // refreshes this list too.
+  const { data: teamsData, isLoading: isLoadingTeams } = useQuery<{
+    items: Team[];
+    total: number;
+  }>({
+    queryKey: ["teams", "list", queryParams],
+    queryFn: async () => {
+      const response = await get(`/teams?${queryParams}`);
+      const items: Team[] = await response.json();
+      const total = Number(
+        response.headers.get("X-Total-Count") ?? items.length,
+      );
+      return { items, total };
+    },
+    placeholderData: keepPreviousData,
+  });
+  const teams = teamsData?.items ?? [];
+  const totalItems = teamsData?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
+
+  // Back to the first page whenever the result set changes shape
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [
+    debouncedNameFilter,
+    debouncedAdminEmailFilter,
+    statusFilter,
+    includeDeleted,
+    sortField,
+    sortDirection,
+    pageSize,
+  ]);
 
   const { data: regions = [] } = useQuery<Region[]>({
     queryKey: ["regions"],
@@ -69,93 +134,6 @@ export default function TeamsPage() {
       return response.json();
     },
   });
-
-  // Filtered and sorted teams
-  const filteredAndSortedTeams = useMemo(() => {
-    const filtered = teams.filter((team) => {
-      const nameMatch = team.name
-        .toLowerCase()
-        .includes(nameFilter.toLowerCase());
-      const adminEmailMatch = team.admin_email
-        .toLowerCase()
-        .includes(adminEmailFilter.toLowerCase());
-      const statusMatch =
-        statusFilter === "all" ||
-        (statusFilter === "active" && team.is_active) ||
-        (statusFilter === "inactive" && !team.is_active);
-
-      return nameMatch && adminEmailMatch && statusMatch;
-    });
-
-    if (sortField) {
-      filtered.sort((a, b) => {
-        let aValue: string | boolean | Date;
-        let bValue: string | boolean | Date;
-
-        switch (sortField) {
-          case "name":
-            aValue = a.name.toLowerCase();
-            bValue = b.name.toLowerCase();
-            break;
-          case "admin_email":
-            aValue = a.admin_email.toLowerCase();
-            bValue = b.admin_email.toLowerCase();
-            break;
-          case "is_active":
-            aValue = a.is_active;
-            bValue = b.is_active;
-            break;
-          case "created_at":
-            aValue = new Date(a.created_at);
-            bValue = new Date(b.created_at);
-            break;
-          default:
-            return 0;
-        }
-
-        if (typeof aValue === "string" && typeof bValue === "string") {
-          return sortDirection === "asc"
-            ? aValue.localeCompare(bValue)
-            : bValue.localeCompare(aValue);
-        } else if (typeof aValue === "boolean" && typeof bValue === "boolean") {
-          return sortDirection === "asc"
-            ? aValue === bValue
-              ? 0
-              : aValue
-                ? -1
-                : 1
-            : aValue === bValue
-              ? 0
-              : aValue
-                ? 1
-                : -1;
-        } else if (aValue instanceof Date && bValue instanceof Date) {
-          return sortDirection === "asc"
-            ? aValue.getTime() - bValue.getTime()
-            : bValue.getTime() - aValue.getTime();
-        }
-        return 0;
-      });
-    }
-    return filtered;
-  }, [
-    teams,
-    nameFilter,
-    adminEmailFilter,
-    statusFilter,
-    sortField,
-    sortDirection,
-  ]);
-
-  const {
-    currentPage,
-    pageSize,
-    totalPages,
-    totalItems,
-    paginatedData,
-    goToPage,
-    changePageSize,
-  } = useTablePagination(filteredAndSortedTeams, 10);
 
   const hasActiveFilters = Boolean(
     nameFilter.trim() || adminEmailFilter.trim() || statusFilter !== "all",
@@ -229,7 +207,6 @@ export default function TeamsPage() {
           <h1 className="text-3xl font-bold">Teams</h1>
           <div className="flex space-x-2">
             <MergeTeamsDialog
-              teams={teams}
               open={isMergingTeams}
               onOpenChange={setIsMergingTeams}
             />
@@ -251,8 +228,8 @@ export default function TeamsPage() {
             setSortDirection("asc");
           }}
           hasActiveFilters={hasActiveFilters}
-          totalItems={teams.length}
-          filteredItems={filteredAndSortedTeams.length}
+          totalItems={totalItems}
+          filteredItems={totalItems}
         />
 
         <div className="flex items-center space-x-2 py-2">
@@ -311,14 +288,14 @@ export default function TeamsPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {paginatedData.length === 0 ? (
+                {teams.length === 0 ? (
                   <TableRow>
                     <TableCell colSpan={5} className="text-center py-6">
                       No teams found. Create a new team to get started.
                     </TableCell>
                   </TableRow>
                 ) : (
-                  paginatedData.map((team) => (
+                  teams.map((team) => (
                     <Fragment key={team.id}>
                       <TableRow
                         className={`cursor-pointer hover:bg-muted/50 ${team.deleted_at ? "opacity-50" : ""}`}
@@ -400,8 +377,8 @@ export default function TeamsPage() {
           totalPages={totalPages}
           pageSize={pageSize}
           totalItems={totalItems}
-          onPageChange={goToPage}
-          onPageSizeChange={changePageSize}
+          onPageChange={setCurrentPage}
+          onPageSizeChange={setPageSize}
         />
 
         <EditTeamDialog

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -123,6 +123,11 @@ export default function UsersPage() {
     pageSize,
   ]);
 
+  // Clamp when mutations shrink the result set below the current page
+  useEffect(() => {
+    if (currentPage > totalPages) setCurrentPage(totalPages);
+  }, [currentPage, totalPages]);
+
   const { data: teams = [] } = useQuery<{ id: string; name: string }[]>({
     queryKey: ["teams"],
     queryFn: async () => {

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -7,7 +7,7 @@ import {
   ChevronsUpDown,
   ChevronRight,
 } from "lucide-react";
-import { useState, useMemo, Fragment } from "react";
+import { useState, useMemo, useEffect, Fragment } from "react";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import {
@@ -18,14 +18,19 @@ import {
   TableHeader,
   TableRow,
   TablePagination,
-  useTablePagination,
 } from "@/components/ui/table";
 import { TableActionButtons } from "@/components/ui/table-action-buttons";
 import { TableFilters, FilterField } from "@/components/ui/table-filters";
+import { useDebounce } from "@/hooks/use-debounce";
 import { useToast } from "@/hooks/use-toast";
 import { User, USER_ROLES } from "@/types/user";
 import { get, del, put } from "@/utils/api";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+} from "@tanstack/react-query";
 import { CreateUserDialog } from "./_components/create-user-dialog";
 import { EditUserRoleDialog } from "./_components/edit-user-role-dialog";
 import { UserExpansionRow } from "./_components/user-expansion-row";
@@ -52,16 +57,71 @@ export default function UsersPage() {
   const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
   const [showDeleted, setShowDeleted] = useState(false);
 
+  // Server-side pagination state
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+  const debouncedEmailFilter = useDebounce(emailFilter, 300);
+  const debouncedTeamFilter = useDebounce(teamFilter, 300);
+
+  // Filtering, sorting, and pagination happen server-side; loading every
+  // user into the browser doesn't scale on production.
+  const queryParams = useMemo(() => {
+    const params = new URLSearchParams({
+      skip: ((currentPage - 1) * pageSize).toString(),
+      limit: pageSize.toString(),
+    });
+    if (showDeleted) params.set("include_inactive", "true");
+    if (debouncedEmailFilter) params.set("search", debouncedEmailFilter);
+    if (debouncedTeamFilter) params.set("team", debouncedTeamFilter);
+    if (roleFilter !== "all") params.set("role", roleFilter);
+    if (sortField) {
+      params.set("sort_by", sortField);
+      params.set("sort_order", sortDirection);
+    }
+    return params.toString();
+  }, [
+    currentPage,
+    pageSize,
+    showDeleted,
+    debouncedEmailFilter,
+    debouncedTeamFilter,
+    roleFilter,
+    sortField,
+    sortDirection,
+  ]);
+
   // Queries
-  const { data: users = [], isLoading: isLoadingUsers } = useQuery<User[]>({
-    queryKey: ["users", showDeleted],
+  const { data: usersData, isLoading: isLoadingUsers } = useQuery<{
+    items: User[];
+    total: number;
+  }>({
+    queryKey: ["users", queryParams],
     queryFn: async () => {
-      const response = await get(
-        showDeleted ? "/users?include_inactive=true" : "/users",
+      const response = await get(`/users?${queryParams}`);
+      const items: User[] = await response.json();
+      const total = Number(
+        response.headers.get("X-Total-Count") ?? items.length,
       );
-      return response.json();
+      return { items, total };
     },
+    placeholderData: keepPreviousData,
   });
+  const users = usersData?.items ?? [];
+  const totalItems = usersData?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
+
+  // Back to the first page whenever the result set changes shape
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [
+    debouncedEmailFilter,
+    debouncedTeamFilter,
+    roleFilter,
+    showDeleted,
+    sortField,
+    sortDirection,
+    pageSize,
+  ]);
 
   const { data: teams = [] } = useQuery<{ id: string; name: string }[]>({
     queryKey: ["teams"],
@@ -69,56 +129,9 @@ export default function UsersPage() {
       const response = await get("/teams");
       return response.json();
     },
+    // Only needed to populate the create-user dialog's team dropdown
+    enabled: isAddingUser,
   });
-
-  // Filtered and sorted users
-  const filteredAndSortedUsers = useMemo(() => {
-    const filtered = users.filter((user) => {
-      const emailMatch = user.email
-        .toLowerCase()
-        .includes(emailFilter.toLowerCase());
-      const teamMatch =
-        !teamFilter ||
-        (user.team_name || "None")
-          .toLowerCase()
-          .includes(teamFilter.toLowerCase());
-      const roleMatch = roleFilter === "all" || user.role === roleFilter;
-
-      return emailMatch && teamMatch && roleMatch;
-    });
-
-    if (sortField) {
-      filtered.sort((a, b) => {
-        let aValue: string;
-        let bValue: string;
-
-        switch (sortField) {
-          case "email":
-            aValue = a.email.toLowerCase();
-            bValue = b.email.toLowerCase();
-            break;
-          case "team_name":
-            aValue = (a.team_name || "None").toLowerCase();
-            bValue = (b.team_name || "None").toLowerCase();
-            break;
-          case "role":
-            aValue = (a.role || "").toLowerCase();
-            bValue = (b.role || "").toLowerCase();
-            break;
-          default:
-            return 0;
-        }
-
-        if (sortDirection === "asc") {
-          return aValue.localeCompare(bValue);
-        } else {
-          return bValue.localeCompare(aValue);
-        }
-      });
-    }
-
-    return filtered;
-  }, [users, emailFilter, teamFilter, roleFilter, sortField, sortDirection]);
 
   const hasActiveFilters = Boolean(
     emailFilter.trim() || teamFilter.trim() || roleFilter !== "all",
@@ -155,17 +168,6 @@ export default function UsersPage() {
       ],
     },
   ];
-
-  // Pagination
-  const {
-    currentPage,
-    pageSize,
-    totalPages,
-    totalItems,
-    paginatedData,
-    goToPage,
-    changePageSize,
-  } = useTablePagination(filteredAndSortedUsers, 10);
 
   // Handle sorting
   const handleSort = (field: SortField) => {
@@ -301,8 +303,8 @@ export default function UsersPage() {
           setSortDirection("asc");
         }}
         hasActiveFilters={hasActiveFilters}
-        totalItems={users.length}
-        filteredItems={filteredAndSortedUsers.length}
+        totalItems={totalItems}
+        filteredItems={totalItems}
       />
 
       <div className="rounded-md border">
@@ -343,14 +345,14 @@ export default function UsersPage() {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {paginatedData.length === 0 ? (
+            {users.length === 0 ? (
               <TableRow>
                 <TableCell colSpan={8} className="text-center py-6">
                   No users found. Create a new user to get started.
                 </TableCell>
               </TableRow>
             ) : (
-              paginatedData.map((user) => (
+              users.map((user) => (
                 <Fragment key={user.id}>
                   <TableRow
                     className="cursor-pointer hover:bg-muted/50"
@@ -438,8 +440,8 @@ export default function UsersPage() {
         totalPages={totalPages}
         pageSize={pageSize}
         totalItems={totalItems}
-        onPageChange={goToPage}
-        onPageSizeChange={changePageSize}
+        onPageChange={setCurrentPage}
+        onPageSizeChange={setPageSize}
       />
 
       <EditUserRoleDialog

--- a/frontend/src/hooks/use-teams.ts
+++ b/frontend/src/hooks/use-teams.ts
@@ -3,17 +3,22 @@ import { Team } from "@/types/team";
 import { get, post, put, del } from "@/utils/api";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
-export function useTeams(includeDeleted: boolean = false) {
+export function useTeams(
+  includeDeleted: boolean = false,
+  options: { enabled?: boolean } = {},
+) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
-  // Queries
+  // Queries. The full-list fetch is expensive on production, so callers
+  // that only need the mutations should pass { enabled: false }.
   const teamsQuery = useQuery<Team[]>({
     queryKey: ["teams", includeDeleted],
     queryFn: async () => {
       const response = await get(`/teams?include_deleted=${includeDeleted}`);
       return response.json();
     },
+    enabled: options.enabled ?? true,
   });
 
   // Mutations

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,6 +1,13 @@
 import os
+from collections import defaultdict
+
 from alembic.config import Config
 from alembic.script import ScriptDirectory
+
+# ponytail: the only fork we ever had (Feb 2025, merged by 20250219_merge_heads).
+# Grandfathered so the linearity test can guard everything after it.
+LEGACY_FORK_POINTS = {"00c5de5fd13f"}
+LEGACY_MERGES = {"20250219_merge_heads"}
 
 
 # Helper to get the alembic config
@@ -24,6 +31,42 @@ def test_single_alembic_head():
     assert len(heads) == 1, (
         f"Alembic detected multiple head revisions: {heads}. "
         "Please resolve split heads by creating a merge migration or linearizing your changes."
+    )
+
+
+def test_migration_history_is_linear():
+    """No forks: every revision has at most one parent and at most one child.
+
+    ``test_single_alembic_head`` only catches forks that are still open. A fork
+    closed with a merge revision passes it, but still means two branches were
+    developed in parallel against the same parent. Reject both.
+    """
+    script = ScriptDirectory.from_config(get_alembic_config())
+
+    children = defaultdict(list)
+    merges = []
+    for rev in script.walk_revisions():
+        parents = rev.down_revision
+        parents = parents if isinstance(parents, tuple) else (parents,)
+        if len(parents) > 1 and rev.revision not in LEGACY_MERGES:
+            merges.append(rev.revision)
+        for parent in filter(None, parents):
+            children[parent].append(rev.revision)
+
+    forks = {
+        parent: revs
+        for parent, revs in children.items()
+        if len(revs) > 1 and parent not in LEGACY_FORK_POINTS
+    }
+
+    assert not forks, (
+        f"Alembic migration history forks: {forks}. Rebase your migration onto the "
+        "current head (`alembic heads`) and update its down_revision instead of "
+        "branching off an older revision."
+    )
+    assert not merges, (
+        f"Merge revisions found: {merges}. Keep migration history linear — rebase "
+        "onto the current head rather than merging two branches."
     )
 
 

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -513,6 +513,20 @@ def test_list_teams_paginated(client, admin_token, db):
     assert [t["name"] for t in response.json()] == ["paginated team 0"]
 
 
+def test_list_teams_filter_escapes_wildcards(client, admin_token, db):
+    for name in ["wild_card team", "wildxcard team"]:
+        db.add(DBTeam(name=name, admin_email=f"{name.replace(' ', '-')}@example.com"))
+    db.commit()
+
+    response = client.get(
+        "/teams/?name=wild_card",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    assert response.headers["X-Total-Count"] == "1"
+    assert [t["name"] for t in response.json()] == ["wild_card team"]
+
+
 def test_list_teams_unauthorized(client, test_token):
     """Test listing teams without admin privileges"""
     response = client.get("/teams/", headers={"Authorization": f"Bearer {test_token}"})

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -483,6 +483,36 @@ def test_list_teams(client, admin_token, db, test_team):
     assert any(t["admin_email"] == "testteam@example.com" for t in teams)
 
 
+def test_list_teams_paginated(client, admin_token, db):
+    for i in range(3):
+        db.add(
+            DBTeam(
+                name=f"paginated team {i}",
+                admin_email=f"paginated-team-{i}@example.com",
+            )
+        )
+    db.commit()
+
+    response = client.get(
+        "/teams/?name=paginated team&limit=2&sort_by=name&sort_order=desc",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    assert response.headers["X-Total-Count"] == "3"
+    assert [t["name"] for t in response.json()] == [
+        "paginated team 2",
+        "paginated team 1",
+    ]
+
+    response = client.get(
+        "/teams/?name=paginated team&limit=2&skip=2&sort_by=name&sort_order=desc",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    assert response.headers["X-Total-Count"] == "3"
+    assert [t["name"] for t in response.json()] == ["paginated team 0"]
+
+
 def test_list_teams_unauthorized(client, test_token):
     """Test listing teams without admin privileges"""
     response = client.get("/teams/", headers={"Authorization": f"Bearer {test_token}"})

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -78,6 +78,37 @@ def test_get_users_include_inactive(client, admin_token, db):
     assert "inactive-list@example.com" in [u["email"] for u in response.json()]
 
 
+def test_get_users_paginated(client, admin_token, db):
+    for i in range(3):
+        db.add(
+            DBUser(
+                email=f"paginated-{i}@example.com",
+                hashed_password=get_password_hash("password"),
+                is_active=True,
+            )
+        )
+    db.commit()
+
+    response = client.get(
+        "/users/?search=paginated-&limit=2&sort_by=email&sort_order=desc",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    assert response.headers["X-Total-Count"] == "3"
+    assert [u["email"] for u in response.json()] == [
+        "paginated-2@example.com",
+        "paginated-1@example.com",
+    ]
+
+    response = client.get(
+        "/users/?search=paginated-&limit=2&skip=2&sort_by=email&sort_order=desc",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    assert response.headers["X-Total-Count"] == "3"
+    assert [u["email"] for u in response.json()] == ["paginated-0@example.com"]
+
+
 def test_get_user_by_id(client, admin_token, test_user):
     response = client.get(
         f"/users/{test_user.id}", headers={"Authorization": f"Bearer {admin_token}"}

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -109,6 +109,26 @@ def test_get_users_paginated(client, admin_token, db):
     assert [u["email"] for u in response.json()] == ["paginated-0@example.com"]
 
 
+def test_get_users_search_escapes_wildcards(client, admin_token, db):
+    for email in ["wild_card@example.com", "wildxcard@example.com"]:
+        db.add(
+            DBUser(
+                email=email,
+                hashed_password=get_password_hash("password"),
+                is_active=True,
+            )
+        )
+    db.commit()
+
+    response = client.get(
+        "/users/?search=wild_card",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    assert response.headers["X-Total-Count"] == "1"
+    assert [u["email"] for u in response.json()] == ["wild_card@example.com"]
+
+
 def test_get_user_by_id(client, admin_token, test_user):
     response = client.get(
         f"/users/{test_user.id}", headers={"Authorization": f"Bearer {admin_token}"}


### PR DESCRIPTION
## Problem

**Audit Logs page times out on production.** The frontend already paginates (20 rows/request), but `audit_logs` has no indexes beyond the primary key, so every page view full-scans the table three ways:

- `ORDER BY timestamp DESC` for the page of rows
- `count()`, which also did a pointless unconditional join to `users`
- `/audit/logs/metadata`: three `SELECT DISTINCT` full scans, one over the JSON `details` field

The page blocks rendering until all of that completes → gateway timeout.

**Users and Teams pages are slow.** `GET /users` and `GET /teams` return every row and the pages filter/sort/paginate client-side. The Teams page dialogs each call `useTeams()` (full-list fetch on page mount), and the Users page fetched the full teams list on mount just for the create-user dropdown.

## Fixes

### Audit logs
- New migration adds indexes on `timestamp`, `event_type`, `resource_type`, `user_id`, and an expression index on `details ->> 'status_code'`. Built `CONCURRENTLY` (audit_logs takes an insert on every API request; a blocking build would stall all traffic), with `if_not_exists` so a retry after a failed concurrent build is a no-op.
- `GET /audit/logs` only joins `users` when filtering by email, and eager-loads the user relation for the returned page instead of lazy-loading per row.
- status_code queries (metadata + filter) use `->>` so they match the expression index.

### Users / Teams
- `GET /users` and `GET /teams` accept optional `skip`/`limit`/`sort_by`/`sort_order` plus filter params (`team`/`role`; `name`/`admin_email`/`is_active`) and return the total match count in an `X-Total-Count` header (exposed via CORS). **Response shape is unchanged and behaviour is unpaginated when `limit` is omitted**, so existing consumers keep working.
- The admin Users and Teams pages drive the table from server params with 300ms-debounced text filters and `keepPreviousData`.
- `useTeams()` gains an `enabled` option; mutation-only dialogs stop fetching the full team list, the merge dialog fetches it only when opened, and the create-user dialog's team list loads on open.

## Verification

- Migration validated against real PostgreSQL: upgrade, downgrade, and idempotent re-upgrade pass; `EXPLAIN` confirms the expression index is used for both the metadata `DISTINCT` and the status-code filter.
- Backend: 137 tests pass (`make backend-test-regex regex="test_users or test_teams or test_audit or test_migrations"`), including new pagination tests for both endpoints.
- Frontend: `tsc` clean for source files; the 4 vitest failures and the eslint config crash exist identically on a clean `dev` checkout (pre-existing).

## Known limitations

- The unfiltered `count(*)` on audit_logs is still a full count (a second or two on millions of rows) — next lever if needed.
- Dialog dropdowns (merge teams, create-user team select) still load the full teams list, just lazily on open now.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR improves production scalability across the admin audit-log, user, and team views.
- Adds indexed audit-log query paths and avoids unnecessary user joins and lazy loading.
- Adds optional server-side filtering, sorting, and pagination to the users and teams APIs.
- Moves the admin Users and Teams tables to server-driven pagination and lazily loads full team lists only when required.
- Escapes SQL wildcard characters in user and team text filters.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/audit.py | Optimizes audit-log filtering and relationship loading while aligning status-code expressions with the new index. |
| app/api/users.py | Adds backward-compatible server-side filtering, sorting, pagination, and total-count reporting; the previously reported wildcard issue is fixed. |
| app/api/teams.py | Adds backward-compatible server-side filtering, sorting, pagination, and total-count reporting; the previously reported wildcard issue is fixed. |
| app/migrations/versions/20260728_120000_e5b8c7d2a941_add_audit_log_indexes.py | Adds concurrent, retry-tolerant indexes for the audit-log query paths. |
| frontend/src/app/admin/users/page.tsx | Moves the user table to server-side pagination and now clamps the page after result counts shrink, resolving the prior invalid-page finding. |
| frontend/src/app/admin/teams/page.tsx | Moves the team table to server-side filtering, sorting, and pagination with page reset and clamping. |
| frontend/src/hooks/use-teams.ts | Allows mutation-only consumers to disable the expensive full-team-list query. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(admin): address review feedback — es..."](https://github.com/amazeeio/amazee.ai/commit/71e281c9239ece0c78208db64e1c6d2a07feef30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48003591)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Audit Logging](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/audit-logging.md)
- Knowledge Base — [Database models, session, and migrations](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/database-models.md)
- Knowledge Base — [Frontend App](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/frontend-app.md)
- Knowledge Base — [Teams and Users](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/teams-users.md)
</details>

<!-- /greptile_comment -->