### PR TITLE
fix(auth): reuse orphaned team on sign-in re-registration

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -404,6 +404,24 @@ async def sign_in(
             )
             .first()
         )
+        if team is None and "@" in sign_in_username:
+            # The orphaned team may store a plus-tagged admin_email
+            # (e.g. "user+p12@…") while sign_in_username is the stripped
+            # base form — match tagged variants too.
+            # Escape LIKE wildcards — '_' is common in email local parts.
+            local, domain = (
+                part.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+                for part in sign_in_username.split("@", 1)
+            )
+            team = (
+                db.query(DBTeam)
+                .filter(
+                    DBTeam.admin_email.ilike(f"{local}+%@{domain}", escape="\\"),
+                    DBTeam.deleted_at.is_(None),
+                )
+                .order_by(DBTeam.id)
+                .first()
+            )
         if team:
             auth_logger.info(
                 f"Re-attaching {sign_in_username} to existing team {team.id} as admin"

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -393,29 +393,47 @@ async def sign_in(
         # Only NEW-account creation is velocity-limited; existing-user code logins
         # (the common case, incl. many users behind one corporate IP) are not.
         enforce_signup_velocity(request, db, email=sign_in_username, endpoint="sign-in")
-        # Resolve the sign-up region — first active non-dedicated region
-        sign_up_region = (
-            db.query(DBRegion)
-            .filter(DBRegion.is_active.is_(True), DBRegion.is_dedicated.is_(False))
-            .order_by(DBRegion.id)
+        # Reuse a team orphaned by a user hard-delete: same admin_email, not
+        # soft-deleted. Without this, the unique admin_email on the leftover
+        # team makes re-registration fail forever ("Email already registered").
+        team = (
+            db.query(DBTeam)
+            .filter(
+                func.lower(DBTeam.admin_email) == sign_in_username,
+                DBTeam.deleted_at.is_(None),
+            )
             .first()
         )
-        if not sign_up_region:
-            auth_logger.error("No active public region available for new team creation")
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="No active public region available",
+        if team:
+            auth_logger.info(
+                f"Re-attaching {sign_in_username} to existing team {team.id} as admin"
             )
-        # First create the team
-        team_data = TeamCreate(
-            name=f"Team {sign_in_username}",
-            admin_email=sign_in_username,
-            phone="",  # Required by schema but not used for auto-created teams
-            billing_address="",  # Required by schema but not used for auto-created teams
-            budget_type=BudgetType.PERIODIC,
-            region_id=sign_up_region.id,
-        )
-        team = await register_team(team_data, db)
+        else:
+            # Resolve the sign-up region — first active non-dedicated region
+            sign_up_region = (
+                db.query(DBRegion)
+                .filter(DBRegion.is_active.is_(True), DBRegion.is_dedicated.is_(False))
+                .order_by(DBRegion.id)
+                .first()
+            )
+            if not sign_up_region:
+                auth_logger.error(
+                    "No active public region available for new team creation"
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="No active public region available",
+                )
+            # First create the team
+            team_data = TeamCreate(
+                name=f"Team {sign_in_username}",
+                admin_email=sign_in_username,
+                phone="",  # Required by schema but not used for auto-created teams
+                billing_address="",  # Required by schema but not used for auto-created teams
+                budget_type=BudgetType.PERIODIC,
+                region_id=sign_up_region.id,
+            )
+            team = await register_team(team_data, db)
 
         user_data = UserCreate(
             email=sign_in_username,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -410,6 +410,57 @@ def test_sign_in_new_user_success(client, mock_dynamodb, test_region):
     assert team_user["role"] == "admin"  # User should have admin role in the team
 
 
+def test_sign_in_reuses_orphaned_team(client, db, mock_dynamodb, test_region):
+    """
+    Given a team whose admin user was hard-deleted (team exists, user does not)
+    When the user signs in again with a valid verification code
+    Then they are re-created as admin of the existing team instead of
+    failing with "Email already registered".
+    """
+    from datetime import UTC, datetime
+
+    from app.db.models import DBTeam
+
+    email = "orphaned@example.com"
+    code = "TESTCODE"
+
+    team = DBTeam(
+        name=f"Team {email}",
+        admin_email=email,
+        is_active=True,
+        created_at=datetime.now(UTC),
+        budget_type="periodic",
+    )
+    db.add(team)
+    db.commit()
+    db.refresh(team)
+
+    mock_dynamodb.read_validation_code.return_value = {
+        "email": email,
+        "code": code,
+        "ttl": 1234567890,
+    }
+
+    with (
+        patch("app.api.teams.LiteLLMService.create_team", new_callable=AsyncMock),
+        patch("app.core.litellm_user_sync.LiteLLMService") as mock_sync_litellm,
+    ):
+        mock_sync_litellm.return_value = AsyncMock()
+        response = client.post(
+            "/auth/sign-in", json={"username": email, "verification_code": code}
+        )
+
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+
+    response = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 200
+    user_data = response.json()
+    assert user_data["email"] == email
+    assert user_data["role"] == "admin"
+    assert user_data["team_id"] == team.id  # reused, not a new team
+
+
 def test_create_token_basic(client, test_user, test_token):
     """
     Given a regular user

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -461,6 +461,59 @@ def test_sign_in_reuses_orphaned_team(client, db, mock_dynamodb, test_region):
     assert user_data["team_id"] == team.id  # reused, not a new team
 
 
+def test_sign_in_reuses_orphaned_team_with_plus_tagged_admin_email(
+    client, db, mock_dynamodb, test_region
+):
+    """
+    Given an orphaned team whose stored admin_email is plus-tagged
+    When the user signs in with the base (tag-stripped) email
+    Then the tagged team is reused instead of creating a new one.
+    """
+    from datetime import UTC, datetime
+
+    from app.db.models import DBTeam
+
+    email = "tagged_orphan@example.com"
+    code = "TESTCODE"
+
+    team = DBTeam(
+        name="Team tagged_orphan+p12@example.com",
+        admin_email="tagged_orphan+p12@example.com",
+        is_active=True,
+        created_at=datetime.now(UTC),
+        budget_type="periodic",
+    )
+    db.add(team)
+    db.commit()
+    db.refresh(team)
+
+    mock_dynamodb.read_validation_code.return_value = {
+        "email": email,
+        "code": code,
+        "ttl": 1234567890,
+    }
+
+    with (
+        patch("app.api.teams.LiteLLMService.create_team", new_callable=AsyncMock),
+        patch("app.core.litellm_user_sync.LiteLLMService") as mock_sync_litellm,
+    ):
+        mock_sync_litellm.return_value = AsyncMock()
+        response = client.post(
+            "/auth/sign-in",
+            json={"username": "tagged_orphan+p12@example.com", "verification_code": code},
+        )
+
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+
+    response = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 200
+    user_data = response.json()
+    assert user_data["email"] == email
+    assert user_data["role"] == "admin"
+    assert user_data["team_id"] == team.id  # reused, not a new team
+
+
 def test_create_token_basic(client, test_user, test_token):
     """
     Given a regular user


### PR DESCRIPTION
## Problem
Hard-deleting a user leaves their team behind. The team's unique `admin_email` then makes re-registration fail forever with "Email already registered" — surfaced by the Drupal AI provider module as a wrong verification code.

## Fix
`POST /auth/sign-in` auto-provisioning now re-attaches the user as admin of an existing non-soft-deleted team with the same `admin_email`, instead of trying to create a duplicate team.

## Test
`test_sign_in_reuses_orphaned_team`: team exists, user hard-deleted, sign-in re-creates the user into the same team. All sign-in tests pass.

## Known gap (not addressed)
A soft-deleted team still holds its unique `admin_email` during the retention window; freeing it needs a partial unique index + migration.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds orphaned-team recovery to passwordless sign-in.
- Reuses a non-deleted team whose admin email matches the signing-in user instead of creating a duplicate.
- Adds an integration test confirming that a hard-deleted user is recreated as administrator of the original team.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The email canonicalization mismatch should be fixed before merging because it leaves a currently valid class of orphaned teams unrecoverable.

Sign-in strips plus tags before querying, while team admin addresses may retain them, causing the new recovery branch to miss the intended team and provision against a different canonical address.

**Files Needing Attention:** app/api/auth.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/auth.py | Adds orphaned-team reuse, but its lookup does not apply the same plus-tag canonicalization used for sign-in identities. |
| tests/test_auth.py | Adds coverage for ordinary orphan-team reuse, but not for a plus-tagged stored admin email. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Verified sign-in email has no user] --> B{Matching active team?}
  B -->|Yes| C[Reuse team]
  B -->|No| D[Create team in public region]
  C --> E[Create administrator user]
  D --> E
  E --> F[Issue access token]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): reuse orphaned team on sign-i..."](https://github.com/amazeeio/amazee.ai/commit/bc361e6a42c3deb6cddd8c3f125236fd1f4a5186) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48011677)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Authentication and RBAC](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/auth-rbac.md)

<!-- /greptile_comment -->