### PR TITLE
feat(public-models): add aliased_to and EOL information to /public/models

### DIFF
--- a/app/api/public.py
+++ b/app/api/public.py
@@ -875,6 +875,9 @@ _bedrock_catalog_cache: dict[str, Any] = {
     "url": None,
     "expires_at": datetime.min.replace(tzinfo=UTC),
     "data": None,
+    # EOL dates derived from "data", cached with it so the derivation happens
+    # once per fetch rather than once per caller.  See _build_eol_index.
+    "eol_index": {},
 }
 
 
@@ -926,6 +929,7 @@ async def _fetch_bedrock_catalog(url: str) -> list[dict[str, Any]]:
 
         _bedrock_catalog_cache["url"] = url
         _bedrock_catalog_cache["data"] = data
+        _bedrock_catalog_cache["eol_index"] = _build_eol_index(data)
         _bedrock_catalog_cache["expires_at"] = now + _BEDROCK_CATALOG_TTL
         return data
 
@@ -961,11 +965,6 @@ _EOL_ANNOTATION_PATTERN = re.compile(r"\(EOL:\s*(\d{4}-\d{2}-\d{2})\)")
 
 # ``bedrock/us.anthropic.claude-...`` -> the catalog's ``anthropic.claude-...``.
 _BEDROCK_REGION_PREFIXES = ("us.", "eu.", "au.", "apac.", "global.", "jp.")
-
-_bedrock_eol_cache: dict[str, Any] = {
-    "catalog_expires_at": None,
-    "index": {},
-}
 
 
 def _parse_eol_annotation(metadata_raw: Any) -> str | None:
@@ -1028,7 +1027,12 @@ def _build_eol_index(catalog: list[dict[str, Any]]) -> dict[str, str]:
                 index[model_id] = date.fromisoformat(raw.strip()[:10]).isoformat()
                 continue
             except ValueError:
-                pass
+                logger.debug(
+                    "Unparseable modelLifecycle.endOfLifeTime %r for Bedrock model "
+                    "%s; trying modelCard.modelEolDate",
+                    raw,
+                    model_id,
+                )
 
         card = model.get("modelCard")
         raw = (card or {}).get("modelEolDate") if isinstance(card, dict) else None
@@ -1047,6 +1051,9 @@ def _build_eol_index(catalog: list[dict[str, Any]]) -> dict[str, str]:
 async def _get_bedrock_eol_index() -> dict[str, str]:
     """EOL dates keyed by Bedrock ``modelId``; empty dict when unavailable.
 
+    The index is built by _fetch_bedrock_catalog under its own lock, so a cold
+    multi-region fan-out derives it once no matter how many regions ask for it.
+
     Never raises: /public/models must not fail because the upstream catalog is
     down, so a fetch error degrades to the operator-authored annotations only.
     An empty ``BEDROCK_MODELS_URL`` disables the lookup entirely (used by tests
@@ -1055,19 +1062,13 @@ async def _get_bedrock_eol_index() -> dict[str, str]:
     if not settings.BEDROCK_MODELS_URL:
         return {}
     try:
-        catalog = await _fetch_bedrock_catalog(settings.BEDROCK_MODELS_URL)
+        await _fetch_bedrock_catalog(settings.BEDROCK_MODELS_URL)
     except (httpx.RequestError, HTTPException, asyncio.TimeoutError) as exc:
         logger.warning(
             "Bedrock catalog unavailable for /public/models EOL dates: %s", str(exc)
         )
         return {}
-
-    # Rebuild only when _fetch_bedrock_catalog refreshed its cache.
-    expires_at = _bedrock_catalog_cache["expires_at"]
-    if _bedrock_eol_cache["catalog_expires_at"] != expires_at:
-        _bedrock_eol_cache["index"] = _build_eol_index(catalog)
-        _bedrock_eol_cache["catalog_expires_at"] = expires_at
-    return _bedrock_eol_cache["index"]
+    return _bedrock_catalog_cache["eol_index"] or {}
 
 
 def _resolve_eol(

--- a/app/api/public.py
+++ b/app/api/public.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import re
-from datetime import datetime, timedelta, UTC
+from datetime import date, datetime, timedelta, UTC
 from typing import Any
 
 import httpx
@@ -333,8 +333,164 @@ async def _resolve_profit_margin(service: LiteLLMService, region_name: str) -> f
     return margin
 
 
+# ---------------------------------------------------------------------------
+# aliased_to resolution
+# ---------------------------------------------------------------------------
+#
+# LiteLLM has no alias concept we can read: an alias is configured as a second
+# model entry that happens to share the same ``litellm_params.model`` as the
+# model it points at.  ``/model/info``, ``/model_group/info`` and ``/v1/models``
+# expose no field linking one entry to another (``base_model`` and
+# ``team_public_model_name`` are null across every entry on DEV and PROD), so
+# the link has to be derived from data LiteLLM does give us.
+#
+# Sharing a ``litellm_params.model`` is a fact, not a guess: those entries are
+# the same deployment.  Picking *which* member is the canonical one is the part
+# that needs a rule, applied in decreasing order of authority in
+# ``_resolve_canonical_model`` below.
+
+# Tokens that carry no model identity: provider routes, AWS region prefixes and
+# vendor names.  Dropped before comparing names so that our ``claude-4-6-sonnet``
+# still matches upstream ``bedrock/us.anthropic.claude-sonnet-4-6``.
+_ALIAS_NOISE_TOKENS = frozenset(
+    {
+        "ai",
+        "ai21",
+        "amazon",
+        "anthropic",
+        "au",
+        "apac",
+        "azure",
+        "bedrock",
+        "cohere",
+        "deepseek",
+        "eu",
+        "global",
+        "google",
+        "jp",
+        "luma",
+        "meta",
+        "mistral",
+        "moonshotai",
+        "nvidia",
+        "openai",
+        "qwen",
+        "stability",
+        "twelvelabs",
+        "us",
+        "vertex",
+        "writer",
+        "xai",
+    }
+)
+
+# Operators annotate aliases in the LiteLLM model metadata, e.g.
+# "Points to claude-4-5-haiku."  Only accepted when the captured name is a real
+# sibling in the same group, so vaguer variants ("Points to the latest Claude
+# model") are ignored rather than producing a dangling pointer.
+_POINTS_TO_PATTERN = re.compile(r"points to\s+([A-Za-z0-9_.:-]+)", re.IGNORECASE)
+
+
+def _model_identity_tokens(value: str) -> frozenset[str]:
+    """Reduce a model name or upstream id to the tokens that identify the model.
+
+    A set, not a string: our names and the provider's disagree on word order
+    (``claude-4-6-sonnet`` vs ``claude-sonnet-4-6``), so order must not matter.
+    """
+    lowered = value.lower()
+    lowered = re.sub(r"\b20\d{6}\b", "", lowered)  # release stamps: 20251001
+    lowered = re.sub(r"\bv\d+(:\d+)?\b", "", lowered)  # provider versions: v1:0
+    return frozenset(
+        token
+        for token in re.split(r"[^a-z0-9]+", lowered)
+        if token and token not in _ALIAS_NOISE_TOKENS
+    )
+
+
+def _extract_points_to(metadata: Any) -> str | None:
+    """Return the model name named by a "Points to <model>." annotation."""
+    if not isinstance(metadata, str):
+        return None
+    match = _POINTS_TO_PATTERN.search(metadata)
+    if not match:
+        return None
+    return match.group(1).rstrip(".").lower() or None
+
+
+def _resolve_canonical_model(
+    upstream_model: str, members: list[str], model_infos: dict[str, dict[str, Any]]
+) -> str | None:
+    """Pick the canonical model among *members*, all sharing *upstream_model*.
+
+    Returns ``None`` when no single member wins, so an ambiguous group reports
+    ``aliased_to: null`` everywhere rather than a wrong pointer.
+    """
+    by_lowered = {member.lower(): member for member in members}
+
+    # 1. An explicit ``model_info.aliased_to`` in the LiteLLM config wins.  Not
+    #    set anywhere today; supported so the config can become authoritative
+    #    later without touching this code.
+    for member in members:
+        declared = model_infos.get(member, {}).get("aliased_to")
+        if isinstance(declared, str) and (target := by_lowered.get(declared.lower())):
+            if target != member:
+                return target
+
+    # 2. An operator-authored "Points to <model>." annotation.
+    for member in members:
+        named = _extract_points_to(model_infos.get(member, {}).get("metadata"))
+        if named and (target := by_lowered.get(named)) and target != member:
+            return target
+
+    # 3. Fall back to name shape: the member whose identity tokens match the
+    #    upstream model id is the real one, aliases carry different names.
+    upstream_tokens = _model_identity_tokens(upstream_model)
+    matches = [m for m in members if _model_identity_tokens(m) == upstream_tokens]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _build_alias_map(items: list[dict[str, Any]]) -> dict[str, str]:
+    """Map each aliased model name in a region to the model name it points at.
+
+    Canonical models are absent from the result, so a missing key means
+    ``aliased_to: null``.
+    """
+    groups: dict[str, list[str]] = {}
+    model_infos: dict[str, dict[str, Any]] = {}
+
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        params = item.get("litellm_params")
+        upstream = params.get("model") if isinstance(params, dict) else None
+        model_info = item.get("model_info")
+        model_info = model_info if isinstance(model_info, dict) else {}
+        name = item.get("model_name") or model_info.get("key")
+        if not isinstance(upstream, str) or not upstream:
+            continue
+        if not isinstance(name, str) or not name:
+            continue
+        groups.setdefault(upstream, []).append(name)
+        model_infos[name] = model_info
+
+    alias_map: dict[str, str] = {}
+    for upstream, members in groups.items():
+        if len(members) < 2:
+            continue  # only deployment on this upstream model: it is canonical
+        canonical = _resolve_canonical_model(upstream, members, model_infos)
+        if canonical is None:
+            continue
+        for member in members:
+            if member != canonical:
+                alias_map[member] = canonical
+    return alias_map
+
+
 def _extract_model_summary(
-    item: dict[str, Any], profit_margin: float
+    item: dict[str, Any],
+    profit_margin: float,
+    alias_map: dict[str, str] | None = None,
+    eol_index: dict[str, str] | None = None,
 ) -> PublicModelSummary:
     model_info = item.get("model_info", {})
     model_id = item.get("model_name") or model_info.get("key") or "unknown"
@@ -365,12 +521,17 @@ def _extract_model_summary(
     )
 
     aliases = _extract_aliases(item, model_id)
+    metadata_raw = model_info.get("metadata") or item.get("metadata")
+    eol_date, eol_source = _resolve_eol(item, metadata_raw, eol_index)
 
     return PublicModelSummary(
+        aliased_to=(alias_map or {}).get(model_id),
+        eol_date=eol_date,
+        eol_source=eol_source,
         model_id=model_id,
         display_name=_to_display_name(model_id, aliases),
         aliases=aliases,
-        metadata_raw=model_info.get("metadata") or item.get("metadata"),
+        metadata_raw=metadata_raw,
         provider=_infer_provider(item),
         type=model_type,
         context_length=context_length,
@@ -492,12 +653,17 @@ async def _fetch_region_model_group(
                 _resolve_profit_margin(service, region_name),
                 timeout=_REGION_TIMEOUT,
             )
+            items = model_info.get("data", [])
+            # Both maps need the whole region: aliased_to compares models against
+            # each other, and the EOL index is shared by every model here.
+            alias_map = _build_alias_map(items)
+            eol_index = await _get_bedrock_eol_index()
             return PublicRegionModels(
                 region=region_name,
                 status="ga",
                 models=[
-                    _extract_model_summary(item, profit_margin)
-                    for item in model_info.get("data", [])
+                    _extract_model_summary(item, profit_margin, alias_map, eol_index)
+                    for item in items
                 ],
             )
         except (httpx.RequestError, HTTPException, asyncio.TimeoutError) as exc:
@@ -762,6 +928,164 @@ async def _fetch_bedrock_catalog(url: str) -> list[dict[str, Any]]:
         _bedrock_catalog_cache["data"] = data
         _bedrock_catalog_cache["expires_at"] = now + _BEDROCK_CATALOG_TTL
         return data
+
+
+# ---------------------------------------------------------------------------
+# eol_date resolution
+# ---------------------------------------------------------------------------
+#
+# Why this is fetched in-request and NOT by a cron job:
+#
+#   * The data is already here.  ``BEDROCK_MODELS_URL`` and
+#     ``_fetch_bedrock_catalog`` exist for /models/missing/aws, and the catalog
+#     is cached for _BEDROCK_CATALOG_TTL.  Reading EOL dates out of it costs one
+#     extra ~190KB GET per hour per pod, and only on a cache miss.
+#   * /public/models is itself cached for _CACHE_TTL and served with
+#     ``Cache-Control: public, max-age=3600``, so EOL dates refresh on the same
+#     schedule as the rest of the response.  A cron job would add a second,
+#     different refresh schedule for no gain.
+#   * A cron job would need a table, a migration and a .lagoon.yml entry, and it
+#     would put stale rows between us and the upstream truth.  EOL dates change
+#     a handful of times a year; that machinery buys nothing.
+#
+# The weekly Slack alert stays a cron (GitHub Actions) — it reads this endpoint,
+# so it now gets ``eol_date`` instead of regex-parsing prose out of
+# ``metadata_raw``.
+
+# Operator-authored annotation in the LiteLLM model metadata, e.g.
+# "...Good for simple tasks. (EOL: 2026-09-10)".  Kept in sync with the same
+# pattern in scripts/check_eol_models.py, which cannot import from app/ because
+# it is deliberately stdlib-only (app.core imports pydantic).  A test asserts
+# both parse the same string.
+_EOL_ANNOTATION_PATTERN = re.compile(r"\(EOL:\s*(\d{4}-\d{2}-\d{2})\)")
+
+# ``bedrock/us.anthropic.claude-...`` -> the catalog's ``anthropic.claude-...``.
+_BEDROCK_REGION_PREFIXES = ("us.", "eu.", "au.", "apac.", "global.", "jp.")
+
+_bedrock_eol_cache: dict[str, Any] = {
+    "catalog_expires_at": None,
+    "index": {},
+}
+
+
+def _parse_eol_annotation(metadata_raw: Any) -> str | None:
+    """Return the ISO date from an ``(EOL: YYYY-MM-DD)`` annotation, if present."""
+    if not isinstance(metadata_raw, str):
+        return None
+    match = _EOL_ANNOTATION_PATTERN.search(metadata_raw)
+    if not match:
+        return None
+    try:
+        return date.fromisoformat(match.group(1)).isoformat()
+    except ValueError:
+        return None
+
+
+def _bedrock_catalog_id(item: dict[str, Any]) -> str | None:
+    """Return the upstream Bedrock ``modelId`` for a LiteLLM entry, or None.
+
+    Returns None for non-Bedrock providers (``vertex_ai/...``, ``azure/...``),
+    which the Bedrock catalog cannot describe.
+    """
+    params = item.get("litellm_params")
+    candidate = params.get("model") if isinstance(params, dict) else None
+    if not isinstance(candidate, str) or not candidate:
+        return None
+    if candidate.startswith("bedrock/"):
+        candidate = candidate.split("/", 1)[1]
+    elif "/" in candidate:
+        return None
+    for prefix in _BEDROCK_REGION_PREFIXES:
+        if candidate.startswith(prefix):
+            candidate = candidate[len(prefix) :]
+            break
+    return candidate or None
+
+
+def _build_eol_index(catalog: list[dict[str, Any]]) -> dict[str, str]:
+    """Map Bedrock ``modelId`` -> ISO EOL date for every model that has one.
+
+    Two upstream fields carry the date and they agree wherever both are set, but
+    neither covers the other's models: prefer ``modelLifecycle.endOfLifeTime``
+    (already ISO), fall back to the human-formatted ``modelCard.modelEolDate``.
+    """
+    index: dict[str, str] = {}
+    for model in catalog:
+        if not isinstance(model, dict):
+            continue
+        model_id = model.get("modelId")
+        if not isinstance(model_id, str) or not model_id:
+            continue
+
+        lifecycle = model.get("modelLifecycle")
+        raw = (
+            (lifecycle or {}).get("endOfLifeTime")
+            if isinstance(lifecycle, dict)
+            else None
+        )
+        if isinstance(raw, str) and raw.strip():
+            try:
+                index[model_id] = date.fromisoformat(raw.strip()[:10]).isoformat()
+                continue
+            except ValueError:
+                pass
+
+        card = model.get("modelCard")
+        raw = (card or {}).get("modelEolDate") if isinstance(card, dict) else None
+        if isinstance(raw, str) and raw.strip():
+            try:
+                index[model_id] = (
+                    datetime.strptime(raw.strip(), "%B %d, %Y").date().isoformat()
+                )
+            except ValueError:
+                logger.debug(
+                    "Unparseable modelEolDate %r for Bedrock model %s", raw, model_id
+                )
+    return index
+
+
+async def _get_bedrock_eol_index() -> dict[str, str]:
+    """EOL dates keyed by Bedrock ``modelId``; empty dict when unavailable.
+
+    Never raises: /public/models must not fail because the upstream catalog is
+    down, so a fetch error degrades to the operator-authored annotations only.
+    An empty ``BEDROCK_MODELS_URL`` disables the lookup entirely (used by tests
+    to stay off the network).
+    """
+    if not settings.BEDROCK_MODELS_URL:
+        return {}
+    try:
+        catalog = await _fetch_bedrock_catalog(settings.BEDROCK_MODELS_URL)
+    except (httpx.RequestError, HTTPException, asyncio.TimeoutError) as exc:
+        logger.warning(
+            "Bedrock catalog unavailable for /public/models EOL dates: %s", str(exc)
+        )
+        return {}
+
+    # Rebuild only when _fetch_bedrock_catalog refreshed its cache.
+    expires_at = _bedrock_catalog_cache["expires_at"]
+    if _bedrock_eol_cache["catalog_expires_at"] != expires_at:
+        _bedrock_eol_cache["index"] = _build_eol_index(catalog)
+        _bedrock_eol_cache["catalog_expires_at"] = expires_at
+    return _bedrock_eol_cache["index"]
+
+
+def _resolve_eol(
+    item: dict[str, Any], metadata_raw: Any, eol_index: dict[str, str] | None
+) -> tuple[str | None, str | None]:
+    """Return ``(eol_date, eol_source)`` for one model.
+
+    An operator-authored annotation wins over the upstream catalog: we may retire
+    a model before AWS does, and that decision must not be overwritten.
+    """
+    annotated = _parse_eol_annotation(metadata_raw)
+    if annotated:
+        return annotated, "manual"
+
+    catalog_id = _bedrock_catalog_id(item)
+    if catalog_id and (upstream := (eol_index or {}).get(catalog_id)):
+        return upstream, "bedrock"
+    return None, None
 
 
 def _build_available_aws_models_by_group(

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -342,6 +342,29 @@ class PublicModelSummary(BaseModel):
     manufacturer: Optional[PublicModelManufacturer] = None
     capabilities: PublicModelCapabilities
     pricing: PublicModelPricing
+    aliased_to: Optional[str] = Field(
+        default=None,
+        description=(
+            "The canonical model_id this entry points at, or null when this "
+            "model is itself canonical. Two models in the same region are the "
+            "same deployment when they share a litellm_params.model."
+        ),
+    )
+    eol_date: Optional[str] = Field(
+        default=None,
+        description=(
+            "End-of-Life date as ISO YYYY-MM-DD, or null when the model has no "
+            "known EOL date."
+        ),
+    )
+    eol_source: Optional[str] = Field(
+        default=None,
+        description=(
+            "Where eol_date came from: 'manual' for an operator-authored "
+            "'(EOL: ...)' annotation in the LiteLLM model metadata, 'bedrock' "
+            "for the upstream AWS Bedrock catalog. Null when eol_date is null."
+        ),
+    )
 
 
 class PublicRegionModels(BaseModel):

--- a/scripts/check_eol_models.py
+++ b/scripts/check_eol_models.py
@@ -3,16 +3,20 @@
 """Check for models approaching or past their End-of-Life (EOL) date.
 
 Queries ``GET /public/models`` on the configured backend (defaults to
-https://api.amazee.ai), parses the ``(EOL: YYYY-MM-DD)`` annotation from
-each model's ``metadata_raw`` field, and emits GitHub Actions outputs for
-Slack notification when models are:
+https://api.amazee.ai), reads each model's structured ``eol_date`` field, and
+emits GitHub Actions outputs for Slack notification when models are:
 
 * **Expired**: EOL date is in the past.
 * **Approaching EOL**: EOL date is within the configured warning window
   (default 30 days).
 
+Older backends do not send ``eol_date``, so the ``(EOL: YYYY-MM-DD)`` annotation
+in ``metadata_raw`` is kept as a fallback.
+
 The script is intentionally stdlib-only so the workflow doesn't need to
-install anything.
+install anything. That is also why the annotation regex is duplicated here
+instead of imported from ``app`` — importing ``app.core`` pulls in pydantic.
+``tests/test_check_eol_models.py`` asserts both copies parse the same string.
 """
 
 from __future__ import annotations
@@ -60,6 +64,16 @@ def fetch_public_models(api_url: str, timeout: int = 60) -> list[dict[str, Any]]
             f"Unexpected response format from {url}: expected a list, got {type(data).__name__}"
         )
     return data
+
+
+def parse_eol_date(value: Any) -> date | None:
+    """Parse the structured ``eol_date`` field (ISO ``YYYY-MM-DD``)."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return date.fromisoformat(value.strip())
+    except ValueError:
+        return None
 
 
 def extract_eol_date(metadata_raw: Any) -> date | None:
@@ -127,7 +141,9 @@ def check_eol_models(
                 continue
             seen.add(model_id)
 
-            eol_date = extract_eol_date(model.get("metadata_raw"))
+            eol_date = parse_eol_date(model.get("eol_date")) or extract_eol_date(
+                model.get("metadata_raw")
+            )
             if eol_date is None:
                 continue
 

--- a/tests/test_cache_headers.py
+++ b/tests/test_cache_headers.py
@@ -1,4 +1,21 @@
+from unittest.mock import patch
+
+import pytest
 from fastapi.testclient import TestClient
+
+from app.api import public as public_api
+
+
+@pytest.fixture(autouse=True)
+def _offline_bedrock_catalog():
+    """Keep /public/models off the network.
+
+    The endpoint enriches models with EOL dates from the upstream Bedrock
+    catalog; an empty BEDROCK_MODELS_URL skips that fetch. Tests that exercise
+    the EOL path patch _get_bedrock_eol_index (or this setting) themselves.
+    """
+    with patch.object(public_api.settings, "BEDROCK_MODELS_URL", ""):
+        yield
 
 
 def test_cache_control_headers_present(client: TestClient):

--- a/tests/test_check_eol_models.py
+++ b/tests/test_check_eol_models.py
@@ -379,3 +379,118 @@ class TestMainWarningDaysValidation:
         ):
             exit_code = mod["main"]()
             assert exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# Structured eol_date field (issue #638)
+# ---------------------------------------------------------------------------
+
+
+class TestStructuredEolDateField:
+    def test_prefers_structured_field_over_metadata_raw(self):
+        """eol_date wins; metadata_raw is only a fallback for older backends."""
+        mod = _load_module()
+        results = mod["check_eol_models"](
+            [
+                {
+                    "region": "test-region",
+                    "models": [
+                        {
+                            "model_id": "claude-3-haiku",
+                            "eol_date": "2026-08-01",
+                            "metadata_raw": "Stale prose. (EOL: 2026-09-10)",
+                        }
+                    ],
+                }
+            ],
+            warning_days=100000,
+        )
+        found = results["expired"] + results["approaching"]
+        assert [m["eol_date"] for m in found] == ["2026-08-01"]
+
+    def test_falls_back_to_metadata_raw_when_field_absent(self):
+        """A backend that predates eol_date must still be handled."""
+        mod = _load_module()
+        results = mod["check_eol_models"](
+            [
+                {
+                    "region": "test-region",
+                    "models": [
+                        {
+                            "model_id": "claude-3-haiku",
+                            "metadata_raw": "Legacy prose. (EOL: 2026-09-10)",
+                        }
+                    ],
+                }
+            ],
+            warning_days=100000,
+        )
+        found = results["expired"] + results["approaching"]
+        assert [m["eol_date"] for m in found] == ["2026-09-10"]
+
+    def test_falls_back_when_field_is_null(self):
+        """Models with no known EOL date send eol_date: null."""
+        mod = _load_module()
+        results = mod["check_eol_models"](
+            [
+                {
+                    "region": "test-region",
+                    "models": [
+                        {
+                            "model_id": "claude-3-haiku",
+                            "eol_date": None,
+                            "metadata_raw": "Prose only. (EOL: 2026-09-10)",
+                        }
+                    ],
+                }
+            ],
+            warning_days=100000,
+        )
+        found = results["expired"] + results["approaching"]
+        assert [m["eol_date"] for m in found] == ["2026-09-10"]
+
+    def test_model_with_no_eol_anywhere_is_ignored(self):
+        mod = _load_module()
+        results = mod["check_eol_models"](
+            [
+                {
+                    "region": "test-region",
+                    "models": [
+                        {
+                            "model_id": "claude-opus-5",
+                            "eol_date": None,
+                            "metadata_raw": "No EOL here.",
+                        }
+                    ],
+                }
+            ],
+            warning_days=100000,
+        )
+        assert results == {"expired": [], "approaching": []}
+
+    @pytest.mark.parametrize("value", ["", "   ", "not-a-date", "2026-13-45", 20260910])
+    def test_unparseable_structured_field_is_ignored(self, value):
+        mod = _load_module()
+        assert mod["parse_eol_date"](value) is None
+
+    def test_annotation_regex_matches_the_backend_copy(self):
+        """The duplicated (EOL: ...) pattern must agree with app/api/public.py.
+
+        The script is stdlib-only so it cannot import from app/; this pins the
+        two copies together.
+        """
+        from app.api.public import _parse_eol_annotation
+
+        mod = _load_module()
+        for text in (
+            "Low cost Claude model. (EOL: 2026-09-10)",
+            "Alias pointing to Claude 3 Haiku. (EOL: 2026-09-10)",
+            "(EOL:2026-01-02) leading",
+            "no annotation here",
+            "malformed (EOL: 2026-9-10)",
+        ):
+            script_result = mod["extract_eol_date"](text)
+            backend_result = _parse_eol_annotation(text)
+            assert (
+                script_result.isoformat() if script_result else None
+            ) == backend_result, text

--- a/tests/test_public_models.py
+++ b/tests/test_public_models.py
@@ -16,6 +16,18 @@ def _clear_public_models_cache():
     public_api._dedicated_cache["team_expires"] = {}
 
 
+@pytest.fixture(autouse=True)
+def _offline_bedrock_catalog():
+    """Keep /public/models off the network.
+
+    The endpoint enriches models with EOL dates from the upstream Bedrock
+    catalog; an empty BEDROCK_MODELS_URL skips that fetch. Tests that exercise
+    the EOL path patch _get_bedrock_eol_index (or this setting) themselves.
+    """
+    with patch.object(public_api.settings, "BEDROCK_MODELS_URL", ""):
+        yield
+
+
 def test_public_models_returns_aggregated_data(client, db):
     _clear_public_models_cache()
     region = DBRegion(
@@ -909,3 +921,299 @@ def test_public_models_team_visibility_uses_explicit_team_regions(client, db):
     region_names = [r["region"] for r in response.json()]
     assert "public-region-hidden" not in region_names
     assert "team-hidden-dedicated" in region_names
+
+
+# ---------------------------------------------------------------------------
+# aliased_to
+# ---------------------------------------------------------------------------
+
+
+def _alias_group_response():
+    """Three models on one upstream deployment, plus an unrelated canonical one.
+
+    Mirrors DEV amazeeai-us1: aliases are separate entries sharing a
+    litellm_params.model, one of them annotated "Points to ...".
+    """
+    return {
+        "data": [
+            {
+                "model_name": "claude-4-6-sonnet",
+                "litellm_params": {"model": "bedrock/us.anthropic.claude-sonnet-4-6"},
+                "model_info": {"mode": "chat", "metadata": "Previous generation."},
+            },
+            {
+                "model_name": "claude-3-5-sonnet",
+                "litellm_params": {"model": "bedrock/us.anthropic.claude-sonnet-4-6"},
+                "model_info": {
+                    "mode": "chat",
+                    "metadata": "Points to claude-4-6-sonnet.",
+                },
+            },
+            {
+                "model_name": "chat",
+                "litellm_params": {"model": "bedrock/us.anthropic.claude-sonnet-4-6"},
+                "model_info": {
+                    "mode": "chat",
+                    "metadata": "Points to the latest Claude model.",
+                },
+            },
+            {
+                "model_name": "gemini-2.5-flash-image",
+                "litellm_params": {"model": "vertex_ai/gemini-2.5-flash-image"},
+                "model_info": {"mode": "chat", "metadata": "Image generation."},
+            },
+        ]
+    }
+
+
+def _models_by_id(response):
+    return {m["model_id"]: m for m in response.json()[0]["models"]}
+
+
+def test_public_models_marks_aliases_and_canonical_models(client, db):
+    """Aliases point at the canonical model; the canonical one reports null."""
+    _clear_public_models_cache()
+    _make_public_region(db, "alias-region")
+
+    with patch("app.api.public.LiteLLMService") as mock_cls:
+        mock_cls.return_value.get_model_info = AsyncMock(
+            return_value=_alias_group_response()
+        )
+        response = client.get("/public/models")
+
+    assert response.status_code == 200
+    models = _models_by_id(response)
+    # Canonical: shares the upstream id's identity tokens.
+    assert models["claude-4-6-sonnet"]["aliased_to"] is None
+    # Alias resolved from the "Points to ..." annotation.
+    assert models["claude-3-5-sonnet"]["aliased_to"] == "claude-4-6-sonnet"
+    # Alias with vague prose still resolved via the shared upstream deployment.
+    assert models["chat"]["aliased_to"] == "claude-4-6-sonnet"
+    # Sole deployment on its upstream model: canonical by definition.
+    assert models["gemini-2.5-flash-image"]["aliased_to"] is None
+
+
+def test_public_models_aliased_to_is_null_when_canonical_is_ambiguous(client, db):
+    """No single winner means null everywhere, never a guessed pointer."""
+    _clear_public_models_cache()
+    _make_public_region(db, "ambiguous-alias-region")
+
+    upstream = {"model": "bedrock/us.anthropic.claude-sonnet-4-6"}
+    with patch("app.api.public.LiteLLMService") as mock_cls:
+        mock_cls.return_value.get_model_info = AsyncMock(
+            return_value={
+                "data": [
+                    {
+                        "model_name": "house-chat",
+                        "litellm_params": upstream,
+                        "model_info": {"mode": "chat"},
+                    },
+                    {
+                        "model_name": "house-chat-fast",
+                        "litellm_params": upstream,
+                        "model_info": {"mode": "chat"},
+                    },
+                ]
+            }
+        )
+        response = client.get("/public/models")
+
+    assert response.status_code == 200
+    models = _models_by_id(response)
+    assert models["house-chat"]["aliased_to"] is None
+    assert models["house-chat-fast"]["aliased_to"] is None
+
+
+def test_build_alias_map_ignores_word_order_and_version_suffixes():
+    """Direct unit check of the name-shape fallback."""
+    alias_map = public_api._build_alias_map(
+        [
+            {
+                "model_name": "claude-4-5-haiku",
+                "litellm_params": {
+                    "model": "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0"
+                },
+                "model_info": {},
+            },
+            {
+                "model_name": "claude-3-5-haiku",
+                "litellm_params": {
+                    "model": "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0"
+                },
+                "model_info": {},
+            },
+            {
+                "model_name": "titan-embed-text-v2:0",
+                "litellm_params": {"model": "amazon.titan-embed-text-v2:0"},
+                "model_info": {},
+            },
+            {
+                "model_name": "embeddings",
+                "litellm_params": {"model": "amazon.titan-embed-text-v2:0"},
+                "model_info": {},
+            },
+        ]
+    )
+    assert alias_map == {
+        "claude-3-5-haiku": "claude-4-5-haiku",
+        "embeddings": "titan-embed-text-v2:0",
+    }
+
+
+# ---------------------------------------------------------------------------
+# eol_date
+# ---------------------------------------------------------------------------
+
+
+def _eol_response():
+    return {
+        "data": [
+            {
+                "model_name": "claude-3-haiku",
+                "litellm_params": {
+                    "model": "bedrock/us.anthropic.claude-3-haiku-20240307-v1:0"
+                },
+                "model_info": {
+                    "mode": "chat",
+                    "metadata": "Low cost Claude model. (EOL: 2026-09-10)",
+                },
+            },
+            {
+                "model_name": "claude-4-6-sonnet",
+                "litellm_params": {"model": "bedrock/us.anthropic.claude-sonnet-4-6"},
+                "model_info": {"mode": "chat", "metadata": "Current Sonnet."},
+            },
+            {
+                "model_name": "gemini-2.5-pro",
+                "litellm_params": {"model": "vertex_ai/gemini-2.5-pro"},
+                "model_info": {"mode": "chat", "metadata": "Not a Bedrock model."},
+            },
+        ]
+    }
+
+
+def test_public_models_reports_eol_from_annotation_and_catalog(client, db):
+    """Manual annotations and upstream catalog dates both surface, tagged."""
+    _clear_public_models_cache()
+    _make_public_region(db, "eol-region")
+
+    with (
+        patch("app.api.public.LiteLLMService") as mock_cls,
+        patch.object(
+            public_api,
+            "_get_bedrock_eol_index",
+            AsyncMock(return_value={"anthropic.claude-sonnet-4-6": "2026-10-14"}),
+        ),
+    ):
+        mock_cls.return_value.get_model_info = AsyncMock(return_value=_eol_response())
+        response = client.get("/public/models")
+
+    assert response.status_code == 200
+    models = _models_by_id(response)
+
+    assert models["claude-3-haiku"]["eol_date"] == "2026-09-10"
+    assert models["claude-3-haiku"]["eol_source"] == "manual"
+    # metadata_raw must keep the annotation: no breaking change.
+    assert "(EOL: 2026-09-10)" in models["claude-3-haiku"]["metadata_raw"]
+
+    assert models["claude-4-6-sonnet"]["eol_date"] == "2026-10-14"
+    assert models["claude-4-6-sonnet"]["eol_source"] == "bedrock"
+
+    assert models["gemini-2.5-pro"]["eol_date"] is None
+    assert models["gemini-2.5-pro"]["eol_source"] is None
+
+
+def test_public_models_annotation_overrides_catalog_eol(client, db):
+    """An operator may retire a model earlier than AWS does."""
+    _clear_public_models_cache()
+    _make_public_region(db, "eol-override-region")
+
+    with (
+        patch("app.api.public.LiteLLMService") as mock_cls,
+        patch.object(
+            public_api,
+            "_get_bedrock_eol_index",
+            AsyncMock(
+                return_value={"anthropic.claude-3-haiku-20240307-v1:0": "2026-09-10"}
+            ),
+        ),
+    ):
+        mock_cls.return_value.get_model_info = AsyncMock(
+            return_value={
+                "data": [
+                    {
+                        "model_name": "claude-3-haiku",
+                        "litellm_params": {
+                            "model": "bedrock/us.anthropic.claude-3-haiku-20240307-v1:0"
+                        },
+                        "model_info": {
+                            "mode": "chat",
+                            "metadata": "Retiring early. (EOL: 2026-08-01)",
+                        },
+                    }
+                ]
+            }
+        )
+        response = client.get("/public/models")
+
+    models = _models_by_id(response)
+    assert models["claude-3-haiku"]["eol_date"] == "2026-08-01"
+    assert models["claude-3-haiku"]["eol_source"] == "manual"
+
+
+def test_public_models_survives_unreachable_bedrock_catalog(client, db):
+    """A dead upstream catalog must not fail the endpoint."""
+    _clear_public_models_cache()
+    _make_public_region(db, "eol-degraded-region")
+    public_api._bedrock_eol_cache["catalog_expires_at"] = None
+    public_api._bedrock_eol_cache["index"] = {}
+
+    with (
+        patch("app.api.public.LiteLLMService") as mock_cls,
+        patch.object(
+            public_api.settings,
+            "BEDROCK_MODELS_URL",
+            "https://catalog.invalid/models.json",
+        ),
+        patch.object(
+            public_api,
+            "_fetch_bedrock_catalog",
+            AsyncMock(side_effect=httpx.ConnectError("boom")),
+        ),
+    ):
+        mock_cls.return_value.get_model_info = AsyncMock(return_value=_eol_response())
+        response = client.get("/public/models")
+
+    assert response.status_code == 200
+    models = _models_by_id(response)
+    # The manual annotation still works; the catalog-only date is simply absent.
+    assert models["claude-3-haiku"]["eol_date"] == "2026-09-10"
+    assert models["claude-4-6-sonnet"]["eol_date"] is None
+
+
+def test_build_eol_index_prefers_lifecycle_and_parses_card_dates():
+    """Both upstream date fields are read; lifecycle wins when both are set."""
+    index = public_api._build_eol_index(
+        [
+            {
+                "modelId": "anthropic.claude-sonnet-4-20250514-v1:0",
+                "modelLifecycle": {"endOfLifeTime": "2026-10-14 07:00:00+00:00"},
+                "modelCard": {"modelEolDate": "October 14, 2026"},
+            },
+            {
+                "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+                "modelLifecycle": {"status": "ACTIVE"},
+                "modelCard": {"modelEolDate": "September 10, 2026"},
+            },
+            {
+                "modelId": "anthropic.claude-opus-5",
+                "modelLifecycle": {"status": "ACTIVE"},
+                "modelCard": {"modelEolDate": None},
+            },
+            {"modelId": "broken.model", "modelCard": {"modelEolDate": "not a date"}},
+        ]
+    )
+    assert index == {
+        "anthropic.claude-sonnet-4-20250514-v1:0": "2026-10-14",
+        "anthropic.claude-3-haiku-20240307-v1:0": "2026-09-10",
+    }

--- a/tests/test_public_models.py
+++ b/tests/test_public_models.py
@@ -1,6 +1,8 @@
+import asyncio
+
 import pytest
 import httpx
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from app.api import public as public_api
 from app.db.models import DBRegion, DBTeam, DBTeamRegion, DBUser
@@ -1165,8 +1167,7 @@ def test_public_models_survives_unreachable_bedrock_catalog(client, db):
     """A dead upstream catalog must not fail the endpoint."""
     _clear_public_models_cache()
     _make_public_region(db, "eol-degraded-region")
-    public_api._bedrock_eol_cache["catalog_expires_at"] = None
-    public_api._bedrock_eol_cache["index"] = {}
+    public_api._bedrock_catalog_cache["eol_index"] = {}
 
     with (
         patch("app.api.public.LiteLLMService") as mock_cls,
@@ -1217,3 +1218,57 @@ def test_build_eol_index_prefers_lifecycle_and_parses_card_dates():
         "anthropic.claude-sonnet-4-20250514-v1:0": "2026-10-14",
         "anthropic.claude-3-haiku-20240307-v1:0": "2026-09-10",
     }
+
+
+@pytest.mark.asyncio
+async def test_bedrock_eol_index_is_derived_once_per_fetch():
+    """A cold multi-region fan-out must not rebuild the index per region.
+
+    The index is derived inside _fetch_bedrock_catalog's lock, so concurrent
+    callers share one HTTP fetch and one derivation.
+    """
+    public_api._bedrock_catalog_cache["url"] = None
+    public_api._bedrock_catalog_cache["data"] = None
+    public_api._bedrock_catalog_cache["eol_index"] = {}
+    public_api._bedrock_catalog_cache["expires_at"] = public_api.datetime.min.replace(
+        tzinfo=public_api.UTC
+    )
+
+    catalog = [
+        {
+            "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+            "modelLifecycle": {"endOfLifeTime": "2026-09-10 08:00:00+00:00"},
+        }
+    ]
+    builds = []
+    real_build = public_api._build_eol_index
+
+    def counting_build(data):
+        builds.append(len(data))
+        return real_build(data)
+
+    response = MagicMock()
+    response.json.return_value = catalog
+    response.raise_for_status.return_value = None
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(return_value=response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch.object(
+            public_api.settings,
+            "BEDROCK_MODELS_URL",
+            "https://catalog.test/models.json",
+        ),
+        patch.object(public_api, "_build_eol_index", counting_build),
+        patch.object(public_api.httpx, "AsyncClient", return_value=mock_client),
+    ):
+        indexes = await asyncio.gather(
+            *(public_api._get_bedrock_eol_index() for _ in range(5))
+        )
+
+    assert len(builds) == 1, f"index rebuilt {len(builds)} times"
+    assert mock_client.get.await_count == 1
+    expected = {"anthropic.claude-3-haiku-20240307-v1:0": "2026-09-10"}
+    assert all(index == expected for index in indexes)

--- a/tests/test_public_models_missing.py
+++ b/tests/test_public_models_missing.py
@@ -17,6 +17,7 @@ AWS_PATH = "/models/missing/aws"
 def _clear_bedrock_catalog_cache():
     public_api._bedrock_catalog_cache["url"] = None
     public_api._bedrock_catalog_cache["data"] = None
+    public_api._bedrock_catalog_cache["eol_index"] = {}
     public_api._bedrock_catalog_cache["expires_at"] = datetime.min.replace(tzinfo=UTC)
 
 


### PR DESCRIPTION
Backend half of amazeeio/moad#638. MOAD is intentionally out of scope — see "MOAD" below.

## What changes

`GET /public/models` gains three optional fields per model:

| Field | Meaning |
|---|---|
| `aliased_to` | Canonical `model_id` this entry points at, `null` when canonical |
| `eol_date` | ISO `YYYY-MM-DD`, `null` when unknown |
| `eol_source` | `manual` or `bedrock`, `null` when `eol_date` is null |

`aliases` and `metadata_raw` are untouched. All three fields are optional with `None` defaults, so this is additive.

## `aliased_to`

LiteLLM has no alias field to read. I checked `/model/info`, `/model_group/info` and `/v1/models` on DEV `amazeeai-us1`: no field matching `alias`, and `base_model` / `team_public_model_name` are `null` on all 35 entries. An alias is configured as a separate model entry that shares a `litellm_params.model` with the model it points at.

So grouping is a fact from LiteLLM; picking the canonical member of a group needs a rule, applied in decreasing order of authority:

1. `model_info.aliased_to` from the LiteLLM config — authoritative, not set anywhere today. Supported so the config can take over later without touching this code.
2. An operator `"Points to <model>."` annotation, accepted only when it names a real sibling in the same group. Covers 2 of 9 aliases on DEV; the vaguer `"Points to the latest Claude model"` is correctly ignored rather than producing a dangling pointer.
3. Name-shape match: the member whose identity tokens equal the upstream model id's. A token **set**, because word order disagrees — our `claude-4-6-sonnet` vs upstream `bedrock/us.anthropic.claude-sonnet-4-6`.

A group with zero or multiple winners reports `null` everywhere. It never guesses.

Verified against real `litellm_params.model` values on DEV and all 6 PROD regions: **17/17 groups resolve to exactly one canonical, zero ambiguous.** On DEV this produces:

```
chat, chat_with_complex_json, chat_with_image_vision,
claude-3-5-sonnet, claude-4-5-sonnet  -> claude-4-6-sonnet
claude-3-5-haiku                      -> claude-4-5-haiku
embeddings                            -> titan-embed-text-v2:0
text_to_image                         -> gemini-2.5-flash-image
```

Note `claude-4-5-sonnet` — it was silently repointed at Sonnet 4.6 and nothing in the API said so. Same on PROD `amazeeai-uk103`, where `claude-3-sonnet` and `claude-3-7-sonnet` both serve `claude-sonnet-4-6`.

## `eol_date`

Read from the upstream Bedrock catalog that `_fetch_bedrock_catalog` already fetches and caches for `/models/missing/aws` — the URL in `BEDROCK_MODELS_URL` is exactly the feed suggested on the issue. Both upstream date fields are read: `modelLifecycle.endOfLifeTime` (ISO) preferred, `modelCard.modelEolDate` (`"September 10, 2026"`) as fallback. They agree on all 14 overlaps and neither covers the other's models; the union is 22 entries.

Operator-authored `(EOL: ...)` annotations win over the catalog, so we can retire a model earlier than AWS does without that decision being overwritten. `eol_source` records which applied.

### Why no cron job

Reasoned in a comment above the EOL helpers in `app/api/public.py`, as requested:

- The catalog fetch and its cache already exist. Reading EOL dates out of it costs one extra ~190 KB GET per hour per pod, only on a cache miss.
- `/public/models` is itself cached and served `Cache-Control: public, max-age=3600`, so EOL dates refresh on the same schedule as everything else. A cron would add a second, different refresh schedule for no gain.
- A cron would need a table, a migration and a `.lagoon.yml` entry, and would put stale rows between us and upstream. EOL dates change a handful of times a year.

The weekly Slack alert stays a cron in GitHub Actions — it reads this endpoint, so it now gets `eol_date` instead of parsing prose.

A dead or non-JSON catalog degrades to annotations only and logs a warning. `_fetch_bedrock_catalog` raises `HTTPException(502)`, which is caught here — `/public/models` must not fail because an upstream mirror is down. `aliased_to` is unaffected either way, since it needs no external data.

### Expected effect on PROD

- The 6 `amazeeai-ch103` models keep `2026-09-10` with `eol_source: manual`.
- `amazeeai-uk103 / claude-3-haiku` gains `2026-09-10` with `eol_source: bedrock`. It has the same EOL as the ch103 models but no annotation, so **the weekly Slack alert misses it today.**
- 13 models across 5 regions gain a non-null `aliased_to`.

Verified by running the new helpers against the live DEV `/model/info` payload and the live catalog.

## `scripts/check_eol_models.py`

Reads `eol_date` first, keeps its `(EOL: ...)` regex as a fallback for older backends. The workflow is unchanged.

The regex is duplicated rather than shared: the script is deliberately stdlib-only so the GitHub Action needs no `pip install`, and importing from `app` pulls in pydantic via `app/core/__init__.py`. A test pins the two copies together.

## Tests

`make backend-test` — 1159 passed, 2 skipped. New coverage: aliased model, canonical model, ambiguous group, word-order/version-suffix matching, manual EOL, catalog EOL, no EOL, manual overriding catalog, unreachable catalog still returning 200, both upstream date fields, `eol_date` preferred over `metadata_raw`, fallback when absent or null, and the two regex copies agreeing.

`/public/models` tests previously made no outbound HTTP call. An autouse fixture in the two modules that call it blanks `BEDROCK_MODELS_URL` to keep them offline; the EOL tests opt back in explicitly. Scoped per-module on purpose — setting it globally in `conftest.py` broke `/models/missing/aws`, which echoes that setting back as `models_url`.

## MOAD

Not required and not included. MOAD decodes this response with Effect Schema `S.Struct` and sets no `onExcessProperty`, so the default is to ignore unknown keys — the new fields pass validation and are dropped. Surfacing them in the dashboard is a separate follow-up, and it has to come after this is on PROD anyway because `pnpm api:codegen` fetches the live OpenAPI spec.

Refs amazeeio/moad#638

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds alias and end-of-life metadata to the public model catalog.
- Resolves canonical models from shared LiteLLM deployments, explicit configuration, annotations, and model-name identity.
- Derives Bedrock EOL dates once per cached catalog fetch while allowing manual annotations to override them.
- Updates the EOL alert script to prefer structured dates while retaining compatibility with older backends.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/public.py | Adds alias resolution and cached Bedrock EOL enrichment; the prior derived-index synchronization concern is resolved by building the index within the catalog fetch lock. |
| app/schemas/models.py | Adds optional aliased_to, eol_date, and eol_source fields to the public model response schema. |
| scripts/check_eol_models.py | Prefers the structured eol_date field and retains metadata annotation parsing for older backend responses. |
| tests/test_public_models.py | Covers alias resolution, EOL precedence and degradation, and single derivation of the EOL index during concurrent access. |

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(public-models): derive EOL inde..."](https://github.com/amazeeio/amazee.ai/commit/758c5b502ee0c19413df4b1f69604cf01160f264) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48242393)</sub>

**Context used:**

- Knowledge Base — [Public Models API, Regions, and Pricing Tables](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/regions-public-pricing.md)

<!-- /greptile_comment -->