### PR TITLE
feat(public-models): resolve aliased_to from LiteLLM model_group_alias

### DIFF
--- a/app/api/public.py
+++ b/app/api/public.py
@@ -682,32 +682,37 @@ async def _resolve_optional_user(request: Request, db: Session) -> DBUser | None
         return None
 
 
+async def _fetch_router_aliases(service: LiteLLMService) -> dict[str, str]:
+    """Fetch the region's real model_group_alias map, or {} when unavailable.
+
+    Aliases are enrichment — a broken /router/settings must not mark the whole
+    region unavailable, so every failure degrades to an empty map.
+    """
+    try:
+        return _extract_model_group_alias(await service.get_router_settings())
+    except Exception:
+        return {}
+
+
 async def _fetch_region_model_group(
     service: LiteLLMService, region_name: str
 ) -> PublicRegionModels:
     async with _REGION_SEMAPHORE:
         try:
-            model_info = await asyncio.wait_for(
-                service.get_model_info(), timeout=_REGION_TIMEOUT
-            )
-            profit_margin = await asyncio.wait_for(
-                _resolve_profit_margin(service, region_name),
+            # The three LiteLLM calls are independent; fetch them concurrently
+            # under one deadline so a slow region costs one timeout, not three.
+            model_info, profit_margin, router_aliases = await asyncio.wait_for(
+                asyncio.gather(
+                    service.get_model_info(),
+                    _resolve_profit_margin(service, region_name),
+                    _fetch_router_aliases(service),
+                ),
                 timeout=_REGION_TIMEOUT,
             )
             items = model_info.get("data", [])
             # Both maps need the whole region: aliased_to compares models against
             # each other, and the EOL index is shared by every model here.
-            # Real router aliases win over the derived fake-alias map; the
-            # fetch degrades to {} because aliases are enrichment — a broken
-            # /router/settings must not mark the whole region unavailable.
-            try:
-                router_aliases = _extract_model_group_alias(
-                    await asyncio.wait_for(
-                        service.get_router_settings(), timeout=_REGION_TIMEOUT
-                    )
-                )
-            except Exception:
-                router_aliases = {}
+            # Real router aliases win over the derived fake-alias map.
             alias_map = {**_build_alias_map(items), **router_aliases}
             eol_index = await _get_bedrock_eol_index()
             return PublicRegionModels(

--- a/app/api/public.py
+++ b/app/api/public.py
@@ -337,12 +337,22 @@ async def _resolve_profit_margin(service: LiteLLMService, region_name: str) -> f
 # aliased_to resolution
 # ---------------------------------------------------------------------------
 #
-# LiteLLM has no alias concept we can read: an alias is configured as a second
-# model entry that happens to share the same ``litellm_params.model`` as the
-# model it points at.  ``/model/info``, ``/model_group/info`` and ``/v1/models``
-# expose no field linking one entry to another (``base_model`` and
-# ``team_public_model_name`` are null across every entry on DEV and PROD), so
-# the link has to be derived from data LiteLLM does give us.
+# Aliases come from two sources, merged in ``_fetch_region_model_group`` with
+# the first winning on conflict:
+#
+# 1. LiteLLM's real alias mechanism, ``router_settings.model_group_alias``
+#    (read via ``/router/settings``).  The model endpoints hide it: an alias is
+#    expanded into a ``/model/info`` entry identical to its target except for
+#    ``model_name``, so the mapping itself is only available from the router
+#    settings.
+# 2. Derived from the model list, for regions still running "fake aliases":
+#    an alias configured as a second model entry that happens to share the
+#    same ``litellm_params.model`` as the model it points at.  ``/model/info``,
+#    ``/model_group/info`` and ``/v1/models`` expose no field linking one
+#    entry to another (``base_model`` and ``team_public_model_name`` are null
+#    across every entry on DEV and PROD), so the link has to be derived from
+#    data LiteLLM does give us.  Delete this path once every region has
+#    migrated to real model_group_alias entries.
 #
 # Sharing a ``litellm_params.model`` is a fact, not a guess: those entries are
 # the same deployment.  Picking *which* member is the canonical one is the part
@@ -447,6 +457,37 @@ def _resolve_canonical_model(
     upstream_tokens = _model_identity_tokens(upstream_model)
     matches = [m for m in members if _model_identity_tokens(m) == upstream_tokens]
     return matches[0] if len(matches) == 1 else None
+
+
+def _extract_model_group_alias(router_settings: Any) -> dict[str, str]:
+    """Return LiteLLM's configured ``model_group_alias`` map from /router/settings.
+
+    Values may be plain target names or ``{"model": ..., "hidden": ...}`` items
+    (LiteLLM's RouterModelGroupAliasItem); both normalize to ``alias -> target``.
+    """
+    if not isinstance(router_settings, dict):
+        return {}
+    fields = router_settings.get("fields")
+    if not isinstance(fields, list):
+        return {}
+    raw = next(
+        (
+            field.get("field_value")
+            for field in fields
+            if isinstance(field, dict)
+            and field.get("field_name") == "model_group_alias"
+        ),
+        None,
+    )
+    if not isinstance(raw, dict):
+        return {}
+    aliases: dict[str, str] = {}
+    for alias, target in raw.items():
+        if isinstance(target, dict):
+            target = target.get("model")
+        if isinstance(alias, str) and isinstance(target, str) and alias != target:
+            aliases[alias] = target
+    return aliases
 
 
 def _build_alias_map(items: list[dict[str, Any]]) -> dict[str, str]:
@@ -656,7 +697,18 @@ async def _fetch_region_model_group(
             items = model_info.get("data", [])
             # Both maps need the whole region: aliased_to compares models against
             # each other, and the EOL index is shared by every model here.
-            alias_map = _build_alias_map(items)
+            # Real router aliases win over the derived fake-alias map; the
+            # fetch degrades to {} because aliases are enrichment — a broken
+            # /router/settings must not mark the whole region unavailable.
+            try:
+                router_aliases = _extract_model_group_alias(
+                    await asyncio.wait_for(
+                        service.get_router_settings(), timeout=_REGION_TIMEOUT
+                    )
+                )
+            except Exception:
+                router_aliases = {}
+            alias_map = {**_build_alias_map(items), **router_aliases}
             eol_index = await _get_bedrock_eol_index()
             return PublicRegionModels(
                 region=region_name,

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -679,6 +679,29 @@ class LiteLLMService:
                 detail=f"Failed to get LiteLLM model info: {error_msg}",
             )
 
+    async def get_router_settings(self) -> dict:
+        """Get LiteLLM router settings (includes model_group_alias)."""
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"{self.api_url}/router/settings",
+                    headers={"Authorization": f"Bearer {self.master_key}"},
+                )
+                response.raise_for_status()
+                return response.json()
+        except httpx.HTTPStatusError as e:
+            error_msg = str(e)
+            if hasattr(e, "response") and e.response is not None:
+                try:
+                    error_details = e.response.json()
+                    error_msg = f"Status {e.response.status_code}: {error_details}"
+                except ValueError:
+                    error_msg = f"Status {e.response.status_code}: {e.response.text}"
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to get LiteLLM router settings: {error_msg}",
+            )
+
     async def get_cost_margin_config(self) -> dict:
         """Get LiteLLM provider margin configuration."""
         try:

--- a/tests/test_public_models.py
+++ b/tests/test_public_models.py
@@ -1026,6 +1026,108 @@ def test_public_models_aliased_to_is_null_when_canonical_is_ambiguous(client, db
     assert models["house-chat-fast"]["aliased_to"] is None
 
 
+def _router_settings_response(alias_map):
+    return {
+        "fields": [
+            {"field_name": "routing_strategy", "field_value": "simple-shuffle"},
+            {"field_name": "model_group_alias", "field_value": alias_map},
+        ]
+    }
+
+
+def test_public_models_resolves_aliases_from_router_settings(client, db):
+    """A real model_group_alias resolves groups the derived map cannot."""
+    _clear_public_models_cache()
+    _make_public_region(db, "router-alias-region")
+
+    upstream = {"model": "bedrock/us.anthropic.claude-sonnet-4-6"}
+    with patch("app.api.public.LiteLLMService") as mock_cls:
+        mock_cls.return_value.get_model_info = AsyncMock(
+            return_value={
+                "data": [
+                    {
+                        "model_name": "house-chat",
+                        "litellm_params": upstream,
+                        "model_info": {"mode": "chat"},
+                    },
+                    {
+                        "model_name": "house-chat-fast",
+                        "litellm_params": upstream,
+                        "model_info": {"mode": "chat"},
+                    },
+                ]
+            }
+        )
+        mock_cls.return_value.get_router_settings = AsyncMock(
+            return_value=_router_settings_response({"house-chat": "house-chat-fast"})
+        )
+        response = client.get("/public/models")
+
+    assert response.status_code == 200
+    models = _models_by_id(response)
+    assert models["house-chat"]["aliased_to"] == "house-chat-fast"
+    assert models["house-chat-fast"]["aliased_to"] is None
+
+
+def test_public_models_router_alias_wins_over_derived_map(client, db):
+    """model_group_alias overrides what the fake-alias heuristics derived."""
+    _clear_public_models_cache()
+    _make_public_region(db, "router-priority-region")
+
+    with patch("app.api.public.LiteLLMService") as mock_cls:
+        mock_cls.return_value.get_model_info = AsyncMock(
+            return_value=_alias_group_response()
+        )
+        mock_cls.return_value.get_router_settings = AsyncMock(
+            return_value=_router_settings_response({"chat": "gemini-2.5-flash-image"})
+        )
+        response = client.get("/public/models")
+
+    assert response.status_code == 200
+    models = _models_by_id(response)
+    # Router settings win for chat; the rest keep the derived resolution.
+    assert models["chat"]["aliased_to"] == "gemini-2.5-flash-image"
+    assert models["claude-3-5-sonnet"]["aliased_to"] == "claude-4-6-sonnet"
+
+
+def test_public_models_falls_back_when_router_settings_unavailable(client, db):
+    """A broken /router/settings degrades to the derived map, not an error."""
+    _clear_public_models_cache()
+    _make_public_region(db, "router-broken-region")
+
+    with patch("app.api.public.LiteLLMService") as mock_cls:
+        mock_cls.return_value.get_model_info = AsyncMock(
+            return_value=_alias_group_response()
+        )
+        mock_cls.return_value.get_router_settings = AsyncMock(
+            side_effect=Exception("boom")
+        )
+        response = client.get("/public/models")
+
+    assert response.status_code == 200
+    assert response.json()[0]["status"] == "ga"
+    models = _models_by_id(response)
+    assert models["chat"]["aliased_to"] == "claude-4-6-sonnet"
+
+
+def test_extract_model_group_alias_normalizes_shapes():
+    """Direct unit check: string targets, item dicts, junk, self-aliases."""
+    settings = _router_settings_response(
+        {
+            "chat": "claude-4-7-opus",
+            "vision": {"model": "gemini-2.5-flash-image", "hidden": True},
+            "self": "self",
+            "junk": 42,
+        }
+    )
+    assert public_api._extract_model_group_alias(settings) == {
+        "chat": "claude-4-7-opus",
+        "vision": "gemini-2.5-flash-image",
+    }
+    assert public_api._extract_model_group_alias(None) == {}
+    assert public_api._extract_model_group_alias({"fields": "nope"}) == {}
+
+
 def test_build_alias_map_ignores_word_order_and_version_suffixes():
     """Direct unit check of the name-shape fallback."""
     alias_map = public_api._build_alias_map(


### PR DESCRIPTION
Follow-up to #645.

## What

`aliased_to` is now resolved from LiteLLM's real alias mechanism first: `router_settings.model_group_alias`, read via `GET /router/settings`. The heuristic map derived from the model list (metadata "Points to ..." annotations + shared `litellm_params.model` + name-shape matching) remains as a fallback and is overridden by the router map on conflict.

## Why

Verified against the test instance (litellm-kessel) with `chat` configured as a real `model_group_alias` → `claude-4-7-opus`:

- `/models`, `/model/info`, `/v2/model/info` and `/model_group/info` all expand the alias into an entry **byte-identical** to its target except for `model_name` — no alias marker anywhere.
- The only place the mapping is exposed is `/router/settings` → field `model_group_alias` → `{"chat": "claude-4-7-opus"}`.

Prod regions still run "fake aliases" (aliases added as real model entries pointing at the Bedrock model directly), which never appear in `model_group_alias` — hence the merge: router map wins where present, derived map covers the rest. Once every region is migrated to real aliases, `_build_alias_map` and its helpers can be deleted.

## Notes

- `/router/settings` failures degrade to the derived map (aliases are enrichment; a broken settings endpoint must not mark the region unavailable).
- Handles both `model_group_alias` value shapes: plain string targets and `{"model": ..., "hidden": ...}` items.

## Tests

`make backend-test-regex regex="test_public_models or test_cache_headers"` — 51 passed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR enriches public model records with LiteLLM router aliases while preserving heuristic alias detection as a fallback.
- Adds parsing for string and structured `model_group_alias` values from `/router/settings`.
- Merges router aliases over aliases inferred from model metadata.
- Adds a LiteLLM service method for retrieving router settings.
- Tests router precedence, response-shape normalization, and graceful fallback.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking concern that slow LiteLLM regions can extend uncached catalog refreshes substantially.

Router alias parsing and fallback behavior are well covered, but the new sequential request receives its own full timeout and therefore lengthens the slow-region critical path.

**Files Needing Attention:** app/api/public.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/public.py | Adds router-alias extraction and precedence correctly, but places the new request sequentially behind other independently timed region requests. |
| app/services/litellm.py | Adds a conventional authenticated LiteLLM wrapper for `/router/settings`, with failures contained by its public-catalog caller. |
| tests/test_public_models.py | Covers router alias extraction, precedence over inferred aliases, structured values, and fallback on endpoint failure. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as Public Models API
    participant LiteLLM
    Client->>API: GET /public/models
    API->>LiteLLM: GET /model/info
    LiteLLM-->>API: Region model entries
    API->>LiteLLM: GET cost-margin config
    LiteLLM-->>API: Margin or error
    API->>LiteLLM: GET /router/settings
    alt Router settings available
        LiteLLM-->>API: model_group_alias
        API->>API: Merge derived aliases with router aliases
    else Router settings unavailable
        LiteLLM-->>API: Error or timeout
        API->>API: Retain derived alias map
    end
    API-->>Client: Public models with aliased_to
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(public-models): resolve aliased\_to ..."](https://github.com/amazeeio/amazee.ai/commit/5c62c369d3f765395cecbe1f15d884c7f3b0bdd5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48287943)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Public Models API, Regions, and Pricing Tables](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/regions-public-pricing.md)
- Knowledge Base — [Private AI Keys and LiteLLM Integration](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/private-ai-keys-litellm.md)

<!-- /greptile_comment -->