### PR TITLE
feat(budget-alerts): notify MOAD when spend crosses budget thresholds (AI-448)

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -27,6 +27,13 @@ environments:
         schedule: "30 2 * * *"
         command: python scripts/trigger_prune_signup_events_job.py
         service: backend
+      # Frequent on purpose: a 90% warning is worthless if it lands an hour after
+      # the key stopped working. The sweep is 2 LiteLLM calls per region and
+      # scales with active entities, not key count, so 5 minutes is affordable.
+      - name: monitor-budget-thresholds
+        schedule: "*/5 * * * *"
+        command: python scripts/trigger_budget_alerts_job.py
+        service: backend
     routes:
       - backend:
         - api.amazee.ai:
@@ -65,6 +72,10 @@ environments:
       - name: prune-signup-events
         schedule: "30 2 * * *"
         command: python scripts/trigger_prune_signup_events_job.py
+        service: backend
+      - name: monitor-budget-thresholds
+        schedule: "*/5 * * * *"
+        command: python scripts/trigger_budget_alerts_job.py
         service: backend
 
 tasks:

--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from datetime import UTC, date, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -22,6 +21,10 @@ from app.core.security import (
     get_current_user_from_auth,
     get_private_ai_access,
     get_role_min_team_admin,
+)
+from app.core.spend_period_service import (
+    compute_period_start,
+    resolve_team_period_window,
 )
 from app.db.database import get_db
 from app.db.models import (
@@ -65,51 +68,10 @@ logger = logging.getLogger(__name__)
 MONTHLY_BUDGET_DURATION = "1mo"
 
 
-def _compute_period_start(
-    budget_reset_at: datetime | None, budget_duration: str | None
-) -> datetime | None:
-    """
-    Derive the start of the current budget period from LiteLLM's
-    ``budget_reset_at`` (end-of-period) and ``budget_duration``.
-
-    LiteLLM sets ``budget_reset_at`` to the moment the budget will auto-reset.
-    For ``"Nd"`` durations the reset is rolling N days after the last update;
-    for ``"1mo"`` / ``"30d"`` it snaps to the 1st of the next calendar month.
-
-    We parse the duration string and subtract from ``budget_reset_at`` to get
-    a best-effort calendar ``period_start``.  Returns ``None`` when either
-    input is missing or the duration cannot be parsed.
-    """
-    if budget_reset_at is None or not budget_duration:
-        return None
-
-    # Handle "1mo" / "30d" — both snap to 1st of next calendar month
-    # so the period start is always the 1st of the current month.
-    if budget_duration in ("1mo", "30d"):
-        # budget_reset_at is midnight on the 1st of next month.
-        # If reset is on 1st, the period that just ended started last month.
-        if budget_reset_at.day == 1:
-            if budget_reset_at.month == 1:
-                return budget_reset_at.replace(
-                    year=budget_reset_at.year - 1, month=12, day=1
-                )
-            return budget_reset_at.replace(month=budget_reset_at.month - 1, day=1)
-        return budget_reset_at.replace(day=1)
-
-    match = re.fullmatch(r"(\d+)([dhms])", budget_duration)
-    if not match:
-        return None
-    value = int(match.group(1))
-    unit = match.group(2)
-    if unit == "d":
-        return budget_reset_at - timedelta(days=value)
-    if unit == "h":
-        return budget_reset_at - timedelta(hours=value)
-    if unit == "m":
-        return budget_reset_at - timedelta(minutes=value)
-    if unit == "s":
-        return budget_reset_at - timedelta(seconds=value)
-    return None
+# Period-window maths lives in spend_period_service so the budget-threshold
+# alert engine derives the same window as this API. Kept under the original
+# private name because callers (and tests) already import it from here.
+_compute_period_start = compute_period_start
 
 
 @router.get(
@@ -973,64 +935,15 @@ async def get_team_spend(
     # For subscription-managed POOL teams, expose cycle window semantics from
     # Amazee DB ledger truth instead of LiteLLM counters.
     if team.budget_type == BudgetType.POOL:
-        now = datetime.now(UTC)
-        active_subscription = (
-            db.query(DBPeriodicBudgetLedgerEntry)
-            .filter(
-                DBPeriodicBudgetLedgerEntry.team_id == team_id,
-                DBPeriodicBudgetLedgerEntry.region_id == region_id,
-                DBPeriodicBudgetLedgerEntry.entry_type == "subscription",
-                DBPeriodicBudgetLedgerEntry.is_active.is_(True),
-                DBPeriodicBudgetLedgerEntry.effective_period_start.isnot(None),
-                DBPeriodicBudgetLedgerEntry.effective_period_end.isnot(None),
-                DBPeriodicBudgetLedgerEntry.effective_period_end > now,
-            )
-            .order_by(
-                DBPeriodicBudgetLedgerEntry.effective_period_end.desc(),
-                DBPeriodicBudgetLedgerEntry.id.desc(),
-            )
-            .first()
-        )
+        pool_window = resolve_team_period_window(db, team, region_id)
+        team_budget_duration = pool_window.budget_duration
+        team_budget_reset_at = pool_window.period_end
+        team_period_start = pool_window.period_start
+        active_subscription = pool_window.active_subscription
         if active_subscription is not None:
-            team_budget_duration = "31d"
-            team_budget_reset_at = active_subscription.effective_period_end
-            team_period_start = active_subscription.effective_period_start
             # For POOL teams, expose only current-cycle subscription amount.
             sub_cycle_budget_cents = int(active_subscription.amount_cents or 0)
             periodic_budget_view = round(sub_cycle_budget_cents / 100.0, 4)
-        else:
-            active_topup = (
-                db.query(DBPeriodicBudgetLedgerEntry)
-                .filter(
-                    DBPeriodicBudgetLedgerEntry.team_id == team_id,
-                    DBPeriodicBudgetLedgerEntry.region_id == region_id,
-                    DBPeriodicBudgetLedgerEntry.entry_type.in_(
-                        ["topup", "topup_rollover"]
-                    ),
-                    DBPeriodicBudgetLedgerEntry.is_active.is_(True),
-                    (
-                        DBPeriodicBudgetLedgerEntry.expires_at.is_(None)
-                        | (DBPeriodicBudgetLedgerEntry.expires_at > now)
-                    ),
-                )
-                .order_by(
-                    DBPeriodicBudgetLedgerEntry.purchased_at.desc(),
-                    DBPeriodicBudgetLedgerEntry.id.desc(),
-                )
-                .first()
-            )
-            pool_duration = f"{settings.POOL_PURCHASE_EXPIRY_DAYS}d"
-            team_budget_duration = pool_duration
-            if active_topup is not None and active_topup.purchased_at is not None:
-                anchor = active_topup.purchased_at
-            else:
-                anchor = team.created_at or now
-            if anchor.tzinfo is None:
-                anchor = anchor.replace(tzinfo=UTC)
-            team_period_start = anchor
-            team_budget_reset_at = anchor + timedelta(
-                days=settings.POOL_PURCHASE_EXPIRY_DAYS
-            )
 
     if team.budget_type != BudgetType.POOL:
         periodic_budget_view = None

--- a/app/core/budget_alert_service.py
+++ b/app/core/budget_alert_service.py
@@ -5,10 +5,10 @@ its budget, so a downstream consumer (MOAD) can warn the customer *before* their
 keys stop working.
 
 Scope: **POOL teams**, and keys carrying both a team and a region — the shape MOAD
-provisions and can actually notify. PERIODIC is excluded because on PROD every
-PERIODIC key (12,098 of them) belongs to the single anonymous Drupal trial team,
-which has no MOAD workspace and no addressable owner. Note that the *period-window
-helper* still handles PERIODIC, since the spend API shares it.
+provisions and can actually notify. PERIODIC is excluded because those keys belong
+to the anonymous Drupal trial team, which has no MOAD workspace and no addressable
+owner. Note that the *period-window helper* still handles PERIODIC, since the spend
+API shares it.
 
 Why amazee.ai computes the percentage instead of LiteLLM
 -------------------------------------------------------
@@ -33,19 +33,19 @@ Two stages, both bounded by *activity* rather than by key count:
 
 1. **Discovery and spend** — an unfiltered ``/team/daily/activity`` sweep over the
    window that ``region_sweep_start`` derives from the ledger. LiteLLM writes no
-   daily rows for idle entities, so on PROD region 5 an 11,859-key region reported
-   42 active teams and 351 active keys. Measured cost is 3 pages / ~1 s at the full
-   370-day span (page 1 alone at 62 days was 1.08 s), and usually less, because the
-   window only reaches back as far as the oldest unexpired purchase.
-   ``_fetch_daily_activity`` follows ``has_more``, and pages partition the data
-   rather than repeating it, so the per-day totals add up cleanly.
+   daily rows for idle entities, so the working set is the few percent of keys that
+   saw traffic rather than every key in the region. The request costs a handful of
+   pages even at the full lookback, and usually fewer, because the window only
+   reaches back as far as the oldest unexpired purchase. ``_fetch_daily_activity``
+   follows ``has_more``, and pages partition the data rather than repeating it, so
+   the per-day totals add up cleanly.
 2. **Denominators for keys** — one scoped ``/key/list?team_id=`` per candidate team,
    used for ``max_budget`` and to spot keys being expired. Its ``spend`` figures are
    deliberately ignored; spend comes from the daily rows instead.
 
 So a tick costs ``pages + active_teams`` calls per region, independent of how many
 idle keys exist, plus one scoped back-fill for any team whose budget window opens
-before the wide request (none on PROD today). Sweeping every key instead — the
+before the wide request. Sweeping every key instead — the
 shape of the existing hourly reconciler, ~40 min at 13.9k keys — is what does not
 survive 100k.
 """
@@ -384,6 +384,53 @@ async def _exact_team_key_state(
 # --------------------------------------------------------------------------- #
 
 
+def _unsettled_consumed_dollars(db: Session, team: DBTeam, region_id: int) -> float:
+    """``consumed_cents`` sitting on entries that are *still valid*, in dollars.
+
+    Normally zero, and it has to be added back when it is not. Settlement usually
+    re-bases rather than annotates: ``materialize_topup_rollovers`` deactivates a
+    partly-consumed entry and writes a fresh ``topup_rollover`` holding the
+    remainder with ``consumed_cents = 0``, deactivating the original. So among valid
+    entries the column is 0, face value equals remaining, and the window opening at
+    the oldest valid purchase lines up with it.
+
+    Cancellation is the exception. ``app/api/subscription.py`` runs
+    ``allocate_period_spend_fifo`` but never calls ``materialize_topup_rollovers``,
+    so it increments ``consumed_cents`` on entries that stay valid. The budget would
+    then drop by spend the numerator still counts — the same money subtracted once
+    and added once — and the percentage would read high. Adding it back keeps the
+    two sides describing the same money whichever way the ledger was settled.
+
+    Normally a no-op, and it logs the first time it is not.
+    """
+    consumed_cents = (
+        db.query(func.coalesce(func.sum(DBPeriodicBudgetLedgerEntry.consumed_cents), 0))
+        .filter(
+            DBPeriodicBudgetLedgerEntry.team_id == team.id,
+            DBPeriodicBudgetLedgerEntry.region_id == region_id,
+            DBPeriodicBudgetLedgerEntry.is_active.is_(True),
+            DBPeriodicBudgetLedgerEntry.consumed_cents > 0,
+            (
+                DBPeriodicBudgetLedgerEntry.expires_at.is_(None)
+                | (DBPeriodicBudgetLedgerEntry.expires_at > func.now())
+            ),
+        )
+        .scalar()
+    ) or 0
+    if not consumed_cents:
+        return 0.0
+    dollars = round(int(consumed_cents) / 100.0, 4)
+    logger.info(
+        "Team %s region %s has $%.2f consumed on still-valid ledger entries "
+        "(unsettled, likely a cancellation); added back so the budget matches the "
+        "spend window",
+        team.id,
+        region_id,
+        dollars,
+    )
+    return dollars
+
+
 def _team_budget(db: Session, team: DBTeam, region_id: int) -> float | None:
     """Budget available to a team in a region, from our ledger.
 
@@ -399,12 +446,12 @@ def _team_budget(db: Session, team: DBTeam, region_id: int) -> float | None:
         # This deliberately does *not* apply to POOL teams. A POOL team's budget is
         # the money it bought, so no valid ledger entry means nothing to be a
         # percentage of, and the BUDGET limit is a provisioning allowance rather
-        # than available credit. On PROD 673 POOL teams sit in exactly that state
-        # (662 never purchased at all) carrying a mostly-$27 limit; measuring
-        # spend against it would invent a percentage, and with no purchase to anchor
-        # on there is no cycle start either, so the window would fall back to team
-        # creation. Such a team simply gets no team event; its keys are still
-        # evaluated if they carry their own cap.
+        # than available credit. Many POOL teams sit in exactly that state, never
+        # having purchased at all, and measuring spend against a provisioning
+        # allowance would invent a percentage. With no purchase to anchor on there is
+        # no cycle start either, so the window would fall back to team creation. Such
+        # a team simply gets no team event; its keys are still evaluated if they
+        # carry their own cap.
         limit_value = (
             db.query(DBLimitedResource.max_value)
             .filter(
@@ -415,6 +462,8 @@ def _team_budget(db: Session, team: DBTeam, region_id: int) -> float | None:
             .scalar()
         )
         available = float(limit_value) if limit_value else 0.0
+
+    available += _unsettled_consumed_dollars(db, team, region_id)
 
     cap = (
         db.query(DBSpendCap.max_budget)
@@ -437,9 +486,9 @@ def _litellm_cycle_anchor(
     """Anchor for a budget LiteLLM owns, derived from its own reset date.
 
     ``budget_reset_at`` is the *end* of the cycle it is currently counting, so the
-    anchor is that minus the duration. It can be stale — PROD has keys whose reset
-    date is a month in the past — which is why the caller rolls it forward instead
-    of using it directly.
+    anchor is that minus the duration. It can be stale — a key's reset date may sit
+    in the past — which is why the caller rolls it forward instead of using it
+    directly.
     """
     if key_state is None or not budget_duration:
         return None
@@ -467,10 +516,9 @@ def _cap_cycle_anchor(cap_created_at: datetime | None, team: DBTeam) -> datetime
     amount-only change deliberately passes no duration, so the original anchor
     survives and ``created_at`` stays the right one.
 
-    Verified against PROD: for a team whose cap was set 44 days after the team
-    itself, ``created_at`` reproduces LiteLLM's ``budget_reset_at`` to the
-    time-of-day, while team creation was 18.7 days out. 29 of the 130 rolling
-    ``31d`` caps were set more than a day after their team, by up to 420 days.
+    Team creation is the wrong anchor whenever a cap was added later than the team,
+    which is common: the two dates can be hundreds of days apart, and the cap's own
+    timestamp is the one that reproduces LiteLLM's ``budget_reset_at``.
 
     ``team.created_at`` is only a fallback for a cap row with no timestamp.
     """
@@ -486,9 +534,9 @@ def _member_budget(
     """Per-member budget and the cycle it applies to.
 
     The team-member cap wins, else the user's BUDGET limit. The cap carries a
-    duration (every one on PROD is ``1mo``) because it is a per-cycle allowance;
-    the BUDGET limit is absolute and returns ``None`` for the duration, so the
-    caller measures it over the team's cycle instead.
+    duration because it is a per-cycle allowance; the BUDGET limit is absolute and
+    returns ``None`` for the duration, so the caller measures it over the team's
+    cycle instead.
     """
     cap = (
         db.query(
@@ -615,10 +663,10 @@ def denominator_change_candidates(
     """Teams whose *budget* just fell, regardless of whether they spent anything.
 
     Traffic-driven discovery rests on "percent only rises when spend rises", which
-    is false: the denominator moves too. On PROD every active ledger entry carries
-    an ``expires_at`` (321 of them due to expire), so a lapsing top-up or
-    subscription drops a team's remaining budget and can push it past 90 % while
-    it sits completely idle. Such a team produces no daily-activity rows, so
+    is false: the denominator moves too. Active ledger entries carry an
+    ``expires_at``, so a lapsing top-up or subscription drops a team's remaining
+    budget and can push it past 90 % while it sits completely idle. Such a team
+    produces no daily-activity rows, so
     without this it would never be looked at and the warning would never fire —
     the exact scenario the feature exists to prevent.
 
@@ -728,10 +776,10 @@ async def evaluate_region(
         logger.info("No active teams in region %s this sweep", region.name)
         return result
 
-    # POOL only. These are the teams MOAD provisions and can actually notify —
-    # every PERIODIC key on PROD (12,098 of them) belongs to the single anonymous
-    # Drupal trial team, which has no MOAD workspace and no addressable owner, so
-    # a threshold webhook for it would have nowhere to go.
+    # POOL only. These are the teams MOAD provisions and can actually notify. The
+    # PERIODIC keys belong to the anonymous Drupal trial team, which has no MOAD
+    # workspace and no addressable owner, so a threshold webhook for it would have
+    # nowhere to go.
     teams = (
         db.query(DBTeam)
         .filter(
@@ -755,7 +803,7 @@ async def evaluate_region(
         # Only keys carrying both a team and a region — the shape MOAD provisions.
         # A key with just an owner and no team has no team budget to be a share of,
         # and no workspace to notify, so it is out of scope by design rather than
-        # by omission. On PROD that is 418 of 13,930 keys.
+        # by omission.
         db_keys = (
             db.query(DBPrivateAIKey)
             .filter(
@@ -773,8 +821,8 @@ async def evaluate_region(
         elif not (team_budget or cap_map):
             # Nothing to measure, so nothing to fetch. A POOL team with no valid
             # ledger entry anchors on team.created_at, which is routinely older than
-            # the window, and there are 673 of those on PROD — spending a call on
-            # each would cost a call per team per tick for no possible event.
+            # the window, and there are many such teams — spending a call on each
+            # would cost a call per team per tick for no possible event.
             continue
         else:
             # The wide sweep starts after this team's window opens, so its rows hold
@@ -786,10 +834,9 @@ async def evaluate_region(
             # So the team is back-filled with a scoped call over its own window
             # instead. /team/daily/activity takes a team_ids filter, and one team's
             # rows are bounded by the number of days, so this stays cheap. It costs
-            # one extra call only for teams the wide sweep cannot cover — none on
-            # PROD today, where no anchor is older than 69 days against a 370-day
-            # floor. Skipping such a team instead would hide every crossing it has
-            # until the floor was raised by hand.
+            # one extra call only for teams the wide sweep cannot cover, which the
+            # default lookback already spans. Skipping such a team instead would hide
+            # every crossing it has until the floor was raised by hand.
             logger.info(
                 "Team %s window opens %s, before the %s sweep start; "
                 "back-filling its spend with a scoped activity call",
@@ -827,7 +874,7 @@ async def evaluate_region(
         # team event alone cannot. Withheld when the team has a single in-scope key,
         # because then the key percentage is arithmetically identical to the team's
         # and the alert would just be the team event repeated. That is the common
-        # shape: 481 of 739 POOL teams on PROD hold exactly one key.
+        # shape — most POOL teams hold exactly one key.
         pool_fallback_budget = team_budget if len(db_keys) > 1 else None
 
         member_spend: dict[int, float] = {}
@@ -862,7 +909,7 @@ async def evaluate_region(
             # Denominator precedence: our own cap, then whatever LiteLLM enforces,
             # then the team pool. Applies equally to service keys (no owner) and
             # user keys — a key is in scope for having a team, not for having an
-            # owner. On PROD: 405 service and 929 user keys across POOL teams.
+            # owner.
             cap_entry = cap_map.get(db_key.id)
             key_budget: float | None = None
             cap_duration: str | None = None
@@ -905,7 +952,7 @@ async def evaluate_region(
                 continue
 
             # A cap is an allowance *per cycle*, so its percentage is measured over
-            # that cycle. Every cap on PROD is 31d or 1mo, and LiteLLM zeroes the
+            # that cycle. Caps are written as 31d or 1mo and LiteLLM zeroes the
             # key's spend at each boundary; dividing the team's longer cycle of
             # spend by a one-month cap would read far above 100 % and alert on
             # nothing. A key bounded by the pool has no cycle of its own and keeps
@@ -986,8 +1033,8 @@ async def evaluate_region(
                     db, team.id, user.id, region.id
                 )
                 # Same rule as for key caps: a team-member cap is a per-cycle
-                # allowance (all 38 on PROD are 1mo), so it is measured over its own
-                # cycle. A plain USER BUDGET limit is absolute and keeps the team's.
+                # allowance, so it is measured over its own cycle. A plain USER
+                # BUDGET limit is absolute and keeps the team's.
                 member_window = window
                 member_total = member_spend.get(user.id, 0.0)
                 if member_duration:
@@ -1302,10 +1349,10 @@ def regions_to_sweep(db: Session) -> list[DBRegion]:
 
     Deliberately NOT filtered on ``is_active``. That flag governs whether a
     region accepts *new* provisioning, not whether its existing keys still serve
-    traffic. On PROD, region 5 (``amazeeai-de103``) is inactive yet holds 11,859
-    keys — 85% of all keys, including the anonymous Drupal trial fleet, which is
-    exactly the population that runs into budget limits. Filtering on
-    ``is_active`` silently excluded them from every alert.
+    traffic. An inactive region can still hold the large majority of a fleet's keys,
+    including the anonymous Drupal trial keys, which are exactly the population that
+    runs into budget limits. Filtering on ``is_active`` silently excluded them from
+    every alert.
 
     Requiring a live key also keeps the sweep off decommissioned regions, whose
     LiteLLM URL may no longer resolve, without needing a second flag: an empty

--- a/app/core/budget_alert_service.py
+++ b/app/core/budget_alert_service.py
@@ -869,7 +869,20 @@ async def evaluate_region(
             cap_anchor: datetime | None = None
             budget_source = "key_cap"
             if cap_entry is not None:
-                key_budget, cap_duration, cap_anchor = cap_entry
+                key_budget, cap_duration, cap_created_at = cap_entry
+                # Phase comes from LiteLLM when it is enforcing the same cycle.
+                # It recomputes each boundary from the day its reset job runs, so
+                # budget_reset_at is where the cycle actually lands, drift included,
+                # while our created_at only predicts it correctly for as long as
+                # that job stays punctual. Requiring the durations to match keeps a
+                # 1mo reset date from being read as a 31d one.
+                litellm_duration = (
+                    key_state.get("budget_duration") if key_state is not None else None
+                )
+                if litellm_duration == cap_duration:
+                    cap_anchor = _litellm_cycle_anchor(key_state, cap_duration)
+                if cap_anchor is None:
+                    cap_anchor = cap_created_at
             if key_budget is None and litellm_max_budget is not None:
                 key_budget = float(litellm_max_budget)
                 cap_duration = (

--- a/app/core/budget_alert_service.py
+++ b/app/core/budget_alert_service.py
@@ -44,8 +44,10 @@ Two stages, both bounded by *activity* rather than by key count:
    deliberately ignored; see ``spend_window_start``.
 
 So a tick costs ``pages + active_teams`` calls per region, independent of how many
-idle keys exist. Sweeping every key instead — the shape of the existing hourly
-reconciler, ~40 min at 13.9k keys — is what does not survive 100k.
+idle keys exist, plus one scoped back-fill for any team whose budget window opens
+before the wide request (none on PROD today). Sweeping every key instead — the
+shape of the existing hourly reconciler, ~40 min at 13.9k keys — is what does not
+survive 100k.
 """
 
 from __future__ import annotations
@@ -327,13 +329,11 @@ async def _exact_team_key_state(
 ) -> dict[str, dict]:
     """Current per-key ``spend``/``max_budget`` for one team, keyed by hashed token.
 
-    Needed when the daily-activity sweep cannot answer on its own:
-
-    * a POOL window that opened before the sweep's lookback (its total would be
-      partial) — LiteLLM's key spend is the pool-lifetime spend, which is exactly
-      what a non-resetting pool window wants;
-    * PERIODIC keys, whose authoritative ``max_budget`` lives in LiteLLM rather
-      than in our ``spend_caps``.
+    Supplies the ``max_budget`` a key is measured against when our ``spend_caps``
+    hold none, and flags keys being expired via ``budget_duration``. Its ``spend``
+    is never read: LiteLLM's key counters are lifetime totals that a top-up does
+    not reset, so they cannot be divided by a budget that excludes expired
+    entries. Spend always comes from the daily-activity rows.
     """
     try:
         keys = await service.list_keys_for_team(lite_team_id)
@@ -470,8 +470,9 @@ def region_sweep_start(db: Session, region_id: int, now: datetime) -> date:
     Anchoring on the ledger also usually makes the sweep *cheaper* than the
     370-day default: most POOL money was bought recently, so the request narrows
     to the days that can matter. ``BUDGET_ALERT_MAX_LOOKBACK_DAYS`` remains a hard
-    floor, and any team whose window opens before it is skipped rather than
-    reported wrongly.
+    floor on this one wide request; a team whose window opens before it is
+    back-filled with its own scoped call in ``evaluate_region`` rather than being
+    summed from partial rows.
     """
     floor = _sweep_start(now)
     oldest_anchor = (
@@ -659,31 +660,54 @@ async def evaluate_region(
         cap_map = _key_cap_map(db, region.id, [key.id for key in db_keys])
         team_budget = _team_budget(db, team, region.id)
 
-        if since < sweep_start:
-            # region_sweep_start already stretched the request to the oldest ledger
-            # anchor, so reaching here means the window predates the hard lookback
-            # floor. Summing anyway would understate the percentage for good and
-            # announce a low band for a team that is actually near its limit, so
-            # the team is dropped instead.
+        if since >= sweep_start:
+            entity_totals, key_totals = _sum_activity_since(team_rows, since)
+        elif not (team_budget or cap_map):
+            # Nothing to measure, so nothing to fetch. A POOL team with no valid
+            # ledger entry anchors on team.created_at, which is routinely older than
+            # the window, and there are 673 of those on PROD — spending a call on
+            # each would cost a call per team per tick for no possible event.
+            continue
+        else:
+            # The wide sweep starts after this team's window opens, so its rows hold
+            # only part of the team's spend. Summing them anyway would understate the
+            # percentage for good — not merely imprecisely — because the missing days
+            # never enter the window: a team truly at 92 % would be told it is at
+            # 30 %, and would never reach the 90 band at all.
             #
-            # Only worth complaining about when the team had a budget to measure.
-            # A POOL team with no valid ledger entry anchors on team.created_at,
-            # which is routinely older than the window, and there are 673 of those
-            # on PROD — logging each one would bury the case that matters.
-            if team_budget or cap_map:
+            # So the team is back-filled with a scoped call over its own window
+            # instead. /team/daily/activity takes a team_ids filter, and one team's
+            # rows are bounded by the number of days, so this stays cheap. It costs
+            # one extra call only for teams the wide sweep cannot cover — none on
+            # PROD today, where no anchor is older than 69 days against a 370-day
+            # floor. Skipping such a team instead would hide every crossing it has
+            # until the floor was raised by hand.
+            logger.info(
+                "Team %s window opens %s, before the %s sweep start; "
+                "back-filling its spend with a scoped activity call",
+                team.id,
+                since,
+                sweep_start,
+            )
+            try:
+                scoped_rows = await service.get_team_daily_activity(
+                    lite_team_id, since.isoformat(), end_str
+                )
+                result.litellm_calls += 1
+            except Exception as exc:
+                # Without the back-fill the only honest options are a wrong number
+                # or no number; take no number, and make the reason visible.
                 logger.error(
-                    "Team %s skipped: spend window opens %s, before the %s sweep "
-                    "floor. Raise BUDGET_ALERT_MAX_LOOKBACK_DAYS to cover it.",
+                    "Team %s skipped: could not back-fill spend from %s: %s",
                     team.id,
                     since,
-                    sweep_start,
+                    exc,
                 )
                 budget_alert_subjects_skipped_total.labels(
-                    reason="window_before_lookback"
+                    reason="activity_backfill_failed"
                 ).inc()
-            continue
-
-        entity_totals, key_totals = _sum_activity_since(team_rows, since)
+                continue
+            entity_totals, key_totals = _sum_activity_since(scoped_rows, since)
 
         # /key/list supplies the key *denominators* (max_budget) and flags keys being
         # expired; its spend figures are deliberately not used.

--- a/app/core/budget_alert_service.py
+++ b/app/core/budget_alert_service.py
@@ -31,15 +31,18 @@ How it scales to 100k keys
 --------------------------
 Two stages, both bounded by *activity* rather than by key count:
 
-1. **Discovery** — one unfiltered ``/team/daily/activity`` call per region tells us
-   which teams spent anything. LiteLLM writes no daily rows for idle entities, so
-   on PROD region 5 an 11,859-key region reported 42 active teams in one 1.68 s
-   page. Only entity *ids* are used from this; see ``_active_entity_ids``.
-2. **Measurement** — one scoped ``/key/list?team_id=`` per candidate team gives
-   exact ``spend`` and ``max_budget`` for that team's keys.
+1. **Discovery and spend** — an unfiltered ``/team/daily/activity`` sweep over the
+   lookback. LiteLLM writes no daily rows for idle entities, so on PROD region 5 an
+   11,859-key region reported 42 active teams and 351 active keys. Measured cost is
+   3 pages / ~1 s at the 370-day default (page 1 alone at 62 days was 1.08 s);
+   ``_fetch_daily_activity`` follows ``has_more``, and pages partition the data
+   rather than repeating it, so the per-day totals add up cleanly.
+2. **Denominators for keys** — one scoped ``/key/list?team_id=`` per candidate team,
+   used for ``max_budget`` and to spot keys being expired. Its ``spend`` figures are
+   deliberately ignored; see ``spend_window_start``.
 
-So a tick costs ``1 + active_teams`` calls per region, independent of how many idle
-keys exist. Sweeping every key instead — the shape of the existing hourly
+So a tick costs ``pages + active_teams`` calls per region, independent of how many
+idle keys exist. Sweeping every key instead — the shape of the existing hourly
 reconciler, ~40 min at 13.9k keys — is what does not survive 100k.
 """
 

--- a/app/core/budget_alert_service.py
+++ b/app/core/budget_alert_service.py
@@ -801,6 +801,39 @@ def write_audit_logs(
 # --------------------------------------------------------------------------- #
 
 
+def regions_to_sweep(db: Session) -> list[DBRegion]:
+    """Regions worth evaluating: any that still hold at least one live key.
+
+    Deliberately NOT filtered on ``is_active``. That flag governs whether a
+    region accepts *new* provisioning, not whether its existing keys still serve
+    traffic. On PROD, region 5 (``amazeeai-de103``) is inactive yet holds 11,859
+    keys — 85% of all keys, including the anonymous Drupal trial fleet, which is
+    exactly the population that runs into budget limits. Filtering on
+    ``is_active`` silently excluded them from every alert.
+
+    Requiring a live key also keeps the sweep off decommissioned regions, whose
+    LiteLLM URL may no longer resolve, without needing a second flag: an empty
+    region has nothing to alert on regardless of its status.
+    """
+    return (
+        db.query(DBRegion)
+        .filter(
+            DBRegion.litellm_api_url.isnot(None),
+            DBRegion.litellm_api_url != "",
+            DBRegion.litellm_api_key.isnot(None),
+            DBRegion.litellm_api_key != "",
+            db.query(DBPrivateAIKey.id)
+            .filter(
+                DBPrivateAIKey.region_id == DBRegion.id,
+                DBPrivateAIKey.litellm_token.isnot(None),
+            )
+            .exists(),
+        )
+        .order_by(DBRegion.id)
+        .all()
+    )
+
+
 @budget_alert_run_duration.time()
 async def monitor_budget_thresholds(db: Session) -> dict[str, int]:
     """Sweep every active region, notify new crossings, and record what stuck.
@@ -816,12 +849,7 @@ async def monitor_budget_thresholds(db: Session) -> dict[str, int]:
         logger.warning("No budget alert thresholds configured; nothing to do")
         return {"regions": 0, "events": 0, "delivered": 0}
 
-    regions = (
-        db.query(DBRegion)
-        .filter(DBRegion.is_active.is_(True))
-        .order_by(DBRegion.id)
-        .all()
-    )
+    regions = regions_to_sweep(db)
     logger.info(
         "Budget threshold sweep starting: %d region(s), thresholds=%s, enabled=%s",
         len(regions),

--- a/app/core/budget_alert_service.py
+++ b/app/core/budget_alert_service.py
@@ -725,6 +725,61 @@ def denominator_change_candidates(
     return candidates
 
 
+def window_before_sweep_candidates(
+    db: Session, region_id: int, sweep_start: date, now: datetime
+) -> set[int]:
+    """Teams whose budget window opens before the wide request does.
+
+    Such a team may have spent nothing inside the swept range and so produce no
+    daily-activity row at all, which would keep it out of the candidate set — and
+    out of the scoped back-fill that exists precisely for it. Its spend would then
+    go unreported however far past a threshold it is, including on a first run when
+    no state exists to say otherwise.
+
+    ``region_sweep_start`` derives the floor from these same anchors, so today the
+    set is empty: a still-valid purchase cannot predate a lookback longer than the
+    purchase expiry. That is a coincidence between two settings rather than a
+    guarantee, and lowering ``BUDGET_ALERT_MAX_LOOKBACK_DAYS`` below the pool expiry
+    would quietly make it non-empty. Discovering these teams explicitly costs one
+    indexed query and removes the dependency.
+    """
+    rows = (
+        db.query(DBPeriodicBudgetLedgerEntry.team_id)
+        .join(DBTeam, DBTeam.id == DBPeriodicBudgetLedgerEntry.team_id)
+        .filter(
+            DBPeriodicBudgetLedgerEntry.region_id == region_id,
+            DBPeriodicBudgetLedgerEntry.is_active.is_(True),
+            DBTeam.deleted_at.is_(None),
+            DBTeam.budget_type == BudgetType.POOL,
+            (
+                DBPeriodicBudgetLedgerEntry.expires_at.is_(None)
+                | (DBPeriodicBudgetLedgerEntry.expires_at > now)
+            ),
+            (
+                (DBPeriodicBudgetLedgerEntry.purchased_at.isnot(None))
+                & (DBPeriodicBudgetLedgerEntry.purchased_at < sweep_start)
+            )
+            | (
+                (DBPeriodicBudgetLedgerEntry.effective_period_start.isnot(None))
+                & (DBPeriodicBudgetLedgerEntry.effective_period_start < sweep_start)
+            ),
+        )
+        .distinct()
+        .all()
+    )
+    candidates = {int(team_id) for (team_id,) in rows if team_id is not None}
+    if candidates:
+        logger.warning(
+            "Region %s: %d team(s) hold budget older than the %s sweep start; "
+            "they are evaluated from their own scoped activity call. Raise "
+            "BUDGET_ALERT_MAX_LOOKBACK_DAYS to keep them in the wide request.",
+            region_id,
+            len(candidates),
+            sweep_start,
+        )
+    return candidates
+
+
 async def evaluate_region(
     db: Session,
     region: DBRegion,
@@ -771,6 +826,14 @@ async def evaluate_region(
     # evaluated even though they were silent.
     denominator_change_team_ids = denominator_change_candidates(db, region.id, now)
     candidate_team_ids.update(denominator_change_team_ids)
+
+    # Nor is appearing in the wide request the only way to be worth evaluating: a
+    # team whose window predates it may have spent nothing inside the swept range
+    # and still be over a threshold. Those are found from the ledger and back-filled
+    # below rather than being invisible.
+    candidate_team_ids.update(
+        window_before_sweep_candidates(db, region.id, sweep_start, now)
+    )
 
     if not candidate_team_ids:
         logger.info("No active teams in region %s this sweep", region.name)

--- a/app/core/budget_alert_service.py
+++ b/app/core/budget_alert_service.py
@@ -49,6 +49,7 @@ from app.core.pool_budget_service import pool_available_budget_for_team_region
 from app.core.spend_period_service import TeamPeriodWindow, resolve_team_period_window
 from app.core.team_service import get_team_region_litellm_keys
 from app.db.models import (
+    DBAuditLog,
     DBBudgetAlertState,
     DBLimitedResource,
     DBPrivateAIKey,
@@ -729,6 +730,72 @@ def mark_notified(
     return advanced
 
 
+def write_audit_logs(
+    db: Session,
+    events: list[BudgetAlertEvent],
+    delivered_event_ids: set[str],
+    now: datetime | None = None,
+) -> int:
+    """Record each attempted crossing in the audit log.
+
+    ``budget_alert_state`` only holds the *current* band per subject, so without
+    this there is no answer to "did we warn this customer before their keys were
+    cut off" — a billing-dispute question that application logs (rotated, and
+    absent from the DB) cannot settle. ``delivered`` distinguishes "the customer
+    was told" from "we detected it but could not reach the consumer".
+
+    An undelivered crossing is re-detected next tick, so a consumer outage
+    produces one row per attempt. That repetition is the retry record, and it is
+    bounded by the tick interval rather than by traffic.
+
+    Audit failure must never fail the sweep: alerting is the job, auditing is the
+    side effect.
+    """
+    if not events:
+        return 0
+    now = now or datetime.now(UTC)
+    written = 0
+    try:
+        for event in events:
+            db.add(
+                DBAuditLog(
+                    timestamp=now,
+                    user_id=None,
+                    event_type="WORKER",
+                    resource_type=event.subject_type,
+                    resource_id=event.subject_key,
+                    action="budget.threshold_reached",
+                    details={
+                        "event_id": event.event_id,
+                        "delivered": event.event_id in delivered_event_ids,
+                        "threshold_percent": event.threshold_pct,
+                        "percent_used": event.percent_used,
+                        "spend": event.spend,
+                        "max_budget": event.max_budget,
+                        "region_id": event.region_id,
+                        "region_name": event.region_name,
+                        "team_id": event.team_id,
+                        "user_id": event.user_id,
+                        "key_id": event.key_id,
+                        "period_key": event.period_key,
+                    },
+                    request_source=None,
+                )
+            )
+            written += 1
+        db.commit()
+    except Exception as exc:
+        logger.error("Failed to write budget alert audit logs: %s", exc)
+        try:
+            db.rollback()
+        except Exception as rollback_exc:
+            logger.warning(
+                "Failed to roll back budget alert audit logs: %s", rollback_exc
+            )
+        return 0
+    return written
+
+
 # --------------------------------------------------------------------------- #
 # Job entry point
 # --------------------------------------------------------------------------- #
@@ -767,6 +834,7 @@ async def monitor_budget_thresholds(db: Session) -> dict[str, int]:
         "subjects": 0,
         "events": 0,
         "delivered": 0,
+        "audited": 0,
         "litellm_calls": 0,
     }
 
@@ -834,15 +902,19 @@ async def monitor_budget_thresholds(db: Session) -> dict[str, int]:
         undelivered = len(evaluation.events) - len(delivered)
         if undelivered > 0:
             budget_alert_delivery_failures_total.inc(undelivered)
+        # Audit before advancing state: if mark_notified were to fail, the record
+        # that we did warn the customer should still survive.
+        totals["audited"] += write_audit_logs(db, evaluation.events, delivered)
         mark_notified(db, region, evaluation, delivered)
 
     logger.info(
         "Budget threshold sweep finished: regions=%d subjects=%d events=%d "
-        "delivered=%d litellm_calls=%d",
+        "delivered=%d audited=%d litellm_calls=%d",
         totals["regions"],
         totals["subjects"],
         totals["events"],
         totals["delivered"],
+        totals["audited"],
         totals["litellm_calls"],
     )
     return totals

--- a/app/core/budget_alert_service.py
+++ b/app/core/budget_alert_service.py
@@ -360,9 +360,19 @@ def _team_budget(db: Session, team: DBTeam, region_id: int) -> float | None:
     (``spend_caps`` scope ``team``) only ever tightens it.
     """
     available = pool_available_budget_for_team_region(db, team.id, region_id)
-    if available <= 0:
-        # PERIODIC teams with no ledger yet (e.g. trials) still carry a BUDGET
-        # limit, which is the only budget they have.
+    if available <= 0 and team.budget_type != BudgetType.POOL:
+        # A PERIODIC team with no ledger yet (e.g. a trial) still carries a BUDGET
+        # limit, which is the only budget it has.
+        #
+        # This deliberately does *not* apply to POOL teams. A POOL team's budget is
+        # the money it bought, so no valid ledger entry means nothing to be a
+        # percentage of, and the BUDGET limit is a provisioning allowance rather
+        # than available credit. On PROD 673 POOL teams sit in exactly that state
+        # (662 never purchased at all) carrying a mostly-$27 limit; measuring
+        # lifetime spend against it would invent a percentage, and with no purchase
+        # to anchor on, spend_window_start would fall back to team.created_at and
+        # sum an unbounded stretch of history. Such a team simply gets no team
+        # event; its keys are still evaluated if they carry their own cap.
         limit_value = (
             db.query(DBLimitedResource.max_value)
             .filter(
@@ -632,30 +642,6 @@ async def evaluate_region(
         # decides whether an expired top-up corrupts the percentage.
         since_dt = spend_window_start(db, team, region.id, now)
         since = since_dt.date()
-        if since < sweep_start:
-            # region_sweep_start already stretched the request to the oldest ledger
-            # anchor, so reaching here means the window predates the hard lookback
-            # floor. Summing anyway would understate the percentage for good and
-            # announce a low band for a team that is actually near its limit, so
-            # the team is dropped instead. Raise BUDGET_ALERT_MAX_LOOKBACK_DAYS if
-            # this ever appears in the logs.
-            logger.error(
-                "Team %s skipped: spend window opens %s, before the %s sweep floor. "
-                "Raise BUDGET_ALERT_MAX_LOOKBACK_DAYS to cover it.",
-                team.id,
-                since,
-                sweep_start,
-            )
-            budget_alert_subjects_skipped_total.labels(
-                reason="window_before_lookback"
-            ).inc()
-            continue
-        entity_totals, key_totals = _sum_activity_since(team_rows, since)
-
-        # /key/list supplies the key *denominators* (max_budget) and flags keys being
-        # expired; its spend figures are deliberately not used.
-        exact_keys = await _exact_team_key_state(service, lite_team_id)
-        result.litellm_calls += 1
 
         # Only keys carrying both a team and a region — the shape MOAD provisions.
         # A key with just an owner and no team has no team budget to be a share of,
@@ -672,6 +658,37 @@ async def evaluate_region(
         )
         cap_map = _key_cap_map(db, region.id, [key.id for key in db_keys])
         team_budget = _team_budget(db, team, region.id)
+
+        if since < sweep_start:
+            # region_sweep_start already stretched the request to the oldest ledger
+            # anchor, so reaching here means the window predates the hard lookback
+            # floor. Summing anyway would understate the percentage for good and
+            # announce a low band for a team that is actually near its limit, so
+            # the team is dropped instead.
+            #
+            # Only worth complaining about when the team had a budget to measure.
+            # A POOL team with no valid ledger entry anchors on team.created_at,
+            # which is routinely older than the window, and there are 673 of those
+            # on PROD — logging each one would bury the case that matters.
+            if team_budget or cap_map:
+                logger.error(
+                    "Team %s skipped: spend window opens %s, before the %s sweep "
+                    "floor. Raise BUDGET_ALERT_MAX_LOOKBACK_DAYS to cover it.",
+                    team.id,
+                    since,
+                    sweep_start,
+                )
+                budget_alert_subjects_skipped_total.labels(
+                    reason="window_before_lookback"
+                ).inc()
+            continue
+
+        entity_totals, key_totals = _sum_activity_since(team_rows, since)
+
+        # /key/list supplies the key *denominators* (max_budget) and flags keys being
+        # expired; its spend figures are deliberately not used.
+        exact_keys = await _exact_team_key_state(service, lite_team_id)
+        result.litellm_calls += 1
 
         # An uncapped key's only budget is the team pool, so that is what it is
         # measured against — it answers "which key is eating the pool", which the
@@ -814,8 +831,15 @@ def _classify_subjects(
         if state is not None and state.period_key == period_key:
             previous_band = int(state.last_threshold_pct or 0)
 
+        # The arming this crossing belongs to. Every silent reset bumps it, which is
+        # what lets a genuine re-crossing of an already-notified band carry a new
+        # event_id instead of colliding with the first one. See event_id_for.
+        arm_seq = int(state.arm_seq or 0) if state is not None else 0
+
         if band > previous_band:
-            result.events.append(_build_event(region, subject, band, period_key))
+            result.events.append(
+                _build_event(region, subject, band, period_key, arm_seq)
+            )
         elif band != previous_band or (
             state is not None and state.period_key != period_key
         ):
@@ -825,7 +849,7 @@ def _classify_subjects(
             result.resets.append((subject, band))
 
 
-def event_id_for(subject_key: str, period_key: str, band: int) -> str:
+def event_id_for(subject_key: str, period_key: str, band: int, arm_seq: int) -> str:
     """A stable id for one crossing, so a retry carries the id of the original.
 
     Delivery is at-least-once: a POST whose response is lost leaves the state
@@ -834,18 +858,27 @@ def event_id_for(subject_key: str, period_key: str, band: int) -> str:
     de-duplication on ``event_id`` — which is the only thing protecting the
     customer from a duplicate notification — could not catch it.
 
-    (subject, period, band) identifies a crossing exactly: bands only ever move
-    upward within a period, so the same triple cannot legitimately occur twice.
+    ``arm_seq`` is what keeps that from going too far. A band can legitimately
+    recur inside one period: a POOL top-up raises the denominator, the percentage
+    falls, the band is silently re-armed, and later spend crosses the same band
+    again. That second crossing is a real event the customer must hear about. It is
+    only distinguishable from a retry because ``arm_seq`` was bumped by the reset,
+    so (subject, period, band) alone would collapse the two and the consumer would
+    discard the new warning.
+
+    So the identity of a crossing is (subject, period, band, arm generation), and
+    re-sending it is the only thing that reproduces the same id.
     """
-    digest = hashlib.sha256(f"{subject_key}|{period_key}|{band}".encode()).hexdigest()
+    payload = f"{subject_key}|{period_key}|{band}|{arm_seq}"
+    digest = hashlib.sha256(payload.encode()).hexdigest()
     return f"evt_{digest[:32]}"
 
 
 def _build_event(
-    region: DBRegion, subject: _Subject, band: int, period_key: str
+    region: DBRegion, subject: _Subject, band: int, period_key: str, arm_seq: int
 ) -> BudgetAlertEvent:
     return BudgetAlertEvent(
-        event_id=event_id_for(subject.subject_key, period_key, band),
+        event_id=event_id_for(subject.subject_key, period_key, band, arm_seq),
         subject_type=subject.subject_type,
         subject_key=subject.subject_key,
         threshold_pct=band,
@@ -882,6 +915,7 @@ def _upsert_state(
     band: int,
     period_key: str,
     notified_at: datetime | None,
+    bump_arm: bool = False,
 ) -> None:
     row = (
         db.query(DBBudgetAlertState)
@@ -893,8 +927,13 @@ def _upsert_state(
             subject_key=subject.subject_key,
             subject_type=subject.subject_type,
             region_id=region_id,
+            arm_seq=0,
         )
         db.add(row)
+    if bump_arm:
+        # A band was re-armed, so the next crossing of it is a new event and must
+        # not reuse the id of the one already sent.
+        row.arm_seq = int(row.arm_seq or 0) + 1
     row.subject_type = subject.subject_type
     row.region_id = region_id
     row.team_id = subject.team.id if subject.team else None
@@ -919,6 +958,7 @@ def apply_resets(db: Session, region: DBRegion, evaluation: RegionEvaluation) ->
             band=band,
             period_key=subject.window.period_key,
             notified_at=None,
+            bump_arm=True,
         )
     if evaluation.resets:
         db.commit()

--- a/app/core/budget_alert_service.py
+++ b/app/core/budget_alert_service.py
@@ -66,6 +66,7 @@ from app.core.config import settings
 from app.core.pool_budget_service import pool_available_budget_for_team_region
 from app.core.spend_period_service import (
     TeamPeriodWindow,
+    compute_period_start,
     current_cycle_start,
     resolve_team_period_window,
 )
@@ -74,7 +75,6 @@ from app.db.models import (
     DBBudgetAlertState,
     DBLimitedResource,
     DBPeriodicBudgetLedgerEntry,
-    DBPeriodicPayment,
     DBPrivateAIKey,
     DBRegion,
     DBSpendCap,
@@ -431,25 +431,50 @@ def _team_budget(db: Session, team: DBTeam, region_id: int) -> float | None:
     return available if available > 0 else None
 
 
-def _cap_cycle_anchor(db: Session, team: DBTeam) -> datetime | None:
-    """Where a rolling ``Nd`` cap cycle is anchored for this team.
+def _litellm_cycle_anchor(
+    key_state: dict | None, budget_duration: str | None
+) -> datetime | None:
+    """Anchor for a budget LiteLLM owns, derived from its own reset date.
 
-    Mirrors ``app/api/spend.py``: the most recent completed deactivation payment,
-    else team creation. Using the same anchor as the endpoint the customer reads
-    is the point — a cap percentage that disagrees with the dashboard is worse
-    than no alert.
+    ``budget_reset_at`` is the *end* of the cycle it is currently counting, so the
+    anchor is that minus the duration. It can be stale — PROD has keys whose reset
+    date is a month in the past — which is why the caller rolls it forward instead
+    of using it directly.
     """
-    last_deactivation = (
-        db.query(DBPeriodicPayment.payment_date)
-        .filter(
-            DBPeriodicPayment.team_id == team.id,
-            DBPeriodicPayment.payment_type == "deactivation",
-            DBPeriodicPayment.status == "completed",
-        )
-        .order_by(DBPeriodicPayment.payment_date.desc())
-        .first()
-    )
-    anchor = (last_deactivation[0] if last_deactivation else None) or team.created_at
+    if key_state is None or not budget_duration:
+        return None
+    raw = key_state.get("budget_reset_at")
+    if not raw:
+        return None
+    if isinstance(raw, datetime):
+        reset_at = raw
+    else:
+        try:
+            reset_at = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if reset_at.tzinfo is None:
+        reset_at = reset_at.replace(tzinfo=UTC)
+    return compute_period_start(reset_at, budget_duration)
+
+
+def _cap_cycle_anchor(cap_created_at: datetime | None, team: DBTeam) -> datetime | None:
+    """Where a rolling ``Nd`` cap cycle is anchored.
+
+    The cap row's own ``created_at``. Setting a cap calls ``update_key_budget``
+    with the duration, which is the moment LiteLLM starts counting: it stores
+    ``budget_reset_at = that moment + N days`` and steps it on from there. An
+    amount-only change deliberately passes no duration, so the original anchor
+    survives and ``created_at`` stays the right one.
+
+    Verified against PROD: for a team whose cap was set 44 days after the team
+    itself, ``created_at`` reproduces LiteLLM's ``budget_reset_at`` to the
+    time-of-day, while team creation was 18.7 days out. 29 of the 130 rolling
+    ``31d`` caps were set more than a day after their team, by up to 420 days.
+
+    ``team.created_at`` is only a fallback for a cap row with no timestamp.
+    """
+    anchor = cap_created_at or team.created_at
     if anchor is not None and anchor.tzinfo is None:
         anchor = anchor.replace(tzinfo=UTC)
     return anchor
@@ -457,7 +482,7 @@ def _cap_cycle_anchor(db: Session, team: DBTeam) -> datetime | None:
 
 def _member_budget(
     db: Session, team_id: int, user_id: int, region_id: int
-) -> tuple[float | None, str | None]:
+) -> tuple[float | None, str | None, datetime | None]:
     """Per-member budget and the cycle it applies to.
 
     The team-member cap wins, else the user's BUDGET limit. The cap carries a
@@ -466,7 +491,9 @@ def _member_budget(
     caller measures it over the team's cycle instead.
     """
     cap = (
-        db.query(DBSpendCap.max_budget, DBSpendCap.budget_duration)
+        db.query(
+            DBSpendCap.max_budget, DBSpendCap.budget_duration, DBSpendCap.created_at
+        )
         .filter(
             DBSpendCap.scope == "team_member",
             DBSpendCap.region_id == region_id,
@@ -478,7 +505,7 @@ def _member_budget(
     )
     if cap is not None and cap[0] is not None:
         value = float(cap[0])
-        return (value, cap[1]) if value > 0 else (None, None)
+        return (value, cap[1], cap[2]) if value > 0 else (None, None, None)
 
     limit_value = (
         db.query(DBLimitedResource.max_value)
@@ -490,17 +517,22 @@ def _member_budget(
         .scalar()
     )
     if limit_value and float(limit_value) > 0:
-        return float(limit_value), None
-    return None, None
+        return float(limit_value), None, None
+    return None, None, None
 
 
 def _key_cap_map(
     db: Session, region_id: int, key_ids: list[int]
-) -> dict[int, tuple[float, str | None]]:
+) -> dict[int, tuple[float, str | None, datetime | None]]:
     if not key_ids:
         return {}
     rows = (
-        db.query(DBSpendCap.key_id, DBSpendCap.max_budget, DBSpendCap.budget_duration)
+        db.query(
+            DBSpendCap.key_id,
+            DBSpendCap.max_budget,
+            DBSpendCap.budget_duration,
+            DBSpendCap.created_at,
+        )
         .filter(
             DBSpendCap.scope == "key",
             DBSpendCap.region_id == region_id,
@@ -509,12 +541,12 @@ def _key_cap_map(
         )
         .all()
     )
-    # The duration comes along because a cap is a per-cycle allowance, so it
-    # determines the window its percentage must be measured over, not just the
-    # number to divide by.
+    # The duration and the row's own created_at come along because a cap is a
+    # per-cycle allowance: together they say which window its percentage must be
+    # measured over, not just the number to divide by.
     return {
-        int(key_id): (float(value), duration)
-        for key_id, value, duration in rows
+        int(key_id): (float(value), duration, created_at)
+        for key_id, value, duration, created_at in rows
         if value
     }
 
@@ -803,10 +835,6 @@ async def evaluate_region(
         # percentages are always drawn from the same numbers.
         team_spend = 0.0
 
-        # Anchor for a cap whose cycle is a rolling "Nd": the same one the spend
-        # API uses, so the alert and the dashboard agree on where the cycle began.
-        cap_anchor = _cap_cycle_anchor(db, team)
-
         for db_key in db_keys:
             hashed = LiteLLMService.hash_token(db_key.litellm_token)
             key_state = exact_keys.get(hashed)
@@ -838,14 +866,17 @@ async def evaluate_region(
             cap_entry = cap_map.get(db_key.id)
             key_budget: float | None = None
             cap_duration: str | None = None
+            cap_anchor: datetime | None = None
             budget_source = "key_cap"
             if cap_entry is not None:
-                key_budget, cap_duration = cap_entry
+                key_budget, cap_duration, cap_anchor = cap_entry
             if key_budget is None and litellm_max_budget is not None:
                 key_budget = float(litellm_max_budget)
                 cap_duration = (
                     key_state.get("budget_duration") if key_state is not None else None
                 )
+                # LiteLLM owns this budget, so its own reset date is the anchor.
+                cap_anchor = _litellm_cycle_anchor(key_state, cap_duration)
                 budget_source = "litellm_key_budget"
             if not key_budget or key_budget <= 0:
                 # A budget of <= 0 is how a pool-gated key is born blocked;
@@ -855,6 +886,7 @@ async def evaluate_region(
                     continue
                 key_budget = pool_fallback_budget
                 cap_duration = None
+                cap_anchor = None
                 budget_source = "team_pool"
             if not key_budget or key_budget <= 0:
                 continue
@@ -868,7 +900,9 @@ async def evaluate_region(
             key_window = window
             key_since = since
             if cap_duration:
-                cap_start = current_cycle_start(cap_duration, cap_anchor, now)
+                cap_start = current_cycle_start(
+                    cap_duration, _cap_cycle_anchor(cap_anchor, team), now
+                )
                 if cap_start is not None:
                     key_since = cap_start.date()
                     key_window = TeamPeriodWindow(
@@ -935,7 +969,7 @@ async def evaluate_region(
                     )
 
             for user in users:
-                member_budget, member_duration = _member_budget(
+                member_budget, member_duration, member_anchor = _member_budget(
                     db, team.id, user.id, region.id
                 )
                 # Same rule as for key caps: a team-member cap is a per-cycle
@@ -944,7 +978,9 @@ async def evaluate_region(
                 member_window = window
                 member_total = member_spend.get(user.id, 0.0)
                 if member_duration:
-                    cap_start = current_cycle_start(member_duration, cap_anchor, now)
+                    cap_start = current_cycle_start(
+                        member_duration, _cap_cycle_anchor(member_anchor, team), now
+                    )
                     if cap_start is not None:
                         member_since = cap_start.date()
                         member_total = sum(

--- a/app/core/budget_alert_service.py
+++ b/app/core/budget_alert_service.py
@@ -41,7 +41,7 @@ Two stages, both bounded by *activity* rather than by key count:
    rather than repeating it, so the per-day totals add up cleanly.
 2. **Denominators for keys** — one scoped ``/key/list?team_id=`` per candidate team,
    used for ``max_budget`` and to spot keys being expired. Its ``spend`` figures are
-   deliberately ignored; see ``spend_window_start``.
+   deliberately ignored; spend comes from the daily rows instead.
 
 So a tick costs ``pages + active_teams`` calls per region, independent of how many
 idle keys exist, plus one scoped back-fill for any team whose budget window opens
@@ -271,46 +271,28 @@ def _sum_activity_since(
     return entity_spend, key_spend
 
 
-def spend_window_start(
-    db: Session, team: DBTeam, region_id: int, now: datetime
-) -> datetime:
-    """When the spend that counts against the *current* budget began.
+def spend_window_start(window: TeamPeriodWindow, now: datetime) -> datetime:
+    """When the spend that counts against the current budget began.
 
-    This is the purchase date of the **oldest still-valid** ledger entry, and it is
-    the crux of getting top-up-only POOL teams right.
+    Always the start of the **current cycle**, and deliberately nothing else:
 
-    A top-up never resets key spend — ``purchase_periodic_topup`` only raises the
-    team's ``max_budget`` — so LiteLLM's key counters are lifetime totals. The
-    denominator, meanwhile, counts only entries that have not expired. Divide one by
-    the other and an expired top-up leaves its spend in the numerator while its
-    money has left the denominator:
+    * subscription team -> the cycle start (``effective_period_start``);
+    * top-up-only team  -> the last top-up purchase;
+    * neither           -> team creation.
 
-        $100 expired (of which $80 spent) + $100 just bought
-        lifetime spend $82 / remaining $100  ->  82%   (wrong)
-        spend since the valid entry $2 / $100 ->  2%   (right)
+    Those are exactly the windows ``resolve_team_period_window`` already resolves
+    for the spend API, so this is a thin read of it rather than a second rule. An
+    alert has to quote the number the dashboard shows, and two independent window
+    calculations would eventually disagree.
 
-    Anchoring on the oldest *valid* entry rather than the newest purchase is what
-    makes both directions correct: money bought earlier but still valid keeps its
-    spend counted, while money that has expired takes its spend with it.
+    Reaching back further than the cycle start would *double count*: the
+    denominator is ``purchased - consumed_cents``, and ``consumed_cents`` is
+    incremented at cycle close while LiteLLM's spend is reset on the same call
+    (see the invariant at ``app/api/spend.py``). A closed cycle's spend is
+    therefore already subtracted from the budget, so counting it again in the
+    numerator inflates the percentage and fires alerts nobody has earned.
     """
-    oldest_valid = (
-        db.query(func.min(DBPeriodicBudgetLedgerEntry.purchased_at))
-        .filter(
-            DBPeriodicBudgetLedgerEntry.team_id == team.id,
-            DBPeriodicBudgetLedgerEntry.region_id == region_id,
-            DBPeriodicBudgetLedgerEntry.is_active.is_(True),
-            DBPeriodicBudgetLedgerEntry.purchased_at.isnot(None),
-            (
-                DBPeriodicBudgetLedgerEntry.expires_at.is_(None)
-                | (DBPeriodicBudgetLedgerEntry.expires_at > now)
-            ),
-        )
-        .scalar()
-    )
-    anchor = oldest_valid or team.created_at or now
-    if anchor.tzinfo is None:
-        anchor = anchor.replace(tzinfo=UTC)
-    return anchor
+    return window.period_start or now
 
 
 def _amazee_team_id_from_litellm(entity_id: str, region_name: str) -> int | None:
@@ -369,10 +351,10 @@ def _team_budget(db: Session, team: DBTeam, region_id: int) -> float | None:
         # percentage of, and the BUDGET limit is a provisioning allowance rather
         # than available credit. On PROD 673 POOL teams sit in exactly that state
         # (662 never purchased at all) carrying a mostly-$27 limit; measuring
-        # lifetime spend against it would invent a percentage, and with no purchase
-        # to anchor on, spend_window_start would fall back to team.created_at and
-        # sum an unbounded stretch of history. Such a team simply gets no team
-        # event; its keys are still evaluated if they carry their own cap.
+        # spend against it would invent a percentage, and with no purchase to anchor
+        # on there is no cycle start either, so the window would fall back to team
+        # creation. Such a team simply gets no team event; its keys are still
+        # evaluated if they carry their own cap.
         limit_value = (
             db.query(DBLimitedResource.max_value)
             .filter(
@@ -466,6 +448,10 @@ def region_sweep_start(db: Session, region_id: int, now: datetime) -> date:
     precision — the percentage stays permanently understated, so a team truly at
     90 % is reported at 55 % and gets told it is fine. The fix is to make the
     request cover the earliest window in the region rather than a fixed span.
+
+    It anchors on the oldest still-valid purchase, which is a *conservative* lower
+    bound: a cycle start is always at or after the purchase that funded it, so this
+    can fetch a few more days than any team needs but can never fetch too few.
 
     Anchoring on the ledger also usually makes the sweep *cheaper* than the
     370-day default: most POOL money was bought recently, so the request narrows
@@ -637,11 +623,11 @@ async def evaluate_region(
         window = resolve_team_period_window(db, team, region.id, now=now)
         lite_team_id = LiteLLMService.format_team_id(region.name, team.id)
 
-        # Spend is summed from the purchase date of the oldest still-valid ledger
-        # entry — NOT taken from LiteLLM's key counters, which are lifetime totals a
-        # top-up never resets. See spend_window_start for why that distinction
-        # decides whether an expired top-up corrupts the percentage.
-        since_dt = spend_window_start(db, team, region.id, now)
+        # Alerts are per cycle, so spend is summed from the current cycle's start:
+        # the subscription's effective_period_start, or the last top-up purchase for
+        # a team that only buys top-ups. Never from LiteLLM's key counters, which
+        # are lifetime totals a top-up does not reset.
+        since_dt = spend_window_start(window, now)
         since = since_dt.date()
 
         # Only keys carrying both a team and a region — the shape MOAD provisions.
@@ -730,19 +716,26 @@ async def evaluate_region(
         for db_key in db_keys:
             hashed = LiteLLMService.hash_token(db_key.litellm_token)
             key_state = exact_keys.get(hashed)
-            if key_state is not None and _is_expiring(key_state):
-                # Being expired via budget_duration "0d"; not a budget warning.
-                continue
             key_spend = float(key_totals.get(hashed, 0.0))
             litellm_max_budget = (
                 key_state.get("max_budget") if key_state is not None else None
             )
-            team_spend += key_spend
 
+            # Money a key spent counts towards its team and its owner whatever the
+            # key's own state, so these totals are accumulated before any of the
+            # per-key skips below. Dropping an expiring key's spend here would
+            # understate the team percentage and make the reconciliation warning
+            # further down fire on a gap that does not exist.
+            team_spend += key_spend
             if db_key.owner_id:
                 member_spend[db_key.owner_id] = (
                     member_spend.get(db_key.owner_id, 0.0) + key_spend
                 )
+
+            if key_state is not None and _is_expiring(key_state):
+                # Being expired via budget_duration "0d". No key-scope alert: the
+                # key is on its way out, which is not a budget problem.
+                continue
 
             # Denominator precedence: our own cap, then whatever LiteLLM enforces,
             # then the team pool. Applies equally to service keys (no owner) and
@@ -1137,9 +1130,11 @@ def regions_to_sweep(db: Session) -> list[DBRegion]:
 async def monitor_budget_thresholds(db: Session) -> dict[str, int]:
     """Sweep every active region, notify new crossings, and record what stuck.
 
-    Regions are independent, so they are swept concurrently — but each region's
-    DB work runs on the shared session, so evaluation is serialised per region
-    and only the LiteLLM reads overlap.
+    Regions are independent, so their LiteLLM reads are overlapped. They share one
+    Session, so their DB work interleaves at every ``await`` — safe only because
+    each query is synchronous (nothing else can run mid-query) and ``evaluate_region``
+    never writes. Every write happens below, sequentially, after the gather. Adding
+    a write inside ``evaluate_region`` would need a session per region.
     """
     from app.services.budget_alert_webhook import deliver_events
 

--- a/app/core/budget_alert_service.py
+++ b/app/core/budget_alert_service.py
@@ -32,9 +32,11 @@ How it scales to 100k keys
 Two stages, both bounded by *activity* rather than by key count:
 
 1. **Discovery and spend** — an unfiltered ``/team/daily/activity`` sweep over the
-   lookback. LiteLLM writes no daily rows for idle entities, so on PROD region 5 an
-   11,859-key region reported 42 active teams and 351 active keys. Measured cost is
-   3 pages / ~1 s at the 370-day default (page 1 alone at 62 days was 1.08 s);
+   window that ``region_sweep_start`` derives from the ledger. LiteLLM writes no
+   daily rows for idle entities, so on PROD region 5 an 11,859-key region reported
+   42 active teams and 351 active keys. Measured cost is 3 pages / ~1 s at the full
+   370-day span (page 1 alone at 62 days was 1.08 s), and usually less, because the
+   window only reaches back as far as the oldest unexpired purchase.
    ``_fetch_daily_activity`` follows ``has_more``, and pages partition the data
    rather than repeating it, so the per-day totals add up cleanly.
 2. **Denominators for keys** — one scoped ``/key/list?team_id=`` per candidate team,
@@ -49,8 +51,8 @@ reconciler, ~40 min at 13.9k keys — is what does not survive 100k.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
-import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, date, datetime, timedelta
 
@@ -91,6 +93,12 @@ budget_alerts_fired_total = Counter(
 budget_alert_delivery_failures_total = Counter(
     "budget_alert_delivery_failures_total",
     "Budget threshold events that were detected but not delivered",
+)
+
+budget_alert_subjects_skipped_total = Counter(
+    "budget_alert_subjects_skipped_total",
+    "Subjects that could not be evaluated safely and were dropped",
+    ["reason"],
 )
 
 budget_alert_subjects_evaluated = Gauge(
@@ -435,7 +443,46 @@ def _key_cap_map(db: Session, region_id: int, key_ids: list[int]) -> dict[int, f
 
 
 def _sweep_start(now: datetime) -> date:
+    """The hard floor on how far back a sweep will ever ask LiteLLM to go."""
     return (now - timedelta(days=settings.BUDGET_ALERT_MAX_LOOKBACK_DAYS)).date()
+
+
+def region_sweep_start(db: Session, region_id: int, now: datetime) -> date:
+    """First day the activity sweep must cover for this region.
+
+    Each team's spend is summed from its own window start (see
+    ``spend_window_start``), so a sweep that begins *after* that date returns only
+    part of the team's spend. Summing a partial answer does not merely lose
+    precision — the percentage stays permanently understated, so a team truly at
+    90 % is reported at 55 % and gets told it is fine. The fix is to make the
+    request cover the earliest window in the region rather than a fixed span.
+
+    Anchoring on the ledger also usually makes the sweep *cheaper* than the
+    370-day default: most POOL money was bought recently, so the request narrows
+    to the days that can matter. ``BUDGET_ALERT_MAX_LOOKBACK_DAYS`` remains a hard
+    floor, and any team whose window opens before it is skipped rather than
+    reported wrongly.
+    """
+    floor = _sweep_start(now)
+    oldest_anchor = (
+        db.query(func.min(DBPeriodicBudgetLedgerEntry.purchased_at))
+        .join(DBTeam, DBTeam.id == DBPeriodicBudgetLedgerEntry.team_id)
+        .filter(
+            DBPeriodicBudgetLedgerEntry.region_id == region_id,
+            DBPeriodicBudgetLedgerEntry.is_active.is_(True),
+            DBPeriodicBudgetLedgerEntry.purchased_at.isnot(None),
+            (
+                DBPeriodicBudgetLedgerEntry.expires_at.is_(None)
+                | (DBPeriodicBudgetLedgerEntry.expires_at > now)
+            ),
+            DBTeam.deleted_at.is_(None),
+            DBTeam.budget_type == BudgetType.POOL,
+        )
+        .scalar()
+    )
+    if oldest_anchor is None:
+        return floor
+    return max(floor, oldest_anchor.date())
 
 
 def _is_expiring(key_state: dict) -> bool:
@@ -528,7 +575,7 @@ async def evaluate_region(
     service = LiteLLMService(
         api_url=region.litellm_api_url, api_key=region.litellm_api_key
     )
-    sweep_start = _sweep_start(now)
+    sweep_start = region_sweep_start(db, region.id, now)
     start_str = sweep_start.isoformat()
     end_str = now.date().isoformat()
 
@@ -586,13 +633,23 @@ async def evaluate_region(
         since_dt = spend_window_start(db, team, region.id, now)
         since = since_dt.date()
         if since < sweep_start:
-            logger.warning(
-                "Team %s spend window opens %s, before the %s sweep start; "
-                "percentage may be understated. Raise BUDGET_ALERT_MAX_LOOKBACK_DAYS.",
+            # region_sweep_start already stretched the request to the oldest ledger
+            # anchor, so reaching here means the window predates the hard lookback
+            # floor. Summing anyway would understate the percentage for good and
+            # announce a low band for a team that is actually near its limit, so
+            # the team is dropped instead. Raise BUDGET_ALERT_MAX_LOOKBACK_DAYS if
+            # this ever appears in the logs.
+            logger.error(
+                "Team %s skipped: spend window opens %s, before the %s sweep floor. "
+                "Raise BUDGET_ALERT_MAX_LOOKBACK_DAYS to cover it.",
                 team.id,
                 since,
                 sweep_start,
             )
+            budget_alert_subjects_skipped_total.labels(
+                reason="window_before_lookback"
+            ).inc()
+            continue
         entity_totals, key_totals = _sum_activity_since(team_rows, since)
 
         # /key/list supplies the key *denominators* (max_budget) and flags keys being
@@ -768,11 +825,27 @@ def _classify_subjects(
             result.resets.append((subject, band))
 
 
+def event_id_for(subject_key: str, period_key: str, band: int) -> str:
+    """A stable id for one crossing, so a retry carries the id of the original.
+
+    Delivery is at-least-once: a POST whose response is lost leaves the state
+    unadvanced, and the next tick rebuilds the same crossing. A random id would
+    make that retry look like a second, separate crossing to the consumer, and its
+    de-duplication on ``event_id`` — which is the only thing protecting the
+    customer from a duplicate notification — could not catch it.
+
+    (subject, period, band) identifies a crossing exactly: bands only ever move
+    upward within a period, so the same triple cannot legitimately occur twice.
+    """
+    digest = hashlib.sha256(f"{subject_key}|{period_key}|{band}".encode()).hexdigest()
+    return f"evt_{digest[:32]}"
+
+
 def _build_event(
     region: DBRegion, subject: _Subject, band: int, period_key: str
 ) -> BudgetAlertEvent:
     return BudgetAlertEvent(
-        event_id=f"evt_{uuid.uuid4().hex}",
+        event_id=event_id_for(subject.subject_key, period_key, band),
         subject_type=subject.subject_type,
         subject_key=subject.subject_key,
         threshold_pct=band,

--- a/app/core/budget_alert_service.py
+++ b/app/core/budget_alert_service.py
@@ -1,0 +1,848 @@
+"""Budget threshold alerts — detect when spend crosses a share of budget.
+
+Emits an event when a team, key or team member crosses 50 / 75 / 90 / 100 % of
+its budget, so a downstream consumer (MOAD) can warn the customer *before* their
+keys stop working.
+
+Why amazee.ai computes the percentage instead of LiteLLM
+-------------------------------------------------------
+LiteLLM has native budget alerting, but it cannot produce the right number for
+our teams:
+
+* **Wrong numerator for PERIODIC teams.** LiteLLM's team-level ``spend`` counter
+  is never reset; our billing cycle zeroes the *per-key* spends instead. Dividing
+  a lifetime total by a one-cycle budget sits permanently above 100 %. The spend
+  API works around this by summing key spends (``app/api/spend.py``), and so do we.
+* **Moving denominator for POOL teams.** The budget is owned by our ledger and
+  pushed to LiteLLM. Buying a top-up raises it, so a percentage can fall back
+  below a band it already crossed. LiteLLM's TTL-based dedup would suppress the
+  genuine second crossing.
+* Its thresholds are hardcoded to 85 % / 95 % and are not configurable.
+
+So LiteLLM is the source of *spend*, and every budget number comes from our DB.
+
+How it scales to 100k keys
+--------------------------
+Spend is read from ``/team/daily/activity`` and ``/user/daily/activity`` with no
+entity filter — two calls per region, regardless of key count. LiteLLM only
+writes daily-spend rows for entities that actually spent, so the cost tracks
+*active* entities rather than total keys. Enumerating every key instead (the
+shape of the existing hourly reconciler) is what does not survive 100k.
+
+The one place we still enumerate keys is a scoped ``/key/list?team_id=`` for a
+team we have already decided is worth confirming — see ``_exact_team_key_state``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime, timedelta
+
+from prometheus_client import Counter, Gauge, Summary
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.core.pool_budget_service import pool_available_budget_for_team_region
+from app.core.spend_period_service import TeamPeriodWindow, resolve_team_period_window
+from app.core.team_service import get_team_region_litellm_keys
+from app.db.models import (
+    DBBudgetAlertState,
+    DBLimitedResource,
+    DBPrivateAIKey,
+    DBRegion,
+    DBSpendCap,
+    DBTeam,
+    DBUser,
+)
+from app.schemas.limits import OwnerType, ResourceType
+from app.schemas.models import BudgetType
+from app.services.litellm import LiteLLMService
+
+logger = logging.getLogger(__name__)
+
+SUBJECT_TEAM = "team"
+SUBJECT_KEY = "key"
+SUBJECT_TEAM_MEMBER = "team_member"
+
+budget_alerts_fired_total = Counter(
+    "budget_alerts_fired_total",
+    "Budget threshold crossings detected",
+    ["scope", "threshold"],
+)
+
+budget_alert_delivery_failures_total = Counter(
+    "budget_alert_delivery_failures_total",
+    "Budget threshold events that were detected but not delivered",
+)
+
+budget_alert_subjects_evaluated = Gauge(
+    "budget_alert_subjects_evaluated",
+    "Subjects evaluated in the last budget threshold sweep, per region",
+    ["region_name"],
+)
+
+budget_alert_run_duration = Summary(
+    "budget_alert_run_duration_seconds",
+    "Time taken to complete the budget threshold sweep",
+)
+
+# LiteLLM's own bookkeeping teams show up in the activity breakdown; they are not
+# amazee.ai teams and have no budget of ours.
+_NON_TEAM_ENTITY_IDS = frozenset({"litellm-dashboard"})
+
+
+def parse_thresholds(raw: str | None = None) -> list[int]:
+    """Parse the configured thresholds into a sorted, de-duplicated list."""
+    raw = raw if raw is not None else settings.BUDGET_ALERT_THRESHOLDS
+    values: set[int] = set()
+    for chunk in (raw or "").split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        try:
+            value = int(float(chunk))
+        except (TypeError, ValueError):
+            logger.warning("Ignoring unparseable budget alert threshold: %r", chunk)
+            continue
+        if 0 < value <= 1000:
+            values.add(value)
+    return sorted(values)
+
+
+def highest_crossed_band(percent_used: float, thresholds: list[int]) -> int:
+    """Return the highest threshold at or below ``percent_used`` (0 if none).
+
+    Only the highest band is ever reported, so a key that jumps from 0 % to 95 %
+    in one tick produces a single 90 % event rather than 50 + 75 + 90.
+    """
+    crossed = 0
+    for threshold in thresholds:
+        if percent_used >= threshold:
+            crossed = threshold
+    return crossed
+
+
+@dataclass(frozen=True)
+class BudgetAlertEvent:
+    """One threshold crossing, ready to serialise for the webhook."""
+
+    event_id: str
+    subject_type: str
+    subject_key: str
+    threshold_pct: int
+    percent_used: float
+    spend: float
+    max_budget: float
+    region_id: int
+    region_name: str
+    period_key: str
+    period_start: datetime | None
+    period_end: datetime | None
+    budget_duration: str | None
+    team_id: int | None = None
+    team_name: str | None = None
+    user_id: int | None = None
+    user_email: str | None = None
+    key_id: int | None = None
+    key_name: str | None = None
+
+
+@dataclass
+class _Subject:
+    """A thing with a budget, evaluated against the thresholds."""
+
+    subject_type: str
+    subject_key: str
+    spend: float
+    max_budget: float | None
+    window: TeamPeriodWindow
+    team: DBTeam | None = None
+    user: DBUser | None = None
+    key: DBPrivateAIKey | None = None
+
+    @property
+    def percent_used(self) -> float:
+        if not self.max_budget or self.max_budget <= 0:
+            return 0.0
+        return round((self.spend / self.max_budget) * 100.0, 4)
+
+
+@dataclass
+class RegionEvaluation:
+    """Result of evaluating one region."""
+
+    events: list[BudgetAlertEvent] = field(default_factory=list)
+    # Subjects whose band dropped or whose period rolled over. Their state is
+    # rewritten without notifying, so a later genuine re-crossing still fires.
+    resets: list[tuple[_Subject, int]] = field(default_factory=list)
+    # Every subject considered this tick, kept so a delivered event can be
+    # re-joined to the ORM objects behind it. Events stay plain data because they
+    # get serialised; subjects hold ORM instances and never leave this module.
+    subjects: list[_Subject] = field(default_factory=list)
+    litellm_calls: int = 0
+
+    @property
+    def subjects_evaluated(self) -> int:
+        return len(self.subjects)
+
+
+# --------------------------------------------------------------------------- #
+# Spend collection
+# --------------------------------------------------------------------------- #
+
+
+def _sum_activity_by_entity(
+    rows: list[dict], since: date | None
+) -> tuple[dict[str, float], dict[str, float], date | None]:
+    """Fold daily-activity rows into per-entity and per-key spend totals.
+
+    ``rows`` is one entry per UTC day. Days before ``since`` are skipped so each
+    team is only credited with spend inside its own billing window, even though
+    a single sweep covers every team's window at once.
+
+    Returns ``(entity_spend, key_spend, earliest_day_seen)``. The third value
+    lets the caller tell whether the sweep actually reached back to the start of
+    a window, or whether the total it just computed is partial.
+    """
+    entity_spend: dict[str, float] = {}
+    key_spend: dict[str, float] = {}
+    earliest: date | None = None
+
+    for row in rows:
+        raw_date = row.get("date")
+        try:
+            row_date = date.fromisoformat(str(raw_date)[:10])
+        except (TypeError, ValueError):
+            logger.warning("Skipping daily-activity row with bad date: %r", raw_date)
+            continue
+        if since is not None and row_date < since:
+            continue
+        if earliest is None or row_date < earliest:
+            earliest = row_date
+
+        breakdown = row.get("breakdown") or {}
+        for entity_id, payload in (breakdown.get("entities") or {}).items():
+            metrics = (payload or {}).get("metrics") or {}
+            entity_spend[entity_id] = entity_spend.get(entity_id, 0.0) + float(
+                metrics.get("spend") or 0.0
+            )
+        for hashed_token, payload in (breakdown.get("api_keys") or {}).items():
+            metrics = (payload or {}).get("metrics") or {}
+            key_spend[hashed_token] = key_spend.get(hashed_token, 0.0) + float(
+                metrics.get("spend") or 0.0
+            )
+
+    return entity_spend, key_spend, earliest
+
+
+def _amazee_team_id_from_litellm(entity_id: str, region_name: str) -> int | None:
+    """Recover our team id from LiteLLM's ``<region>_<team_id>`` team id."""
+    if entity_id in _NON_TEAM_ENTITY_IDS:
+        return None
+    prefix = f"{region_name.replace(' ', '_')}_"
+    if not entity_id.startswith(prefix):
+        return None
+    suffix = entity_id[len(prefix) :]
+    return int(suffix) if suffix.isdigit() else None
+
+
+async def _exact_team_key_state(
+    service: LiteLLMService, lite_team_id: str
+) -> dict[str, dict]:
+    """Current per-key ``spend``/``max_budget`` for one team, keyed by hashed token.
+
+    Needed when the daily-activity sweep cannot answer on its own:
+
+    * a POOL window that opened before the sweep's lookback (its total would be
+      partial) — LiteLLM's key spend is the pool-lifetime spend, which is exactly
+      what a non-resetting pool window wants;
+    * PERIODIC keys, whose authoritative ``max_budget`` lives in LiteLLM rather
+      than in our ``spend_caps``.
+    """
+    try:
+        keys = await service.list_keys_for_team(lite_team_id)
+    except Exception as exc:
+        logger.warning("Could not fetch exact key state for %s: %s", lite_team_id, exc)
+        return {}
+    return {
+        str(key.get("token")): key
+        for key in keys
+        if isinstance(key, dict) and key.get("token")
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Denominators — always ours, never LiteLLM's
+# --------------------------------------------------------------------------- #
+
+
+def _team_budget(db: Session, team: DBTeam, region_id: int) -> float | None:
+    """Budget available to a team in a region, from our ledger.
+
+    Mirrors what the spend API reports as ``period_budget``: remaining
+    subscription entries plus remaining top-ups. An operator cap
+    (``spend_caps`` scope ``team``) only ever tightens it.
+    """
+    available = pool_available_budget_for_team_region(db, team.id, region_id)
+    if available <= 0:
+        # PERIODIC teams with no ledger yet (e.g. trials) still carry a BUDGET
+        # limit, which is the only budget they have.
+        limit_value = (
+            db.query(DBLimitedResource.max_value)
+            .filter(
+                DBLimitedResource.owner_type == OwnerType.TEAM,
+                DBLimitedResource.owner_id == team.id,
+                DBLimitedResource.resource == ResourceType.BUDGET,
+            )
+            .scalar()
+        )
+        available = float(limit_value) if limit_value else 0.0
+
+    cap = (
+        db.query(DBSpendCap.max_budget)
+        .filter(
+            DBSpendCap.scope == "team",
+            DBSpendCap.region_id == region_id,
+            DBSpendCap.team_id == team.id,
+            DBSpendCap.max_budget.isnot(None),
+        )
+        .scalar()
+    )
+    if cap is not None:
+        available = min(available, float(cap))
+    return available if available > 0 else None
+
+
+def _member_budget(
+    db: Session, team_id: int, user_id: int, region_id: int
+) -> float | None:
+    """Per-member budget: the team-member cap, else the user's BUDGET limit."""
+    cap = (
+        db.query(DBSpendCap.max_budget)
+        .filter(
+            DBSpendCap.scope == "team_member",
+            DBSpendCap.region_id == region_id,
+            DBSpendCap.team_id == team_id,
+            DBSpendCap.user_id == user_id,
+            DBSpendCap.max_budget.isnot(None),
+        )
+        .scalar()
+    )
+    if cap is not None:
+        return float(cap) if float(cap) > 0 else None
+
+    limit_value = (
+        db.query(DBLimitedResource.max_value)
+        .filter(
+            DBLimitedResource.owner_type == OwnerType.USER,
+            DBLimitedResource.owner_id == user_id,
+            DBLimitedResource.resource == ResourceType.BUDGET,
+        )
+        .scalar()
+    )
+    if limit_value and float(limit_value) > 0:
+        return float(limit_value)
+    return None
+
+
+def _key_cap_map(db: Session, region_id: int, key_ids: list[int]) -> dict[int, float]:
+    if not key_ids:
+        return {}
+    rows = (
+        db.query(DBSpendCap.key_id, DBSpendCap.max_budget)
+        .filter(
+            DBSpendCap.scope == "key",
+            DBSpendCap.region_id == region_id,
+            DBSpendCap.key_id.in_(key_ids),
+            DBSpendCap.max_budget.isnot(None),
+        )
+        .all()
+    )
+    return {int(key_id): float(value) for key_id, value in rows if value}
+
+
+# --------------------------------------------------------------------------- #
+# Evaluation
+# --------------------------------------------------------------------------- #
+
+
+def _sweep_start(now: datetime) -> date:
+    return (now - timedelta(days=settings.BUDGET_ALERT_MAX_LOOKBACK_DAYS)).date()
+
+
+def _window_since(window: TeamPeriodWindow, sweep_start: date) -> date:
+    if window.period_start is None:
+        return sweep_start
+    return max(window.period_start.date(), sweep_start)
+
+
+def _is_expiring(key_state: dict) -> bool:
+    """A key set to ``0d`` is being expired; it is not a budget problem."""
+    return str(key_state.get("budget_duration") or "") == "0d"
+
+
+async def evaluate_region(
+    db: Session,
+    region: DBRegion,
+    *,
+    thresholds: list[int] | None = None,
+    now: datetime | None = None,
+) -> RegionEvaluation:
+    """Evaluate every active subject in one region against the thresholds."""
+    thresholds = thresholds or parse_thresholds()
+    now = now or datetime.now(UTC)
+    result = RegionEvaluation()
+    if not thresholds:
+        return result
+
+    service = LiteLLMService(
+        api_url=region.litellm_api_url, api_key=region.litellm_api_key
+    )
+    sweep_start = _sweep_start(now)
+    start_str = sweep_start.isoformat()
+    end_str = now.date().isoformat()
+
+    try:
+        team_rows, user_rows = await asyncio.gather(
+            service.get_all_team_daily_activity(start_str, end_str),
+            service.get_all_user_daily_activity(start_str, end_str),
+        )
+        result.litellm_calls += 2
+    except Exception as exc:
+        logger.error("Budget alert sweep failed for region %s: %s", region.name, exc)
+        return result
+
+    subjects: list[_Subject] = []
+
+    # --- candidate teams --------------------------------------------------- #
+    # Only entities that actually spent appear in the sweep, so this is the
+    # working set: on a DEV region with 2,740 keys it was 27 teams. A team with
+    # no traffic in the lookback cannot have newly crossed a band, since spend
+    # only rises with traffic and we notify on upward moves only.
+    team_totals_all, _, _ = _sum_activity_by_entity(team_rows, None)
+    candidate_team_ids = {
+        team_id
+        for entity_id in team_totals_all
+        if (team_id := _amazee_team_id_from_litellm(entity_id, region.name)) is not None
+    }
+
+    # A key owned by a user but not attached to a LiteLLM team contributes no
+    # team entity, so its team would be invisible above. The user sweep closes
+    # that gap: active user ids map back to their team.
+    active_user_totals, _, _ = _sum_activity_by_entity(user_rows, None)
+    active_user_ids = [
+        int(user_id) for user_id in active_user_totals if str(user_id).isdigit()
+    ]
+    if active_user_ids:
+        candidate_team_ids.update(
+            team_id
+            for (team_id,) in db.query(DBUser.team_id)
+            .filter(DBUser.id.in_(active_user_ids), DBUser.team_id.isnot(None))
+            .distinct()
+            .all()
+        )
+
+    if not candidate_team_ids:
+        logger.info("No active teams in region %s this sweep", region.name)
+        return result
+
+    teams = (
+        db.query(DBTeam)
+        .filter(DBTeam.id.in_(candidate_team_ids), DBTeam.deleted_at.is_(None))
+        .all()
+    )
+    for team in teams:
+        window = resolve_team_period_window(db, team, region.id, now=now)
+        since = _window_since(window, sweep_start)
+        team_totals, key_totals, _ = _sum_activity_by_entity(team_rows, since)
+        lite_team_id = LiteLLMService.format_team_id(region.name, team.id)
+
+        # Whole-UTC-day granularity and a lookback shorter than the window both
+        # make the swept total partial. POOL windows run for
+        # POOL_PURCHASE_EXPIRY_DAYS (365 by default), well past the lookback, so
+        # for those we take LiteLLM's live key spend instead: a pool window never
+        # resets, so key spend *is* the window total.
+        window_predates_sweep = (
+            window.period_start is not None and window.period_start.date() < sweep_start
+        )
+        needs_exact_keys = window_predates_sweep or team.budget_type != BudgetType.POOL
+        exact_keys = (
+            await _exact_team_key_state(service, lite_team_id)
+            if needs_exact_keys
+            else {}
+        )
+        if exact_keys:
+            result.litellm_calls += 1
+
+        # Includes keys owned by team members but not attached to the team, which
+        # is the same ownership rule the spend API and the billing cycle use.
+        db_keys = get_team_region_litellm_keys(db, team_id=team.id, region_id=region.id)
+        cap_map = _key_cap_map(db, region.id, [key.id for key in db_keys])
+
+        team_spend = float(team_totals.get(lite_team_id, 0.0))
+        member_spend: dict[int, float] = {}
+
+        for db_key in db_keys:
+            hashed = LiteLLMService.hash_token(db_key.litellm_token)
+            key_state = exact_keys.get(hashed)
+            if key_state is not None:
+                if _is_expiring(key_state):
+                    continue
+                key_spend = float(key_state.get("spend") or 0.0)
+                litellm_max_budget = key_state.get("max_budget")
+            else:
+                key_spend = float(key_totals.get(hashed, 0.0))
+                litellm_max_budget = None
+
+            if db_key.owner_id:
+                member_spend[db_key.owner_id] = (
+                    member_spend.get(db_key.owner_id, 0.0) + key_spend
+                )
+
+            # A DB cap wins; otherwise fall back to what LiteLLM enforces.
+            key_budget = cap_map.get(db_key.id)
+            if key_budget is None and litellm_max_budget is not None:
+                key_budget = float(litellm_max_budget)
+            # max_budget of 0 is how a pool-gated key is born blocked. Alerting
+            # 100 % at creation would be pure noise, so an absent or
+            # non-positive budget means "no key-level threshold".
+            if not key_budget or key_budget <= 0:
+                continue
+
+            subjects.append(
+                _Subject(
+                    subject_type=SUBJECT_KEY,
+                    subject_key=f"key:{db_key.id}",
+                    spend=key_spend,
+                    max_budget=key_budget,
+                    window=window,
+                    team=team,
+                    key=db_key,
+                )
+            )
+
+        if exact_keys:
+            # Prefer the live sum for the team as well, so the team percentage and
+            # its keys' percentages are drawn from the same numbers.
+            team_spend = sum(
+                float(state.get("spend") or 0.0)
+                for state in exact_keys.values()
+                if not _is_expiring(state)
+            )
+
+        subjects.append(
+            _Subject(
+                subject_type=SUBJECT_TEAM,
+                subject_key=f"team:{team.id}:{region.id}",
+                spend=team_spend,
+                max_budget=_team_budget(db, team, region.id),
+                window=window,
+                team=team,
+            )
+        )
+
+        # --- team members -------------------------------------------------- #
+        if member_spend:
+            users = (
+                db.query(DBUser).filter(DBUser.id.in_(list(member_spend.keys()))).all()
+            )
+            for user in users:
+                subjects.append(
+                    _Subject(
+                        subject_type=SUBJECT_TEAM_MEMBER,
+                        subject_key=f"member:{team.id}:{user.id}:{region.id}",
+                        spend=member_spend.get(user.id, 0.0),
+                        max_budget=_member_budget(db, team.id, user.id, region.id),
+                        window=window,
+                        team=team,
+                        user=user,
+                    )
+                )
+
+    result.subjects = subjects
+    _classify_subjects(db, region, subjects, thresholds, result)
+    return result
+
+
+def _classify_subjects(
+    db: Session,
+    region: DBRegion,
+    subjects: list[_Subject],
+    thresholds: list[int],
+    result: RegionEvaluation,
+) -> None:
+    """Split subjects into new crossings to notify and states to quietly reset."""
+    if not subjects:
+        return
+
+    existing = {
+        row.subject_key: row
+        for row in db.query(DBBudgetAlertState)
+        .filter(DBBudgetAlertState.subject_key.in_([s.subject_key for s in subjects]))
+        .all()
+    }
+
+    for subject in subjects:
+        if not subject.max_budget or subject.max_budget <= 0:
+            continue
+        band = highest_crossed_band(subject.percent_used, thresholds)
+        state = existing.get(subject.subject_key)
+        period_key = subject.window.period_key
+
+        previous_band = 0
+        if state is not None and state.period_key == period_key:
+            previous_band = int(state.last_threshold_pct or 0)
+
+        if band > previous_band:
+            result.events.append(_build_event(region, subject, band, period_key))
+        elif band != previous_band or (
+            state is not None and state.period_key != period_key
+        ):
+            # Either the period rolled over, or the percentage fell — a POOL
+            # top-up raises the denominator. Rewrite the band silently so a real
+            # re-crossing later still notifies, but never announce a decrease.
+            result.resets.append((subject, band))
+
+
+def _build_event(
+    region: DBRegion, subject: _Subject, band: int, period_key: str
+) -> BudgetAlertEvent:
+    return BudgetAlertEvent(
+        event_id=f"evt_{uuid.uuid4().hex}",
+        subject_type=subject.subject_type,
+        subject_key=subject.subject_key,
+        threshold_pct=band,
+        percent_used=subject.percent_used,
+        spend=round(subject.spend, 4),
+        max_budget=round(float(subject.max_budget or 0.0), 4),
+        region_id=region.id,
+        region_name=region.name,
+        period_key=period_key,
+        period_start=subject.window.period_start,
+        period_end=subject.window.period_end,
+        budget_duration=subject.window.budget_duration,
+        team_id=subject.team.id if subject.team else None,
+        team_name=subject.team.name if subject.team else None,
+        user_id=subject.user.id if subject.user else None,
+        user_email=subject.user.email if subject.user else None,
+        key_id=subject.key.id if subject.key else None,
+        key_name=subject.key.name if subject.key else None,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# State persistence
+# --------------------------------------------------------------------------- #
+
+
+def _upsert_state(
+    db: Session,
+    *,
+    subject: _Subject,
+    region_id: int,
+    band: int,
+    period_key: str,
+    notified_at: datetime | None,
+) -> None:
+    row = (
+        db.query(DBBudgetAlertState)
+        .filter(DBBudgetAlertState.subject_key == subject.subject_key)
+        .first()
+    )
+    if row is None:
+        row = DBBudgetAlertState(
+            subject_key=subject.subject_key,
+            subject_type=subject.subject_type,
+            region_id=region_id,
+        )
+        db.add(row)
+    row.subject_type = subject.subject_type
+    row.region_id = region_id
+    row.team_id = subject.team.id if subject.team else None
+    row.user_id = subject.user.id if subject.user else None
+    row.key_id = subject.key.id if subject.key else None
+    row.period_key = period_key
+    row.last_threshold_pct = band
+    row.spend_at_notify = round(subject.spend, 4)
+    row.budget_at_notify = round(float(subject.max_budget or 0.0), 4)
+    row.percent_at_notify = subject.percent_used
+    if notified_at is not None:
+        row.notified_at = notified_at
+
+
+def apply_resets(db: Session, region: DBRegion, evaluation: RegionEvaluation) -> None:
+    """Persist silent band/period rewrites. Safe to run before delivery."""
+    for subject, band in evaluation.resets:
+        _upsert_state(
+            db,
+            subject=subject,
+            region_id=region.id,
+            band=band,
+            period_key=subject.window.period_key,
+            notified_at=None,
+        )
+    if evaluation.resets:
+        db.commit()
+
+
+def mark_notified(
+    db: Session,
+    region: DBRegion,
+    evaluation: RegionEvaluation,
+    delivered_event_ids: set[str],
+    now: datetime | None = None,
+) -> int:
+    """Advance state for the events that were actually delivered.
+
+    Called *after* delivery on purpose. If the webhook fails, the band is left
+    where it was and the next tick re-detects the same crossing, which gives
+    at-least-once delivery without an outbox table. Consumers de-duplicate on
+    ``event_id``.
+    """
+    now = now or datetime.now(UTC)
+    by_subject = {
+        event.subject_key: event
+        for event in evaluation.events
+        if event.event_id in delivered_event_ids
+    }
+    if not by_subject:
+        return 0
+
+    advanced = 0
+    for subject in evaluation.subjects:
+        event = by_subject.get(subject.subject_key)
+        if event is None:
+            continue
+        _upsert_state(
+            db,
+            subject=subject,
+            region_id=region.id,
+            band=event.threshold_pct,
+            period_key=event.period_key,
+            notified_at=now,
+        )
+        advanced += 1
+    db.commit()
+    return advanced
+
+
+# --------------------------------------------------------------------------- #
+# Job entry point
+# --------------------------------------------------------------------------- #
+
+
+@budget_alert_run_duration.time()
+async def monitor_budget_thresholds(db: Session) -> dict[str, int]:
+    """Sweep every active region, notify new crossings, and record what stuck.
+
+    Regions are independent, so they are swept concurrently — but each region's
+    DB work runs on the shared session, so evaluation is serialised per region
+    and only the LiteLLM reads overlap.
+    """
+    from app.services.budget_alert_webhook import deliver_events
+
+    thresholds = parse_thresholds()
+    if not thresholds:
+        logger.warning("No budget alert thresholds configured; nothing to do")
+        return {"regions": 0, "events": 0, "delivered": 0}
+
+    regions = (
+        db.query(DBRegion)
+        .filter(DBRegion.is_active.is_(True))
+        .order_by(DBRegion.id)
+        .all()
+    )
+    logger.info(
+        "Budget threshold sweep starting: %d region(s), thresholds=%s, enabled=%s",
+        len(regions),
+        thresholds,
+        settings.BUDGET_ALERT_ENABLED,
+    )
+
+    totals = {
+        "regions": 0,
+        "subjects": 0,
+        "events": 0,
+        "delivered": 0,
+        "litellm_calls": 0,
+    }
+
+    semaphore = asyncio.Semaphore(max(1, settings.BUDGET_ALERT_REGION_CONCURRENCY))
+
+    async def _evaluate(region: DBRegion) -> tuple[DBRegion, RegionEvaluation | None]:
+        async with semaphore:
+            try:
+                return region, await evaluate_region(db, region, thresholds=thresholds)
+            except Exception as exc:
+                logger.error(
+                    "Budget threshold evaluation failed for region %s: %s",
+                    region.name,
+                    exc,
+                    exc_info=True,
+                )
+                return region, None
+
+    for region, evaluation in await asyncio.gather(
+        *[_evaluate(region) for region in regions]
+    ):
+        if evaluation is None:
+            continue
+        totals["regions"] += 1
+        totals["subjects"] += evaluation.subjects_evaluated
+        totals["events"] += len(evaluation.events)
+        totals["litellm_calls"] += evaluation.litellm_calls
+        budget_alert_subjects_evaluated.labels(region_name=region.name).set(
+            evaluation.subjects_evaluated
+        )
+        for event in evaluation.events:
+            budget_alerts_fired_total.labels(
+                scope=event.subject_type, threshold=str(event.threshold_pct)
+            ).inc()
+
+        # Silent rewrites are unconditional: they carry no notification, so
+        # holding them back would only cause a stale band to suppress a later
+        # genuine crossing.
+        apply_resets(db, region, evaluation)
+
+        if not evaluation.events:
+            continue
+
+        for event in evaluation.events:
+            logger.info(
+                "Budget threshold crossed: scope=%s subject=%s %.2f%% "
+                "(spend=%.4f budget=%.4f) band=%d%% region=%s",
+                event.subject_type,
+                event.subject_key,
+                event.percent_used,
+                event.spend,
+                event.max_budget,
+                event.threshold_pct,
+                event.region_name,
+            )
+
+        if not settings.BUDGET_ALERT_ENABLED:
+            # Log-only mode: percentages can be validated against the spend API
+            # before any third party is told anything. State is left untouched so
+            # enabling delivery later still sends these crossings.
+            continue
+
+        delivered = await deliver_events(evaluation.events)
+        totals["delivered"] += len(delivered)
+        undelivered = len(evaluation.events) - len(delivered)
+        if undelivered > 0:
+            budget_alert_delivery_failures_total.inc(undelivered)
+        mark_notified(db, region, evaluation, delivered)
+
+    logger.info(
+        "Budget threshold sweep finished: regions=%d subjects=%d events=%d "
+        "delivered=%d litellm_calls=%d",
+        totals["regions"],
+        totals["subjects"],
+        totals["events"],
+        totals["delivered"],
+        totals["litellm_calls"],
+    )
+    return totals

--- a/app/core/budget_alert_service.py
+++ b/app/core/budget_alert_service.py
@@ -64,12 +64,17 @@ from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.core.pool_budget_service import pool_available_budget_for_team_region
-from app.core.spend_period_service import TeamPeriodWindow, resolve_team_period_window
+from app.core.spend_period_service import (
+    TeamPeriodWindow,
+    current_cycle_start,
+    resolve_team_period_window,
+)
 from app.db.models import (
     DBAuditLog,
     DBBudgetAlertState,
     DBLimitedResource,
     DBPeriodicBudgetLedgerEntry,
+    DBPeriodicPayment,
     DBPrivateAIKey,
     DBRegion,
     DBSpendCap,
@@ -235,14 +240,59 @@ def _active_entity_ids(rows: list[dict]) -> set[str]:
     return entity_ids
 
 
+def _day_series(
+    rows: list[dict],
+) -> tuple[dict[str, dict[date, float]], dict[str, dict[date, float]]]:
+    """Index per-day activity by entity and by hashed key.
+
+    Kept as a series rather than pre-summed because subjects do not share a
+    window: a team is measured over its billing cycle while a capped key is
+    measured over that cap's own cycle. One pass over the rows, then each subject
+    sums the days its own window covers.
+    """
+    entity_days: dict[str, dict[date, float]] = {}
+    key_days: dict[str, dict[date, float]] = {}
+
+    for row in rows:
+        raw_date = row.get("date")
+        try:
+            row_date = date.fromisoformat(str(raw_date)[:10])
+        except (TypeError, ValueError):
+            logger.warning("Skipping daily-activity row with bad date: %r", raw_date)
+            continue
+
+        breakdown = row.get("breakdown") or {}
+        for entity_id, payload in (breakdown.get("entities") or {}).items():
+            metrics = (payload or {}).get("metrics") or {}
+            bucket = entity_days.setdefault(entity_id, {})
+            bucket[row_date] = bucket.get(row_date, 0.0) + float(
+                metrics.get("spend") or 0.0
+            )
+        for hashed_token, payload in (breakdown.get("api_keys") or {}).items():
+            metrics = (payload or {}).get("metrics") or {}
+            bucket = key_days.setdefault(hashed_token, {})
+            bucket[row_date] = bucket.get(row_date, 0.0) + float(
+                metrics.get("spend") or 0.0
+            )
+
+    return entity_days, key_days
+
+
+def _sum_from(series: dict[date, float] | None, since: date) -> float:
+    """Total the days at or after ``since``.
+
+    Rows are whole UTC days, so a window opening mid-day includes that whole day —
+    an overstatement bounded by one day.
+    """
+    if not series:
+        return 0.0
+    return sum(value for day, value in series.items() if day >= since)
+
+
 def _sum_activity_since(
     rows: list[dict], since: date
 ) -> tuple[dict[str, float], dict[str, float]]:
-    """Sum per-day activity from ``since`` onwards, by entity and by hashed key.
-
-    Returns ``(entity_spend, key_spend)``. Rows are one per UTC day, so a window
-    opening mid-day includes that whole day — an overstatement bounded by one day.
-    """
+    """Sum per-day activity from ``since`` onwards, by entity and by hashed key."""
     entity_spend: dict[str, float] = {}
     key_spend: dict[str, float] = {}
 
@@ -381,12 +431,42 @@ def _team_budget(db: Session, team: DBTeam, region_id: int) -> float | None:
     return available if available > 0 else None
 
 
+def _cap_cycle_anchor(db: Session, team: DBTeam) -> datetime | None:
+    """Where a rolling ``Nd`` cap cycle is anchored for this team.
+
+    Mirrors ``app/api/spend.py``: the most recent completed deactivation payment,
+    else team creation. Using the same anchor as the endpoint the customer reads
+    is the point — a cap percentage that disagrees with the dashboard is worse
+    than no alert.
+    """
+    last_deactivation = (
+        db.query(DBPeriodicPayment.payment_date)
+        .filter(
+            DBPeriodicPayment.team_id == team.id,
+            DBPeriodicPayment.payment_type == "deactivation",
+            DBPeriodicPayment.status == "completed",
+        )
+        .order_by(DBPeriodicPayment.payment_date.desc())
+        .first()
+    )
+    anchor = (last_deactivation[0] if last_deactivation else None) or team.created_at
+    if anchor is not None and anchor.tzinfo is None:
+        anchor = anchor.replace(tzinfo=UTC)
+    return anchor
+
+
 def _member_budget(
     db: Session, team_id: int, user_id: int, region_id: int
-) -> float | None:
-    """Per-member budget: the team-member cap, else the user's BUDGET limit."""
+) -> tuple[float | None, str | None]:
+    """Per-member budget and the cycle it applies to.
+
+    The team-member cap wins, else the user's BUDGET limit. The cap carries a
+    duration (every one on PROD is ``1mo``) because it is a per-cycle allowance;
+    the BUDGET limit is absolute and returns ``None`` for the duration, so the
+    caller measures it over the team's cycle instead.
+    """
     cap = (
-        db.query(DBSpendCap.max_budget)
+        db.query(DBSpendCap.max_budget, DBSpendCap.budget_duration)
         .filter(
             DBSpendCap.scope == "team_member",
             DBSpendCap.region_id == region_id,
@@ -394,10 +474,11 @@ def _member_budget(
             DBSpendCap.user_id == user_id,
             DBSpendCap.max_budget.isnot(None),
         )
-        .scalar()
+        .first()
     )
-    if cap is not None:
-        return float(cap) if float(cap) > 0 else None
+    if cap is not None and cap[0] is not None:
+        value = float(cap[0])
+        return (value, cap[1]) if value > 0 else (None, None)
 
     limit_value = (
         db.query(DBLimitedResource.max_value)
@@ -409,15 +490,17 @@ def _member_budget(
         .scalar()
     )
     if limit_value and float(limit_value) > 0:
-        return float(limit_value)
-    return None
+        return float(limit_value), None
+    return None, None
 
 
-def _key_cap_map(db: Session, region_id: int, key_ids: list[int]) -> dict[int, float]:
+def _key_cap_map(
+    db: Session, region_id: int, key_ids: list[int]
+) -> dict[int, tuple[float, str | None]]:
     if not key_ids:
         return {}
     rows = (
-        db.query(DBSpendCap.key_id, DBSpendCap.max_budget)
+        db.query(DBSpendCap.key_id, DBSpendCap.max_budget, DBSpendCap.budget_duration)
         .filter(
             DBSpendCap.scope == "key",
             DBSpendCap.region_id == region_id,
@@ -426,7 +509,14 @@ def _key_cap_map(db: Session, region_id: int, key_ids: list[int]) -> dict[int, f
         )
         .all()
     )
-    return {int(key_id): float(value) for key_id, value in rows if value}
+    # The duration comes along because a cap is a per-cycle allowance, so it
+    # determines the window its percentage must be measured over, not just the
+    # number to divide by.
+    return {
+        int(key_id): (float(value), duration)
+        for key_id, value, duration in rows
+        if value
+    }
 
 
 # --------------------------------------------------------------------------- #
@@ -647,7 +737,7 @@ async def evaluate_region(
         team_budget = _team_budget(db, team, region.id)
 
         if since >= sweep_start:
-            entity_totals, key_totals = _sum_activity_since(team_rows, since)
+            entity_days, key_days = _day_series(team_rows)
         elif not (team_budget or cap_map):
             # Nothing to measure, so nothing to fetch. A POOL team with no valid
             # ledger entry anchors on team.created_at, which is routinely older than
@@ -693,7 +783,7 @@ async def evaluate_region(
                     reason="activity_backfill_failed"
                 ).inc()
                 continue
-            entity_totals, key_totals = _sum_activity_since(scoped_rows, since)
+            entity_days, key_days = _day_series(scoped_rows)
 
         # /key/list supplies the key *denominators* (max_budget) and flags keys being
         # expired; its spend figures are deliberately not used.
@@ -713,23 +803,27 @@ async def evaluate_region(
         # percentages are always drawn from the same numbers.
         team_spend = 0.0
 
+        # Anchor for a cap whose cycle is a rolling "Nd": the same one the spend
+        # API uses, so the alert and the dashboard agree on where the cycle began.
+        cap_anchor = _cap_cycle_anchor(db, team)
+
         for db_key in db_keys:
             hashed = LiteLLMService.hash_token(db_key.litellm_token)
             key_state = exact_keys.get(hashed)
-            key_spend = float(key_totals.get(hashed, 0.0))
             litellm_max_budget = (
                 key_state.get("max_budget") if key_state is not None else None
             )
 
             # Money a key spent counts towards its team and its owner whatever the
-            # key's own state, so these totals are accumulated before any of the
-            # per-key skips below. Dropping an expiring key's spend here would
-            # understate the team percentage and make the reconciliation warning
-            # further down fire on a gap that does not exist.
-            team_spend += key_spend
+            # key's own state, so these totals are accumulated over the *team's*
+            # cycle before any of the per-key skips below. Dropping an expiring
+            # key's spend here would understate the team percentage and make the
+            # reconciliation warning further down fire on a gap that does not exist.
+            team_cycle_spend = _sum_from(key_days.get(hashed), since)
+            team_spend += team_cycle_spend
             if db_key.owner_id:
                 member_spend[db_key.owner_id] = (
-                    member_spend.get(db_key.owner_id, 0.0) + key_spend
+                    member_spend.get(db_key.owner_id, 0.0) + team_cycle_spend
                 )
 
             if key_state is not None and _is_expiring(key_state):
@@ -741,10 +835,17 @@ async def evaluate_region(
             # then the team pool. Applies equally to service keys (no owner) and
             # user keys — a key is in scope for having a team, not for having an
             # owner. On PROD: 405 service and 929 user keys across POOL teams.
-            key_budget = cap_map.get(db_key.id)
+            cap_entry = cap_map.get(db_key.id)
+            key_budget: float | None = None
+            cap_duration: str | None = None
             budget_source = "key_cap"
+            if cap_entry is not None:
+                key_budget, cap_duration = cap_entry
             if key_budget is None and litellm_max_budget is not None:
                 key_budget = float(litellm_max_budget)
+                cap_duration = (
+                    key_state.get("budget_duration") if key_state is not None else None
+                )
                 budget_source = "litellm_key_budget"
             if not key_budget or key_budget <= 0:
                 # A budget of <= 0 is how a pool-gated key is born blocked;
@@ -753,9 +854,34 @@ async def evaluate_region(
                 if litellm_max_budget is not None and float(litellm_max_budget) <= 0:
                     continue
                 key_budget = pool_fallback_budget
+                cap_duration = None
                 budget_source = "team_pool"
             if not key_budget or key_budget <= 0:
                 continue
+
+            # A cap is an allowance *per cycle*, so its percentage is measured over
+            # that cycle. Every cap on PROD is 31d or 1mo, and LiteLLM zeroes the
+            # key's spend at each boundary; dividing the team's longer cycle of
+            # spend by a one-month cap would read far above 100 % and alert on
+            # nothing. A key bounded by the pool has no cycle of its own and keeps
+            # the team's window.
+            key_window = window
+            key_since = since
+            if cap_duration:
+                cap_start = current_cycle_start(cap_duration, cap_anchor, now)
+                if cap_start is not None:
+                    key_since = cap_start.date()
+                    key_window = TeamPeriodWindow(
+                        period_start=cap_start,
+                        period_end=None,
+                        budget_duration=cap_duration,
+                        source=f"key_cap:{cap_duration}",
+                    )
+            key_spend = (
+                team_cycle_spend
+                if key_since == since
+                else _sum_from(key_days.get(hashed), key_since)
+            )
 
             subjects.append(
                 _Subject(
@@ -763,7 +889,7 @@ async def evaluate_region(
                     subject_key=f"key:{db_key.id}",
                     spend=key_spend,
                     max_budget=key_budget,
-                    window=window,
+                    window=key_window,
                     team=team,
                     key=db_key,
                     budget_source=budget_source,
@@ -773,7 +899,7 @@ async def evaluate_region(
         # The entity total covers every key LiteLLM attributes to the team, including
         # any we do not have a row for. A gap means our key table is out of sync, and
         # the team percentage would be understated, so it is worth saying so.
-        entity_total = float(entity_totals.get(lite_team_id, 0.0))
+        entity_total = _sum_from(entity_days.get(lite_team_id), since)
         if entity_total - team_spend > 0.01:
             logger.warning(
                 "Team %s region %s: LiteLLM attributes %.4f but our keys account for "
@@ -801,14 +927,43 @@ async def evaluate_region(
             users = (
                 db.query(DBUser).filter(DBUser.id.in_(list(member_spend.keys()))).all()
             )
+            owned_keys: dict[int, list[str]] = {}
+            for db_key in db_keys:
+                if db_key.owner_id:
+                    owned_keys.setdefault(db_key.owner_id, []).append(
+                        LiteLLMService.hash_token(db_key.litellm_token)
+                    )
+
             for user in users:
+                member_budget, member_duration = _member_budget(
+                    db, team.id, user.id, region.id
+                )
+                # Same rule as for key caps: a team-member cap is a per-cycle
+                # allowance (all 38 on PROD are 1mo), so it is measured over its own
+                # cycle. A plain USER BUDGET limit is absolute and keeps the team's.
+                member_window = window
+                member_total = member_spend.get(user.id, 0.0)
+                if member_duration:
+                    cap_start = current_cycle_start(member_duration, cap_anchor, now)
+                    if cap_start is not None:
+                        member_since = cap_start.date()
+                        member_total = sum(
+                            _sum_from(key_days.get(hashed), member_since)
+                            for hashed in owned_keys.get(user.id, [])
+                        )
+                        member_window = TeamPeriodWindow(
+                            period_start=cap_start,
+                            period_end=None,
+                            budget_duration=member_duration,
+                            source=f"member_cap:{member_duration}",
+                        )
                 subjects.append(
                     _Subject(
                         subject_type=SUBJECT_TEAM_MEMBER,
                         subject_key=f"member:{team.id}:{user.id}:{region.id}",
-                        spend=member_spend.get(user.id, 0.0),
-                        max_budget=_member_budget(db, team.id, user.id, region.id),
-                        window=window,
+                        spend=member_total,
+                        max_budget=member_budget,
+                        window=member_window,
                         team=team,
                         user=user,
                     )

--- a/app/core/budget_alert_service.py
+++ b/app/core/budget_alert_service.py
@@ -4,6 +4,12 @@ Emits an event when a team, key or team member crosses 50 / 75 / 90 / 100 % of
 its budget, so a downstream consumer (MOAD) can warn the customer *before* their
 keys stop working.
 
+Scope: **POOL teams**, and keys carrying both a team and a region — the shape MOAD
+provisions and can actually notify. PERIODIC is excluded because on PROD every
+PERIODIC key (12,098 of them) belongs to the single anonymous Drupal trial team,
+which has no MOAD workspace and no addressable owner. Note that the *period-window
+helper* still handles PERIODIC, since the spend API shares it.
+
 Why amazee.ai computes the percentage instead of LiteLLM
 -------------------------------------------------------
 LiteLLM has native budget alerting, but it cannot produce the right number for
@@ -23,14 +29,18 @@ So LiteLLM is the source of *spend*, and every budget number comes from our DB.
 
 How it scales to 100k keys
 --------------------------
-Spend is read from ``/team/daily/activity`` and ``/user/daily/activity`` with no
-entity filter — two calls per region, regardless of key count. LiteLLM only
-writes daily-spend rows for entities that actually spent, so the cost tracks
-*active* entities rather than total keys. Enumerating every key instead (the
-shape of the existing hourly reconciler) is what does not survive 100k.
+Two stages, both bounded by *activity* rather than by key count:
 
-The one place we still enumerate keys is a scoped ``/key/list?team_id=`` for a
-team we have already decided is worth confirming — see ``_exact_team_key_state``.
+1. **Discovery** — one unfiltered ``/team/daily/activity`` call per region tells us
+   which teams spent anything. LiteLLM writes no daily rows for idle entities, so
+   on PROD region 5 an 11,859-key region reported 42 active teams in one 1.68 s
+   page. Only entity *ids* are used from this; see ``_active_entity_ids``.
+2. **Measurement** — one scoped ``/key/list?team_id=`` per candidate team gives
+   exact ``spend`` and ``max_budget`` for that team's keys.
+
+So a tick costs ``1 + active_teams`` calls per region, independent of how many idle
+keys exist. Sweeping every key instead — the shape of the existing hourly
+reconciler, ~40 min at 13.9k keys — is what does not survive 100k.
 """
 
 from __future__ import annotations
@@ -42,16 +52,17 @@ from dataclasses import dataclass, field
 from datetime import UTC, date, datetime, timedelta
 
 from prometheus_client import Counter, Gauge, Summary
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.core.pool_budget_service import pool_available_budget_for_team_region
 from app.core.spend_period_service import TeamPeriodWindow, resolve_team_period_window
-from app.core.team_service import get_team_region_litellm_keys
 from app.db.models import (
     DBAuditLog,
     DBBudgetAlertState,
     DBLimitedResource,
+    DBPeriodicBudgetLedgerEntry,
     DBPrivateAIKey,
     DBRegion,
     DBSpendCap,
@@ -143,12 +154,16 @@ class BudgetAlertEvent:
     period_start: datetime | None
     period_end: datetime | None
     budget_duration: str | None
+    budget_source: str = "team_ledger"
     team_id: int | None = None
     team_name: str | None = None
     user_id: int | None = None
     user_email: str | None = None
     key_id: int | None = None
     key_name: str | None = None
+    # Service keys belong to the team itself; user keys have an owner. Both are in
+    # scope, and consumers route the notification differently for each.
+    is_service_key: bool = False
 
 
 @dataclass
@@ -163,6 +178,9 @@ class _Subject:
     team: DBTeam | None = None
     user: DBUser | None = None
     key: DBPrivateAIKey | None = None
+    # Where the denominator came from. Consumers need this to word the message:
+    # "90% of this key's limit" and "90% of the team pool" are different sentences.
+    budget_source: str = "team_ledger"
 
     @property
     def percent_used(self) -> float:
@@ -195,22 +213,25 @@ class RegionEvaluation:
 # --------------------------------------------------------------------------- #
 
 
-def _sum_activity_by_entity(
-    rows: list[dict], since: date | None
-) -> tuple[dict[str, float], dict[str, float], date | None]:
-    """Fold daily-activity rows into per-entity and per-key spend totals.
+def _active_entity_ids(rows: list[dict]) -> set[str]:
+    """Entity ids that appear anywhere in a daily-activity sweep (discovery)."""
+    entity_ids: set[str] = set()
+    for row in rows:
+        breakdown = row.get("breakdown") or {}
+        entity_ids.update((breakdown.get("entities") or {}).keys())
+    return entity_ids
 
-    ``rows`` is one entry per UTC day. Days before ``since`` are skipped so each
-    team is only credited with spend inside its own billing window, even though
-    a single sweep covers every team's window at once.
 
-    Returns ``(entity_spend, key_spend, earliest_day_seen)``. The third value
-    lets the caller tell whether the sweep actually reached back to the start of
-    a window, or whether the total it just computed is partial.
+def _sum_activity_since(
+    rows: list[dict], since: date
+) -> tuple[dict[str, float], dict[str, float]]:
+    """Sum per-day activity from ``since`` onwards, by entity and by hashed key.
+
+    Returns ``(entity_spend, key_spend)``. Rows are one per UTC day, so a window
+    opening mid-day includes that whole day — an overstatement bounded by one day.
     """
     entity_spend: dict[str, float] = {}
     key_spend: dict[str, float] = {}
-    earliest: date | None = None
 
     for row in rows:
         raw_date = row.get("date")
@@ -219,10 +240,8 @@ def _sum_activity_by_entity(
         except (TypeError, ValueError):
             logger.warning("Skipping daily-activity row with bad date: %r", raw_date)
             continue
-        if since is not None and row_date < since:
+        if row_date < since:
             continue
-        if earliest is None or row_date < earliest:
-            earliest = row_date
 
         breakdown = row.get("breakdown") or {}
         for entity_id, payload in (breakdown.get("entities") or {}).items():
@@ -236,7 +255,49 @@ def _sum_activity_by_entity(
                 metrics.get("spend") or 0.0
             )
 
-    return entity_spend, key_spend, earliest
+    return entity_spend, key_spend
+
+
+def spend_window_start(
+    db: Session, team: DBTeam, region_id: int, now: datetime
+) -> datetime:
+    """When the spend that counts against the *current* budget began.
+
+    This is the purchase date of the **oldest still-valid** ledger entry, and it is
+    the crux of getting top-up-only POOL teams right.
+
+    A top-up never resets key spend — ``purchase_periodic_topup`` only raises the
+    team's ``max_budget`` — so LiteLLM's key counters are lifetime totals. The
+    denominator, meanwhile, counts only entries that have not expired. Divide one by
+    the other and an expired top-up leaves its spend in the numerator while its
+    money has left the denominator:
+
+        $100 expired (of which $80 spent) + $100 just bought
+        lifetime spend $82 / remaining $100  ->  82%   (wrong)
+        spend since the valid entry $2 / $100 ->  2%   (right)
+
+    Anchoring on the oldest *valid* entry rather than the newest purchase is what
+    makes both directions correct: money bought earlier but still valid keeps its
+    spend counted, while money that has expired takes its spend with it.
+    """
+    oldest_valid = (
+        db.query(func.min(DBPeriodicBudgetLedgerEntry.purchased_at))
+        .filter(
+            DBPeriodicBudgetLedgerEntry.team_id == team.id,
+            DBPeriodicBudgetLedgerEntry.region_id == region_id,
+            DBPeriodicBudgetLedgerEntry.is_active.is_(True),
+            DBPeriodicBudgetLedgerEntry.purchased_at.isnot(None),
+            (
+                DBPeriodicBudgetLedgerEntry.expires_at.is_(None)
+                | (DBPeriodicBudgetLedgerEntry.expires_at > now)
+            ),
+        )
+        .scalar()
+    )
+    anchor = oldest_valid or team.created_at or now
+    if anchor.tzinfo is None:
+        anchor = anchor.replace(tzinfo=UTC)
+    return anchor
 
 
 def _amazee_team_id_from_litellm(entity_id: str, region_name: str) -> int | None:
@@ -374,15 +435,77 @@ def _sweep_start(now: datetime) -> date:
     return (now - timedelta(days=settings.BUDGET_ALERT_MAX_LOOKBACK_DAYS)).date()
 
 
-def _window_since(window: TeamPeriodWindow, sweep_start: date) -> date:
-    if window.period_start is None:
-        return sweep_start
-    return max(window.period_start.date(), sweep_start)
-
-
 def _is_expiring(key_state: dict) -> bool:
     """A key set to ``0d`` is being expired; it is not a budget problem."""
     return str(key_state.get("budget_duration") or "") == "0d"
+
+
+def denominator_change_candidates(
+    db: Session, region_id: int, now: datetime
+) -> set[int]:
+    """Teams whose *budget* just fell, regardless of whether they spent anything.
+
+    Traffic-driven discovery rests on "percent only rises when spend rises", which
+    is false: the denominator moves too. On PROD every active ledger entry carries
+    an ``expires_at`` (321 of them due to expire), so a lapsing top-up or
+    subscription drops a team's remaining budget and can push it past 90 % while
+    it sits completely idle. Such a team produces no daily-activity rows, so
+    without this it would never be looked at and the warning would never fire —
+    the exact scenario the feature exists to prevent.
+
+    Two sources, both cheap because they are bounded by *changes* rather than by
+    team count:
+
+    * a ledger entry that expired within the recheck grace window;
+    * a spend cap edited within the same window (lowering a cap shrinks the
+      denominator just as effectively as an expiry).
+
+    The grace window spans several ticks on purpose. Re-notification is not a risk
+    — ``budget_alert_state`` suppresses a band already sent — so it is better to
+    look a few times too often than to miss the one tick the change landed in.
+    """
+    grace_hours = max(1, settings.BUDGET_ALERT_RECHECK_GRACE_HOURS)
+    since = now - timedelta(hours=grace_hours)
+
+    expired_team_ids = {
+        team_id
+        for (team_id,) in db.query(DBPeriodicBudgetLedgerEntry.team_id)
+        .filter(
+            DBPeriodicBudgetLedgerEntry.region_id == region_id,
+            DBPeriodicBudgetLedgerEntry.expires_at.isnot(None),
+            DBPeriodicBudgetLedgerEntry.expires_at <= now,
+            DBPeriodicBudgetLedgerEntry.expires_at >= since,
+        )
+        .distinct()
+        .all()
+        if team_id is not None
+    }
+
+    capped_team_ids = {
+        team_id
+        for (team_id,) in db.query(DBSpendCap.team_id)
+        .filter(
+            DBSpendCap.region_id == region_id,
+            DBSpendCap.team_id.isnot(None),
+            DBSpendCap.updated_at.isnot(None),
+            DBSpendCap.updated_at >= since,
+        )
+        .distinct()
+        .all()
+        if team_id is not None
+    }
+
+    candidates = expired_team_ids | capped_team_ids
+    if candidates:
+        logger.info(
+            "Region %s: %d team(s) rechecked for a budget decrease "
+            "(%d expiry, %d cap change)",
+            region_id,
+            len(candidates),
+            len(expired_team_ids),
+            len(capped_team_ids),
+        )
+    return candidates
 
 
 async def evaluate_region(
@@ -407,11 +530,8 @@ async def evaluate_region(
     end_str = now.date().isoformat()
 
     try:
-        team_rows, user_rows = await asyncio.gather(
-            service.get_all_team_daily_activity(start_str, end_str),
-            service.get_all_user_daily_activity(start_str, end_str),
-        )
-        result.litellm_calls += 2
+        team_rows = await service.get_all_team_daily_activity(start_str, end_str)
+        result.litellm_calls += 1
     except Exception as exc:
         logger.error("Budget alert sweep failed for region %s: %s", region.name, exc)
         return result
@@ -423,93 +543,123 @@ async def evaluate_region(
     # working set: on a DEV region with 2,740 keys it was 27 teams. A team with
     # no traffic in the lookback cannot have newly crossed a band, since spend
     # only rises with traffic and we notify on upward moves only.
-    team_totals_all, _, _ = _sum_activity_by_entity(team_rows, None)
     candidate_team_ids = {
         team_id
-        for entity_id in team_totals_all
+        for entity_id in _active_entity_ids(team_rows)
         if (team_id := _amazee_team_id_from_litellm(entity_id, region.name)) is not None
     }
 
-    # A key owned by a user but not attached to a LiteLLM team contributes no
-    # team entity, so its team would be invisible above. The user sweep closes
-    # that gap: active user ids map back to their team.
-    active_user_totals, _, _ = _sum_activity_by_entity(user_rows, None)
-    active_user_ids = [
-        int(user_id) for user_id in active_user_totals if str(user_id).isdigit()
-    ]
-    if active_user_ids:
-        candidate_team_ids.update(
-            team_id
-            for (team_id,) in db.query(DBUser.team_id)
-            .filter(DBUser.id.in_(active_user_ids), DBUser.team_id.isnot(None))
-            .distinct()
-            .all()
-        )
+    # Traffic is not the only way to cross a threshold: percent = spend / budget,
+    # and the *budget* can fall on its own. These teams therefore have to be
+    # evaluated even though they were silent.
+    denominator_change_team_ids = denominator_change_candidates(db, region.id, now)
+    candidate_team_ids.update(denominator_change_team_ids)
 
     if not candidate_team_ids:
         logger.info("No active teams in region %s this sweep", region.name)
         return result
 
+    # POOL only. These are the teams MOAD provisions and can actually notify —
+    # every PERIODIC key on PROD (12,098 of them) belongs to the single anonymous
+    # Drupal trial team, which has no MOAD workspace and no addressable owner, so
+    # a threshold webhook for it would have nowhere to go.
     teams = (
         db.query(DBTeam)
-        .filter(DBTeam.id.in_(candidate_team_ids), DBTeam.deleted_at.is_(None))
+        .filter(
+            DBTeam.id.in_(candidate_team_ids),
+            DBTeam.deleted_at.is_(None),
+            DBTeam.budget_type == BudgetType.POOL,
+        )
         .all()
     )
     for team in teams:
         window = resolve_team_period_window(db, team, region.id, now=now)
-        since = _window_since(window, sweep_start)
-        team_totals, key_totals, _ = _sum_activity_by_entity(team_rows, since)
         lite_team_id = LiteLLMService.format_team_id(region.name, team.id)
 
-        # Whole-UTC-day granularity and a lookback shorter than the window both
-        # make the swept total partial. POOL windows run for
-        # POOL_PURCHASE_EXPIRY_DAYS (365 by default), well past the lookback, so
-        # for those we take LiteLLM's live key spend instead: a pool window never
-        # resets, so key spend *is* the window total.
-        window_predates_sweep = (
-            window.period_start is not None and window.period_start.date() < sweep_start
-        )
-        needs_exact_keys = window_predates_sweep or team.budget_type != BudgetType.POOL
-        exact_keys = (
-            await _exact_team_key_state(service, lite_team_id)
-            if needs_exact_keys
-            else {}
-        )
-        if exact_keys:
-            result.litellm_calls += 1
+        # Spend is summed from the purchase date of the oldest still-valid ledger
+        # entry — NOT taken from LiteLLM's key counters, which are lifetime totals a
+        # top-up never resets. See spend_window_start for why that distinction
+        # decides whether an expired top-up corrupts the percentage.
+        since_dt = spend_window_start(db, team, region.id, now)
+        since = since_dt.date()
+        if since < sweep_start:
+            logger.warning(
+                "Team %s spend window opens %s, before the %s sweep start; "
+                "percentage may be understated. Raise BUDGET_ALERT_MAX_LOOKBACK_DAYS.",
+                team.id,
+                since,
+                sweep_start,
+            )
+        entity_totals, key_totals = _sum_activity_since(team_rows, since)
 
-        # Includes keys owned by team members but not attached to the team, which
-        # is the same ownership rule the spend API and the billing cycle use.
-        db_keys = get_team_region_litellm_keys(db, team_id=team.id, region_id=region.id)
+        # /key/list supplies the key *denominators* (max_budget) and flags keys being
+        # expired; its spend figures are deliberately not used.
+        exact_keys = await _exact_team_key_state(service, lite_team_id)
+        result.litellm_calls += 1
+
+        # Only keys carrying both a team and a region — the shape MOAD provisions.
+        # A key with just an owner and no team has no team budget to be a share of,
+        # and no workspace to notify, so it is out of scope by design rather than
+        # by omission. On PROD that is 418 of 13,930 keys.
+        db_keys = (
+            db.query(DBPrivateAIKey)
+            .filter(
+                DBPrivateAIKey.team_id == team.id,
+                DBPrivateAIKey.region_id == region.id,
+                DBPrivateAIKey.litellm_token.isnot(None),
+            )
+            .all()
+        )
         cap_map = _key_cap_map(db, region.id, [key.id for key in db_keys])
+        team_budget = _team_budget(db, team, region.id)
 
-        team_spend = float(team_totals.get(lite_team_id, 0.0))
+        # An uncapped key's only budget is the team pool, so that is what it is
+        # measured against — it answers "which key is eating the pool", which the
+        # team event alone cannot. Withheld when the team has a single in-scope key,
+        # because then the key percentage is arithmetically identical to the team's
+        # and the alert would just be the team event repeated. That is the common
+        # shape: 481 of 739 POOL teams on PROD hold exactly one key.
+        pool_fallback_budget = team_budget if len(db_keys) > 1 else None
+
         member_spend: dict[int, float] = {}
+        # The team total is the sum of its keys' windowed spend, so team and key
+        # percentages are always drawn from the same numbers.
+        team_spend = 0.0
 
         for db_key in db_keys:
             hashed = LiteLLMService.hash_token(db_key.litellm_token)
             key_state = exact_keys.get(hashed)
-            if key_state is not None:
-                if _is_expiring(key_state):
-                    continue
-                key_spend = float(key_state.get("spend") or 0.0)
-                litellm_max_budget = key_state.get("max_budget")
-            else:
-                key_spend = float(key_totals.get(hashed, 0.0))
-                litellm_max_budget = None
+            if key_state is not None and _is_expiring(key_state):
+                # Being expired via budget_duration "0d"; not a budget warning.
+                continue
+            key_spend = float(key_totals.get(hashed, 0.0))
+            litellm_max_budget = (
+                key_state.get("max_budget") if key_state is not None else None
+            )
+            team_spend += key_spend
 
             if db_key.owner_id:
                 member_spend[db_key.owner_id] = (
                     member_spend.get(db_key.owner_id, 0.0) + key_spend
                 )
 
-            # A DB cap wins; otherwise fall back to what LiteLLM enforces.
+            # Denominator precedence: our own cap, then whatever LiteLLM enforces,
+            # then the team pool. Applies equally to service keys (no owner) and
+            # user keys — a key is in scope for having a team, not for having an
+            # owner. On PROD: 405 service and 929 user keys across POOL teams.
             key_budget = cap_map.get(db_key.id)
+            budget_source = "key_cap"
             if key_budget is None and litellm_max_budget is not None:
                 key_budget = float(litellm_max_budget)
-            # max_budget of 0 is how a pool-gated key is born blocked. Alerting
-            # 100 % at creation would be pure noise, so an absent or
-            # non-positive budget means "no key-level threshold".
+                budget_source = "litellm_key_budget"
+            if not key_budget or key_budget <= 0:
+                # A budget of <= 0 is how a pool-gated key is born blocked;
+                # reporting it as "100% used" at creation would be pure noise.
+                # An absent budget instead means the key is bounded by the pool.
+                if litellm_max_budget is not None and float(litellm_max_budget) <= 0:
+                    continue
+                key_budget = pool_fallback_budget
+                budget_source = "team_pool"
             if not key_budget or key_budget <= 0:
                 continue
 
@@ -522,16 +672,23 @@ async def evaluate_region(
                     window=window,
                     team=team,
                     key=db_key,
+                    budget_source=budget_source,
                 )
             )
 
-        if exact_keys:
-            # Prefer the live sum for the team as well, so the team percentage and
-            # its keys' percentages are drawn from the same numbers.
-            team_spend = sum(
-                float(state.get("spend") or 0.0)
-                for state in exact_keys.values()
-                if not _is_expiring(state)
+        # The entity total covers every key LiteLLM attributes to the team, including
+        # any we do not have a row for. A gap means our key table is out of sync, and
+        # the team percentage would be understated, so it is worth saying so.
+        entity_total = float(entity_totals.get(lite_team_id, 0.0))
+        if entity_total - team_spend > 0.01:
+            logger.warning(
+                "Team %s region %s: LiteLLM attributes %.4f but our keys account for "
+                "%.4f; %.4f of spend belongs to keys missing from ai_tokens",
+                team.id,
+                region.id,
+                entity_total,
+                team_spend,
+                entity_total - team_spend,
             )
 
         subjects.append(
@@ -539,7 +696,7 @@ async def evaluate_region(
                 subject_type=SUBJECT_TEAM,
                 subject_key=f"team:{team.id}:{region.id}",
                 spend=team_spend,
-                max_budget=_team_budget(db, team, region.id),
+                max_budget=team_budget,
                 window=window,
                 team=team,
             )
@@ -625,12 +782,14 @@ def _build_event(
         period_start=subject.window.period_start,
         period_end=subject.window.period_end,
         budget_duration=subject.window.budget_duration,
+        budget_source=subject.budget_source,
         team_id=subject.team.id if subject.team else None,
         team_name=subject.team.name if subject.team else None,
         user_id=subject.user.id if subject.user else None,
         user_email=subject.user.email if subject.user else None,
         key_id=subject.key.id if subject.key else None,
         key_name=subject.key.name if subject.key else None,
+        is_service_key=(subject.key is not None and subject.key.owner_id is None),
     )
 
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -125,11 +125,21 @@ class Settings(BaseSettings):
     BUDGET_ALERT_REGION_CONCURRENCY: int = int(
         os.getenv("BUDGET_ALERT_REGION_CONCURRENCY", "4")
     )
-    # How far back the daily-activity sweep looks when a period has no resolvable
-    # start. Also bounds the window for very long POOL periods, since a 365d
-    # sweep would return a year of daily rows for no benefit.
+    # How far back the daily-activity sweep reaches. It must cover the oldest
+    # still-valid ledger entry, because spend is counted from that entry's purchase
+    # date — a shorter window understates the percentage. POOL entries live for
+    # POOL_PURCHASE_EXPIRY_DAYS (365), so the default clears that with margin. The
+    # cost is one extra day-row per day, all within a single page.
     BUDGET_ALERT_MAX_LOOKBACK_DAYS: int = int(
-        os.getenv("BUDGET_ALERT_MAX_LOOKBACK_DAYS", "62")
+        os.getenv("BUDGET_ALERT_MAX_LOOKBACK_DAYS", "370")
+    )
+    # How long a budget *decrease* (an expired ledger entry, an edited spend cap)
+    # keeps a team in the recheck set. A decrease raises the percentage without any
+    # traffic, so such a team would otherwise never be looked at. Spans several
+    # ticks deliberately: alert state prevents re-notification, so looking too
+    # often is harmless where missing the one relevant tick is not.
+    BUDGET_ALERT_RECHECK_GRACE_HOURS: int = int(
+        os.getenv("BUDGET_ALERT_RECHECK_GRACE_HOURS", "24")
     )
 
     PROMETHEUS_API_KEY: str = os.getenv("PROMETHEUS_API_KEY", "")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -104,6 +104,34 @@ class Settings(BaseSettings):
     SIGNUP_EVENTS_RETENTION_DAYS: int = int(
         os.getenv("SIGNUP_EVENTS_RETENTION_DAYS", "7")
     )
+    # --- Budget threshold alerts (AI-448) ---
+    # Off by default: enabling it starts sending webhooks to a third party, so it
+    # must be an explicit per-environment decision.
+    BUDGET_ALERT_ENABLED: bool = os.getenv("BUDGET_ALERT_ENABLED", "false") == "true"
+    # Percentages of budget at which to notify, ascending, comma-separated.
+    BUDGET_ALERT_THRESHOLDS: str = os.getenv("BUDGET_ALERT_THRESHOLDS", "50,75,90,100")
+    # Full destination URL, not a base — the receiving path is MOAD's to choose,
+    # so it is configured rather than hardcoded here.
+    BUDGET_ALERT_WEBHOOK_URL: str = os.getenv("BUDGET_ALERT_WEBHOOK_URL", "")
+    # Bearer token for the webhook. Falls back to the existing MOAD token so a
+    # deployment that already talks to MOAD needs no extra secret.
+    BUDGET_ALERT_WEBHOOK_TOKEN: str = os.getenv(
+        "BUDGET_ALERT_WEBHOOK_TOKEN", os.getenv("MOAD_DASHBOARD_API_TOKEN", "")
+    )
+    BUDGET_ALERT_WEBHOOK_TIMEOUT: float = float(
+        os.getenv("BUDGET_ALERT_WEBHOOK_TIMEOUT", "30")
+    )
+    BUDGET_ALERT_BATCH_SIZE: int = int(os.getenv("BUDGET_ALERT_BATCH_SIZE", "200"))
+    BUDGET_ALERT_REGION_CONCURRENCY: int = int(
+        os.getenv("BUDGET_ALERT_REGION_CONCURRENCY", "4")
+    )
+    # How far back the daily-activity sweep looks when a period has no resolvable
+    # start. Also bounds the window for very long POOL periods, since a 365d
+    # sweep would return a year of daily rows for no benefit.
+    BUDGET_ALERT_MAX_LOOKBACK_DAYS: int = int(
+        os.getenv("BUDGET_ALERT_MAX_LOOKBACK_DAYS", "62")
+    )
+
     PROMETHEUS_API_KEY: str = os.getenv("PROMETHEUS_API_KEY", "")
     POOL_PURCHASE_EXPIRY_DAYS: int = int(os.getenv("POOL_PURCHASE_EXPIRY_DAYS", "365"))
     PERIODIC_TOPUP_EXPIRY_DAYS: int = int(

--- a/app/core/spend_period_service.py
+++ b/app/core/spend_period_service.py
@@ -54,8 +54,15 @@ def current_cycle_start(
     whole cycles until it contains ``now``, which is what LiteLLM does when it
     actually resets.
 
-    ``1mo``/``30d`` snap to the calendar month, matching LiteLLM's own rule and
-    the ``budget_reset_at`` values it stores (always the 1st).
+    ``1mo``/``30d`` snap to the calendar month. That is *not* the window we would
+    choose — it is what LiteLLM does, and ``31d`` exists precisely to avoid it, so
+    that a cap runs from the day it was set rather than resetting on the 1st. But
+    an alert has to predict when the customer's key will actually stop working, and
+    for a key still carrying ``1mo`` LiteLLM really does reset on the 1st: PROD
+    shows those keys with ``budget_reset_at`` at ``2026-08-01T00:00:00``. Measuring
+    them over a rolling month would disagree with the enforcement they are subject
+    to. 66 key caps and all 38 member caps are still ``1mo``; moving them to
+    ``31d`` is a data change, and this follows whichever they carry.
     """
     if not budget_duration:
         return None

--- a/app/core/spend_period_service.py
+++ b/app/core/spend_period_service.py
@@ -188,9 +188,24 @@ def _active_subscription_entry(
     )
 
 
-def _latest_active_topup(
-    db: Session, team_id: int, region_id: int, now: datetime
+def _active_topup(
+    db: Session, team_id: int, region_id: int, now: datetime, *, oldest: bool
 ) -> DBPeriodicBudgetLedgerEntry | None:
+    """The oldest or newest still-valid top-up for a (team, region).
+
+    Both ends are needed: the oldest opens the window and the newest closes it.
+    See ``resolve_team_period_window`` for why they are not the same entry.
+    """
+    order = (
+        DBPeriodicBudgetLedgerEntry.purchased_at.asc()
+        if oldest
+        else DBPeriodicBudgetLedgerEntry.purchased_at.desc()
+    )
+    tiebreak = (
+        DBPeriodicBudgetLedgerEntry.id.asc()
+        if oldest
+        else DBPeriodicBudgetLedgerEntry.id.desc()
+    )
     return (
         db.query(DBPeriodicBudgetLedgerEntry)
         .filter(
@@ -203,12 +218,21 @@ def _latest_active_topup(
                 | (DBPeriodicBudgetLedgerEntry.expires_at > now)
             ),
         )
-        .order_by(
-            DBPeriodicBudgetLedgerEntry.purchased_at.desc(),
-            DBPeriodicBudgetLedgerEntry.id.desc(),
-        )
+        .order_by(order, tiebreak)
         .first()
     )
+
+
+def _latest_active_topup(
+    db: Session, team_id: int, region_id: int, now: datetime
+) -> DBPeriodicBudgetLedgerEntry | None:
+    return _active_topup(db, team_id, region_id, now, oldest=False)
+
+
+def _oldest_active_topup(
+    db: Session, team_id: int, region_id: int, now: datetime
+) -> DBPeriodicBudgetLedgerEntry | None:
+    return _active_topup(db, team_id, region_id, now, oldest=True)
 
 
 def resolve_team_period_window(
@@ -247,16 +271,39 @@ def resolve_team_period_window(
                 active_subscription=active_subscription,
             )
 
-        # No subscription: the window is the top-up purchase lifetime.
-        active_topup = _latest_active_topup(db, team.id, region_id, now)
-        anchor = _as_utc(
-            (active_topup.purchased_at if active_topup is not None else None)
+        # No subscription: the window spans the life of the credit the team still
+        # holds. It opens at the **oldest** still-valid purchase and closes when the
+        # **newest** one expires, so the two ends come from different entries.
+        #
+        # Opening at the oldest rather than the newest is what keeps the window and
+        # the budget describing the same money. The budget is
+        # ``amount - consumed_cents`` summed over every still-valid entry, and
+        # consumed_cents is only written by FIFO allocation at invoice close — which
+        # a team with no subscription never has. On PROD exactly one of 233 top-up
+        # entries has it set. So the budget is the full face value of every valid
+        # purchase, and a window opening at the newest purchase would leave the spend
+        # against the older ones counted nowhere: absent from the numerator, and not
+        # deducted from the denominator either.
+        #
+        # Worked example: $30 bought on 6 July with $25 spent against it, then $30
+        # more on 29 July. Anchored on the newest purchase that reads $0 of $60 while
+        # the team really has $35 left, and later reports 50 % when the true figure
+        # is 92 %. Anchored on the oldest it reads $25 of $60, and keeps counting.
+        oldest_topup = _oldest_active_topup(db, team.id, region_id, now)
+        latest_topup = _latest_active_topup(db, team.id, region_id, now)
+        start_anchor = _as_utc(
+            (oldest_topup.purchased_at if oldest_topup is not None else None)
             or team.created_at
             or now
         )
+        # The pool is only fully gone once the newest purchase lapses.
+        end_anchor = (
+            _as_utc((latest_topup.purchased_at if latest_topup is not None else None))
+            or start_anchor
+        )
         return TeamPeriodWindow(
-            period_start=anchor,
-            period_end=anchor + timedelta(days=settings.POOL_PURCHASE_EXPIRY_DAYS),
+            period_start=start_anchor,
+            period_end=end_anchor + timedelta(days=settings.POOL_PURCHASE_EXPIRY_DAYS),
             budget_duration=f"{settings.POOL_PURCHASE_EXPIRY_DAYS}d",
             source="pool_topup",
         )

--- a/app/core/spend_period_service.py
+++ b/app/core/spend_period_service.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.core.config import settings
 from app.db.models import (
+    DBPeriodicBudgetLedgerEntry,
     DBPrivateAIKey,
     DBTeam,
     DBTeamSpendPeriod,
@@ -30,6 +34,215 @@ def _resolve_budget_type(team: DBTeam) -> str:
     if isinstance(budget_type, BudgetType):
         return budget_type.value
     return str(budget_type).lower()
+
+
+def compute_period_start(
+    budget_reset_at: datetime | None, budget_duration: str | None
+) -> datetime | None:
+    """
+    Derive the start of the current budget period from LiteLLM's
+    ``budget_reset_at`` (end-of-period) and ``budget_duration``.
+
+    LiteLLM sets ``budget_reset_at`` to the moment the budget will auto-reset.
+    For ``"Nd"`` durations the reset is rolling N days after the last update;
+    for ``"1mo"`` / ``"30d"`` it snaps to the 1st of the next calendar month.
+
+    We parse the duration string and subtract from ``budget_reset_at`` to get
+    a best-effort calendar ``period_start``.  Returns ``None`` when either
+    input is missing or the duration cannot be parsed.
+    """
+    if budget_reset_at is None or not budget_duration:
+        return None
+
+    # Handle "1mo" / "30d" — both snap to 1st of next calendar month
+    # so the period start is always the 1st of the current month.
+    if budget_duration in ("1mo", "30d"):
+        # budget_reset_at is midnight on the 1st of next month.
+        # If reset is on 1st, the period that just ended started last month.
+        if budget_reset_at.day == 1:
+            if budget_reset_at.month == 1:
+                return budget_reset_at.replace(
+                    year=budget_reset_at.year - 1, month=12, day=1
+                )
+            return budget_reset_at.replace(month=budget_reset_at.month - 1, day=1)
+        return budget_reset_at.replace(day=1)
+
+    match = re.fullmatch(r"(\d+)([dhms])", budget_duration)
+    if not match:
+        return None
+    value = int(match.group(1))
+    unit = match.group(2)
+    if unit == "d":
+        return budget_reset_at - timedelta(days=value)
+    if unit == "h":
+        return budget_reset_at - timedelta(hours=value)
+    if unit == "m":
+        return budget_reset_at - timedelta(minutes=value)
+    if unit == "s":
+        return budget_reset_at - timedelta(seconds=value)
+    return None
+
+
+def _as_utc(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value
+
+
+@dataclass(frozen=True)
+class TeamPeriodWindow:
+    """The current budget window for one (team, region) pair.
+
+    ``period_end`` is the same instant LiteLLM calls ``budget_reset_at``.
+    ``source`` records which rule produced the window, which makes a wrong
+    percentage traceable to a rule rather than to arithmetic.
+    """
+
+    period_start: datetime | None
+    period_end: datetime | None
+    budget_duration: str | None
+    source: str
+    active_subscription: DBPeriodicBudgetLedgerEntry | None = None
+
+    @property
+    def period_key(self) -> str:
+        """Stable identity for this window, used to re-arm threshold alerts.
+
+        A new billing cycle yields a different key, which is what makes an
+        already-notified threshold fire again in the next period.
+        """
+        if self.period_start is None:
+            return f"{self.source}:none"
+        return f"{self.source}:{self.period_start.isoformat()}"
+
+
+def _active_subscription_entry(
+    db: Session, team_id: int, region_id: int, now: datetime
+) -> DBPeriodicBudgetLedgerEntry | None:
+    return (
+        db.query(DBPeriodicBudgetLedgerEntry)
+        .filter(
+            DBPeriodicBudgetLedgerEntry.team_id == team_id,
+            DBPeriodicBudgetLedgerEntry.region_id == region_id,
+            DBPeriodicBudgetLedgerEntry.entry_type == "subscription",
+            DBPeriodicBudgetLedgerEntry.is_active.is_(True),
+            DBPeriodicBudgetLedgerEntry.effective_period_start.isnot(None),
+            DBPeriodicBudgetLedgerEntry.effective_period_end.isnot(None),
+            DBPeriodicBudgetLedgerEntry.effective_period_end > now,
+        )
+        .order_by(
+            DBPeriodicBudgetLedgerEntry.effective_period_end.desc(),
+            DBPeriodicBudgetLedgerEntry.id.desc(),
+        )
+        .first()
+    )
+
+
+def _latest_active_topup(
+    db: Session, team_id: int, region_id: int, now: datetime
+) -> DBPeriodicBudgetLedgerEntry | None:
+    return (
+        db.query(DBPeriodicBudgetLedgerEntry)
+        .filter(
+            DBPeriodicBudgetLedgerEntry.team_id == team_id,
+            DBPeriodicBudgetLedgerEntry.region_id == region_id,
+            DBPeriodicBudgetLedgerEntry.entry_type.in_(["topup", "topup_rollover"]),
+            DBPeriodicBudgetLedgerEntry.is_active.is_(True),
+            (
+                DBPeriodicBudgetLedgerEntry.expires_at.is_(None)
+                | (DBPeriodicBudgetLedgerEntry.expires_at > now)
+            ),
+        )
+        .order_by(
+            DBPeriodicBudgetLedgerEntry.purchased_at.desc(),
+            DBPeriodicBudgetLedgerEntry.id.desc(),
+        )
+        .first()
+    )
+
+
+def resolve_team_period_window(
+    db: Session,
+    team: DBTeam,
+    region_id: int,
+    *,
+    litellm_budget_duration: str | None = None,
+    litellm_budget_reset_at: datetime | None = None,
+    now: datetime | None = None,
+) -> TeamPeriodWindow:
+    """Resolve the active budget window for a (team, region) pair.
+
+    Single source of truth for "which period are we in", shared by the spend
+    API and the budget-threshold alert engine. If these two ever disagree, a
+    customer sees one percentage in the dashboard and gets alerted on another.
+
+    POOL teams are resolved purely from our own ledger — LiteLLM's counters are
+    not authoritative for them (the budget is pushed there, not owned there).
+    PERIODIC teams prefer the LiteLLM window when the caller has already
+    fetched team info, and fall back to the ledger otherwise, so a caller that
+    cannot afford a LiteLLM round-trip still gets a usable window.
+    """
+    now = now or datetime.now(UTC)
+
+    if team.budget_type == BudgetType.POOL:
+        active_subscription = _active_subscription_entry(db, team.id, region_id, now)
+        if active_subscription is not None:
+            return TeamPeriodWindow(
+                period_start=_as_utc(active_subscription.effective_period_start),
+                period_end=_as_utc(active_subscription.effective_period_end),
+                # Stripe cycles are 30d; LiteLLM carries 31d as the missed-webhook
+                # safety net, matching apply_billing_cycle_for_team.
+                budget_duration="31d",
+                source="subscription_ledger",
+                active_subscription=active_subscription,
+            )
+
+        # No subscription: the window is the top-up purchase lifetime.
+        active_topup = _latest_active_topup(db, team.id, region_id, now)
+        anchor = _as_utc(
+            (active_topup.purchased_at if active_topup is not None else None)
+            or team.created_at
+            or now
+        )
+        return TeamPeriodWindow(
+            period_start=anchor,
+            period_end=anchor + timedelta(days=settings.POOL_PURCHASE_EXPIRY_DAYS),
+            budget_duration=f"{settings.POOL_PURCHASE_EXPIRY_DAYS}d",
+            source="pool_topup",
+        )
+
+    # --- PERIODIC ---
+    if litellm_budget_reset_at is not None and litellm_budget_duration:
+        derived_start = compute_period_start(
+            litellm_budget_reset_at, litellm_budget_duration
+        )
+        if derived_start is not None:
+            return TeamPeriodWindow(
+                period_start=_as_utc(derived_start),
+                period_end=_as_utc(litellm_budget_reset_at),
+                budget_duration=litellm_budget_duration,
+                source="litellm",
+            )
+
+    active_subscription = _active_subscription_entry(db, team.id, region_id, now)
+    if active_subscription is not None:
+        return TeamPeriodWindow(
+            period_start=_as_utc(active_subscription.effective_period_start),
+            period_end=_as_utc(active_subscription.effective_period_end),
+            budget_duration="31d",
+            source="subscription_ledger",
+            active_subscription=active_subscription,
+        )
+
+    anchor = _as_utc(team.last_payment or team.created_at or now)
+    return TeamPeriodWindow(
+        period_start=anchor,
+        period_end=anchor + timedelta(days=31),
+        budget_duration="31d",
+        source="team_anchor",
+    )
 
 
 async def fetch_team_spend_snapshot_for_region(

--- a/app/core/spend_period_service.py
+++ b/app/core/spend_period_service.py
@@ -36,6 +36,47 @@ def _resolve_budget_type(team: DBTeam) -> str:
     return str(budget_type).lower()
 
 
+def current_cycle_start(
+    budget_duration: str | None, anchor: datetime | None, now: datetime
+) -> datetime | None:
+    """Start of the cycle *containing now* for a per-cycle budget.
+
+    Spend caps are per cycle, not absolute: on PROD every one of them is ``31d``
+    or ``1mo``, and LiteLLM zeroes the key's spend at each boundary. A percentage
+    against such a cap therefore has to be summed over that cap's current cycle —
+    dividing a longer stretch of spend by a one-month cap reads far above 100 %
+    and fires alerts nobody has earned.
+
+    This differs from :func:`compute_period_start` in rolling forward. That one
+    derives the window from LiteLLM's ``budget_reset_at``, which can sit in the
+    past (PROD has keys whose ``budget_reset_at`` is a month behind), and would
+    then hand back a window that ended long ago. Here the anchor is stepped by
+    whole cycles until it contains ``now``, which is what LiteLLM does when it
+    actually resets.
+
+    ``1mo``/``30d`` snap to the calendar month, matching LiteLLM's own rule and
+    the ``budget_reset_at`` values it stores (always the 1st).
+    """
+    if not budget_duration:
+        return None
+
+    if budget_duration in ("1mo", "30d"):
+        return now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+    match = re.fullmatch(r"(\d+)d", str(budget_duration).strip())
+    if not match:
+        return None
+    days = int(match.group(1))
+    if days <= 0:
+        return None
+
+    start = _as_utc(anchor) or now
+    if start >= now:
+        return start
+    whole_cycles = (now - start).days // days
+    return start + timedelta(days=whole_cycles * days)
+
+
 def compute_period_start(
     budget_reset_at: datetime | None, budget_duration: str | None
 ) -> datetime | None:

--- a/app/core/spend_period_service.py
+++ b/app/core/spend_period_service.py
@@ -41,16 +41,16 @@ def current_cycle_start(
 ) -> datetime | None:
     """Start of the cycle *containing now* for a per-cycle budget.
 
-    Spend caps are per cycle, not absolute: on PROD every one of them is ``31d``
-    or ``1mo``, and LiteLLM zeroes the key's spend at each boundary. A percentage
+    Spend caps are per cycle, not absolute: they are written as ``31d`` or ``1mo``,
+    and LiteLLM zeroes the key's spend at each boundary. A percentage
     against such a cap therefore has to be summed over that cap's current cycle —
     dividing a longer stretch of spend by a one-month cap reads far above 100 %
     and fires alerts nobody has earned.
 
     This differs from :func:`compute_period_start` in rolling forward. That one
     derives the window from LiteLLM's ``budget_reset_at``, which can sit in the
-    past (PROD has keys whose ``budget_reset_at`` is a month behind), and would
-    then hand back a window that ended long ago. Here the anchor is stepped by
+    past — a key's reset date may be a month behind — and would then hand back a
+    window that ended long ago. Here the anchor is stepped by
     whole cycles until it contains ``now``, which is what LiteLLM does when it
     actually resets.
 
@@ -58,11 +58,11 @@ def current_cycle_start(
     choose — it is what LiteLLM does, and ``31d`` exists precisely to avoid it, so
     that a cap runs from the day it was set rather than resetting on the 1st. But
     an alert has to predict when the customer's key will actually stop working, and
-    for a key still carrying ``1mo`` LiteLLM really does reset on the 1st: PROD
-    shows those keys with ``budget_reset_at`` at ``2026-08-01T00:00:00``. Measuring
-    them over a rolling month would disagree with the enforcement they are subject
-    to. 66 key caps and all 38 member caps are still ``1mo``; moving them to
-    ``31d`` is a data change, and this follows whichever they carry.
+    for a key still carrying ``1mo`` LiteLLM really does reset on the 1st — its
+    stored ``budget_reset_at`` is the 1st of the next month. Measuring such a key
+    over a rolling month would disagree with the enforcement it is subject to. Caps
+    written before the ``31d`` rule still carry ``1mo``; moving them is a data
+    change, and this follows whichever they carry.
     """
     if not budget_duration:
         return None
@@ -279,9 +279,9 @@ def resolve_team_period_window(
         # the budget describing the same money. The budget is
         # ``amount - consumed_cents`` summed over every still-valid entry, and
         # consumed_cents is only written by FIFO allocation at invoice close — which
-        # a team with no subscription never has. On PROD exactly one of 233 top-up
-        # entries has it set. So the budget is the full face value of every valid
-        # purchase, and a window opening at the newest purchase would leave the spend
+        # a team with no subscription never has. So the budget is effectively the full
+        # face value of every valid purchase, and a window opening at the newest
+        # purchase would leave the spend
         # against the older ones counted nowhere: absent from the numerator, and not
         # deducted from the denominator either.
         #

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -773,6 +773,14 @@ class DBBudgetAlertState(Base):
     period_key = Column(String, nullable=False)
     last_threshold_pct = Column(Integer, default=0, nullable=False)
 
+    # How many times this subject's bands have been re-armed inside the current
+    # period. A POOL top-up raises the denominator, so the percentage can fall
+    # below a band already notified and later cross it again — a real second
+    # warning. It is mixed into the event id so that crossing gets a fresh id,
+    # while a redelivery of the first one keeps the original. Without it the
+    # consumer's de-duplication would silently swallow the second warning.
+    arm_seq = Column(Integer, default=0, nullable=False)
+
     # Snapshot of the numbers that triggered the last notification. The
     # denominator is recorded because a POOL top-up moves it, so without this
     # the event cannot be explained after the fact.

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -743,6 +743,48 @@ class DBSignupEvent(Base):
     )
 
 
+class DBBudgetAlertState(Base):
+    """Highest budget threshold already notified for one alert subject.
+
+    One row per subject, **not** one row per notification. ``subject_key``
+    identifies the thing being watched (a key, a team+region, or a member of a
+    team in a region) and ``period_key`` identifies the billing window that
+    ``last_threshold_pct`` refers to.
+
+    The pair is what makes alerts both idempotent and self-re-arming: while the
+    window is unchanged we never re-notify a band we have already sent, and when
+    a new billing cycle produces a different ``period_key`` the bands reset so
+    the customer is warned again in the new period. A TTL-based dedup (which is
+    what LiteLLM's native alerting uses) cannot express that, because it expires
+    on wall-clock time rather than on the cycle boundary.
+    """
+
+    __tablename__ = "budget_alert_state"
+
+    id = Column(Integer, primary_key=True, index=True)
+    # "key:<key_id>" | "team:<team_id>:<region_id>" | "member:<team_id>:<user_id>:<region_id>"
+    subject_key = Column(String, unique=True, nullable=False, index=True)
+    subject_type = Column(String, nullable=False, index=True)  # key|team|team_member
+    region_id = Column(Integer, ForeignKey("regions.id"), nullable=False, index=True)
+    team_id = Column(Integer, ForeignKey("teams.id"), nullable=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True, index=True)
+    key_id = Column(Integer, ForeignKey("ai_tokens.id"), nullable=True, index=True)
+
+    period_key = Column(String, nullable=False)
+    last_threshold_pct = Column(Integer, default=0, nullable=False)
+
+    # Snapshot of the numbers that triggered the last notification. The
+    # denominator is recorded because a POOL top-up moves it, so without this
+    # the event cannot be explained after the fact.
+    spend_at_notify = Column(Float, nullable=True)
+    budget_at_notify = Column(Float, nullable=True)
+    percent_at_notify = Column(Float, nullable=True)
+
+    notified_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now(), nullable=True)
+
+
 class DBDisposableDomain(Base):
     """Blocklist of disposable / dynamic-DNS email domains (trial-account abuse
     protection, moad #620). Populated by the daily refresh cron from a committed

--- a/app/migrations/versions/20260729_220000_d1e2f3a4b5c6_add_budget_alert_state.py
+++ b/app/migrations/versions/20260729_220000_d1e2f3a4b5c6_add_budget_alert_state.py
@@ -30,6 +30,7 @@ def upgrade() -> None:
         sa.Column(
             "last_threshold_pct", sa.Integer(), server_default="0", nullable=False
         ),
+        sa.Column("arm_seq", sa.Integer(), server_default="0", nullable=False),
         sa.Column("spend_at_notify", sa.Float(), nullable=True),
         sa.Column("budget_at_notify", sa.Float(), nullable=True),
         sa.Column("percent_at_notify", sa.Float(), nullable=True),

--- a/app/migrations/versions/20260729_220000_d1e2f3a4b5c6_add_budget_alert_state.py
+++ b/app/migrations/versions/20260729_220000_d1e2f3a4b5c6_add_budget_alert_state.py
@@ -1,0 +1,104 @@
+"""add budget_alert_state table for budget threshold alerts
+
+Revision ID: d1e2f3a4b5c6
+Revises: 6c201dbaea6e
+Create Date: 2026-07-29 22:00:00.000000+00:00
+
+"""
+
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic (read via module reflection).
+revision: str = "d1e2f3a4b5c6"
+down_revision: Union[str, None] = "6c201dbaea6e"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "budget_alert_state",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("subject_key", sa.String(), nullable=False),
+        sa.Column("subject_type", sa.String(), nullable=False),
+        sa.Column("region_id", sa.Integer(), nullable=False),
+        sa.Column("team_id", sa.Integer(), nullable=True),
+        sa.Column("user_id", sa.Integer(), nullable=True),
+        sa.Column("key_id", sa.Integer(), nullable=True),
+        sa.Column("period_key", sa.String(), nullable=False),
+        sa.Column(
+            "last_threshold_pct", sa.Integer(), server_default="0", nullable=False
+        ),
+        sa.Column("spend_at_notify", sa.Float(), nullable=True),
+        sa.Column("budget_at_notify", sa.Float(), nullable=True),
+        sa.Column("percent_at_notify", sa.Float(), nullable=True),
+        sa.Column("notified_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["region_id"], ["regions.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["team_id"], ["teams.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["key_id"], ["ai_tokens.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_budget_alert_state_id"), "budget_alert_state", ["id"])
+    # subject_key is the upsert target for every tick, so it must be unique.
+    op.create_index(
+        op.f("ix_budget_alert_state_subject_key"),
+        "budget_alert_state",
+        ["subject_key"],
+        unique=True,
+    )
+    op.create_index(
+        op.f("ix_budget_alert_state_subject_type"),
+        "budget_alert_state",
+        ["subject_type"],
+    )
+    op.create_index(
+        op.f("ix_budget_alert_state_region_id"), "budget_alert_state", ["region_id"]
+    )
+    op.create_index(
+        op.f("ix_budget_alert_state_team_id"), "budget_alert_state", ["team_id"]
+    )
+    op.create_index(
+        op.f("ix_budget_alert_state_user_id"), "budget_alert_state", ["user_id"]
+    )
+    op.create_index(
+        op.f("ix_budget_alert_state_key_id"), "budget_alert_state", ["key_id"]
+    )
+    # The engine loads existing state for a whole region in one query per tick.
+    op.create_index(
+        "ix_budget_alert_state_region_subject_type",
+        "budget_alert_state",
+        ["region_id", "subject_type"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_budget_alert_state_region_subject_type", table_name="budget_alert_state"
+    )
+    op.drop_index(op.f("ix_budget_alert_state_key_id"), table_name="budget_alert_state")
+    op.drop_index(
+        op.f("ix_budget_alert_state_user_id"), table_name="budget_alert_state"
+    )
+    op.drop_index(
+        op.f("ix_budget_alert_state_team_id"), table_name="budget_alert_state"
+    )
+    op.drop_index(
+        op.f("ix_budget_alert_state_region_id"), table_name="budget_alert_state"
+    )
+    op.drop_index(
+        op.f("ix_budget_alert_state_subject_type"), table_name="budget_alert_state"
+    )
+    op.drop_index(
+        op.f("ix_budget_alert_state_subject_key"), table_name="budget_alert_state"
+    )
+    op.drop_index(op.f("ix_budget_alert_state_id"), table_name="budget_alert_state")
+    op.drop_table("budget_alert_state")

--- a/app/services/budget_alert_webhook.py
+++ b/app/services/budget_alert_webhook.py
@@ -47,6 +47,11 @@ def serialize_event(event: BudgetAlertEvent) -> dict:
             "percent_used": event.percent_used,
             "spend": event.spend,
             "max_budget": event.max_budget,
+            # Where max_budget came from, so the consumer can word the message:
+            # "key_cap" / "litellm_key_budget" = the key's own limit;
+            # "team_pool" = the key is uncapped and measured against the team pool;
+            # "team_ledger" = a team- or member-scope budget.
+            "budget_source": event.budget_source,
             "currency": "USD",
             "budget_duration": event.budget_duration,
             "region": {"id": event.region_id, "name": event.region_name},
@@ -61,7 +66,12 @@ def serialize_event(event: BudgetAlertEvent) -> dict:
                 else None
             ),
             "key": (
-                {"id": event.key_id, "name": event.key_name}
+                {
+                    "id": event.key_id,
+                    "name": event.key_name,
+                    # Service keys belong to the team; user keys have an owner.
+                    "is_service_key": event.is_service_key,
+                }
                 if event.key_id is not None
                 else None
             ),

--- a/app/services/budget_alert_webhook.py
+++ b/app/services/budget_alert_webhook.py
@@ -3,7 +3,10 @@
 Posts batches of events to a single configured URL (MOAD, in practice). There is
 no retry queue by design: the alert engine only advances its threshold state for
 events this module reports as delivered, so a failed POST is re-detected and
-re-sent on the next tick. Consumers de-duplicate on ``event_id``.
+re-sent on the next tick. Consumers de-duplicate on ``event_id``, which is derived
+from (subject, period, band) rather than randomly generated — a retry therefore
+carries the same id as the attempt it repeats, including when a response is lost
+after the consumer already accepted the batch. See ``event_id_for``.
 
 The destination is a full URL from ``BUDGET_ALERT_WEBHOOK_URL`` rather than a
 base plus a hardcoded path, so the receiving route stays the consumer's choice.

--- a/app/services/budget_alert_webhook.py
+++ b/app/services/budget_alert_webhook.py
@@ -1,0 +1,138 @@
+"""Outbound delivery of budget threshold alerts.
+
+Posts batches of events to a single configured URL (MOAD, in practice). There is
+no retry queue by design: the alert engine only advances its threshold state for
+events this module reports as delivered, so a failed POST is re-detected and
+re-sent on the next tick. Consumers de-duplicate on ``event_id``.
+
+The destination is a full URL from ``BUDGET_ALERT_WEBHOOK_URL`` rather than a
+base plus a hardcoded path, so the receiving route stays the consumer's choice.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+import httpx
+
+from app.core.budget_alert_service import BudgetAlertEvent
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Bumped when the event shape changes in a way consumers must notice.
+BUDGET_ALERT_API_VERSION = "2026-08-01"
+
+EVENT_TYPE = "budget.threshold_reached"
+
+
+def _iso(value: datetime | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def serialize_event(event: BudgetAlertEvent) -> dict:
+    """Render one event for the wire, using our identifiers only.
+
+    The LiteLLM token is deliberately absent: it is a live credential and the
+    consumer has no need for it. Our ``key_id`` identifies the key instead.
+    """
+    return {
+        "event_id": event.event_id,
+        "type": EVENT_TYPE,
+        "created_at": datetime.now(UTC).isoformat(),
+        "data": {
+            "scope": event.subject_type,
+            "threshold_percent": event.threshold_pct,
+            "percent_used": event.percent_used,
+            "spend": event.spend,
+            "max_budget": event.max_budget,
+            "currency": "USD",
+            "budget_duration": event.budget_duration,
+            "region": {"id": event.region_id, "name": event.region_name},
+            "team": (
+                {"id": event.team_id, "name": event.team_name}
+                if event.team_id is not None
+                else None
+            ),
+            "user": (
+                {"id": event.user_id, "email": event.user_email}
+                if event.user_id is not None
+                else None
+            ),
+            "key": (
+                {"id": event.key_id, "name": event.key_name}
+                if event.key_id is not None
+                else None
+            ),
+            "period": {
+                "key": event.period_key,
+                "start": _iso(event.period_start),
+                "end": _iso(event.period_end),
+            },
+        },
+    }
+
+
+def _chunk(events: list[BudgetAlertEvent], size: int):
+    size = max(1, size)
+    for start in range(0, len(events), size):
+        yield events[start : start + size]
+
+
+async def deliver_events(events: list[BudgetAlertEvent]) -> set[str]:
+    """POST events in batches. Returns the ids that were accepted.
+
+    A batch is all-or-nothing: on a non-2xx or a transport error none of its ids
+    are returned, so every event in it is retried next tick.
+    """
+    if not events:
+        return set()
+
+    url = settings.BUDGET_ALERT_WEBHOOK_URL
+    if not url:
+        logger.error(
+            "BUDGET_ALERT_WEBHOOK_URL is not set; %d budget alert(s) not delivered",
+            len(events),
+        )
+        return set()
+
+    headers = {"Content-Type": "application/json"}
+    if settings.BUDGET_ALERT_WEBHOOK_TOKEN:
+        headers["Authorization"] = f"Bearer {settings.BUDGET_ALERT_WEBHOOK_TOKEN}"
+
+    delivered: set[str] = set()
+    timeout = settings.BUDGET_ALERT_WEBHOOK_TIMEOUT
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        for batch in _chunk(events, settings.BUDGET_ALERT_BATCH_SIZE):
+            payload = {
+                "api_version": BUDGET_ALERT_API_VERSION,
+                "events": [serialize_event(event) for event in batch],
+            }
+            try:
+                response = await client.post(url, json=payload, headers=headers)
+            except httpx.RequestError as exc:
+                logger.error(
+                    "Budget alert webhook unreachable (%d event(s) will retry): %s",
+                    len(batch),
+                    exc,
+                )
+                continue
+
+            if 200 <= response.status_code < 300:
+                delivered.update(event.event_id for event in batch)
+                logger.info(
+                    "Delivered %d budget alert(s) (status %s)",
+                    len(batch),
+                    response.status_code,
+                )
+            else:
+                logger.error(
+                    "Budget alert webhook returned %s (%d event(s) will retry): %s",
+                    response.status_code,
+                    len(batch),
+                    response.text[:500],
+                )
+
+    return delivered

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -480,25 +480,6 @@ class LiteLLMService:
             page_size=page_size,
         )
 
-    async def get_all_user_daily_activity(
-        self,
-        start_date: str,
-        end_date: str,
-        page_size: int = 1000,
-    ) -> list[dict]:
-        """Fetch per-day usage for **every active user** in this region.
-
-        As :meth:`get_all_team_daily_activity`, but ``breakdown.entities`` is
-        keyed by amazee.ai user id (LiteLLM stores our user ids verbatim).
-        """
-        return await self._fetch_daily_activity(
-            "/user/daily/activity",
-            {},
-            start_date=start_date,
-            end_date=end_date,
-            page_size=page_size,
-        )
-
     async def list_keys_for_team(
         self, team_id: str, page_size: int = 100
     ) -> list[dict]:

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -454,6 +454,105 @@ class LiteLLMService:
             page_size=page_size,
         )
 
+    async def get_all_team_daily_activity(
+        self,
+        start_date: str,
+        end_date: str,
+        page_size: int = 1000,
+    ) -> list[dict]:
+        """Fetch per-day usage for **every active team** in this region.
+
+        Same endpoint as :meth:`get_team_daily_activity` but with no entity
+        filter, which LiteLLM answers with one row per UTC day. Each row's
+        ``breakdown.entities`` is keyed by LiteLLM team id and each
+        ``breakdown.api_keys`` by hashed token, so a single sweep yields period
+        spend for every team *and* key that had any traffic.
+
+        This is deliberately O(active entities), not O(total keys): idle keys
+        produce no daily-spend rows at all. That is what makes a frequent poll
+        affordable at 100k keys, where enumerating every key is not.
+        """
+        return await self._fetch_daily_activity(
+            "/team/daily/activity",
+            {},
+            start_date=start_date,
+            end_date=end_date,
+            page_size=page_size,
+        )
+
+    async def get_all_user_daily_activity(
+        self,
+        start_date: str,
+        end_date: str,
+        page_size: int = 1000,
+    ) -> list[dict]:
+        """Fetch per-day usage for **every active user** in this region.
+
+        As :meth:`get_all_team_daily_activity`, but ``breakdown.entities`` is
+        keyed by amazee.ai user id (LiteLLM stores our user ids verbatim).
+        """
+        return await self._fetch_daily_activity(
+            "/user/daily/activity",
+            {},
+            start_date=start_date,
+            end_date=end_date,
+            page_size=page_size,
+        )
+
+    async def list_keys_for_team(
+        self, team_id: str, page_size: int = 100
+    ) -> list[dict]:
+        """Return the full key objects for one LiteLLM team.
+
+        Used to confirm exact ``spend`` and ``max_budget`` for a team that a
+        daily-activity sweep has already flagged as worth looking at. Scoping
+        by team keeps this cheap; an unscoped ``/key/list`` walk would defeat
+        the point of the sweep.
+
+        ``page_size`` is capped at 100 by LiteLLM (larger values 422), so it is
+        clamped rather than passed through.
+        """
+        page_size = max(1, min(int(page_size), 100))
+        keys: list[dict] = []
+        page = 1
+        max_pages = 1000
+        try:
+            async with httpx.AsyncClient() as client:
+                while page <= max_pages:
+                    response = await client.get(
+                        f"{self.api_url}/key/list",
+                        headers={"Authorization": f"Bearer {self.master_key}"},
+                        params={
+                            "team_id": team_id,
+                            "page": page,
+                            "size": page_size,
+                            "return_full_object": "true",
+                        },
+                    )
+                    response.raise_for_status()
+                    data = response.json()
+                    batch = [k for k in (data.get("keys") or []) if isinstance(k, dict)]
+                    keys.extend(batch)
+                    # Stop on a short or empty page. total_pages is only a
+                    # secondary check: when it is absent, trusting it alone
+                    # truncates the walk after page 1.
+                    if len(batch) < page_size:
+                        break
+                    total_pages = data.get("total_pages") or 0
+                    if total_pages and page >= total_pages:
+                        break
+                    page += 1
+            return keys
+        except httpx.HTTPStatusError as e:
+            status_code, error_msg, _ = self._parse_http_error(e)
+            logger.error(
+                "Error listing LiteLLM keys for team %s: %s", team_id, error_msg
+            )
+            raise HTTPException(
+                status_code=status_code,
+                detail=f"Failed to list LiteLLM keys for team: {error_msg}",
+            )
+
     async def update_budget(
         self,
         litellm_token: str,

--- a/scripts/trigger_budget_alerts_job.py
+++ b/scripts/trigger_budget_alerts_job.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import asyncio
+import logging
+
+# Add the parent directory to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from sqlalchemy.orm import sessionmaker
+from app.db.database import engine
+from app.core.budget_alert_service import monitor_budget_thresholds
+from app.core.locking import try_acquire_lock, release_lock
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def trigger_budget_alerts_job():
+    """Run the budget threshold sweep, guarded by the shared advisory lock."""
+
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = SessionLocal()
+
+    lock_name = "budget_alerts"
+
+    try:
+        logger.info("Starting budget threshold alert job...")
+
+        # The lock timeout is deliberately shorter than for monitor_teams: this
+        # job runs every few minutes, so a stale lock must not block many ticks.
+        if try_acquire_lock(lock_name, db, lock_timeout=5):
+            logger.info("Acquired budget_alerts lock, executing sweep")
+            try:
+                totals = await monitor_budget_thresholds(db)
+                logger.info("Budget threshold sweep completed: %s", totals)
+            except Exception as e:
+                logger.error(f"Error in budget threshold sweep: {str(e)}")
+                raise
+            finally:
+                release_lock(lock_name, db)
+                logger.info("Released budget_alerts lock")
+        else:
+            logger.warning(
+                "Another process holds the budget_alerts lock, skipping this tick"
+            )
+            return False
+
+    except Exception as e:
+        logger.error(f"Error in budget threshold alert job: {str(e)}")
+        raise
+    finally:
+        db.close()
+
+    return True
+
+
+def main():
+    """Main function to run the script"""
+    try:
+        success = asyncio.run(trigger_budget_alerts_job())
+
+        if success:
+            logger.info("✅ Budget threshold sweep completed successfully")
+            sys.exit(0)
+        else:
+            logger.info("⚠️  Sweep skipped (lock held by another process)")
+            # Skipping is expected while a previous tick is still running.
+            sys.exit(0)
+
+    except Exception as e:
+        logger.error(f"❌ Script failed: {str(e)}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_budget_alerts.py
+++ b/tests/test_budget_alerts.py
@@ -1280,28 +1280,96 @@ async def test_sweep_does_not_reach_past_the_lookback_floor(db, region):
 
 
 @pytest.mark.asyncio
-async def test_team_is_skipped_when_its_window_predates_the_floor(db, region):
-    """Better no alert than a confidently wrong one.
+async def test_window_before_the_floor_is_back_filled_not_dropped(db, region):
+    """A team the wide sweep cannot cover gets its own scoped call.
 
-    With the window truncated, the visible spend is only part of the total, so the
-    percentage would sit permanently low — a team at 92% would be told it is at
-    30%. The team is dropped and logged instead.
+    The wide request is bounded by the floor, so its rows hold only part of a
+    200-day window. Summing them would peg the team at 30% for good and it would
+    never reach the 90 band. Skipping it instead would hide every crossing until
+    someone raised the floor by hand, so its spend is fetched over its own window.
     """
     team = _make_team(db)
     _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=200)
     _make_key(db, team, region, token="sk-a")
     lite = f"{region.name}_{team.id}"
 
-    # Only the spend inside the floor is visible; the rest of the 200-day window
-    # is not returned at all.
-    rows = _active(lite, keys={"sk-a": 30.0})
+    # The wide sweep only sees the recent $30 of a $92 window.
+    wide_rows = _active(lite, keys={"sk-a": 30.0})
+    scoped_rows = [
+        _day(lite, 62.0, days_ago=150, keys={"sk-a": 62.0}),
+        _day(lite, 30.0, days_ago=0, keys={"sk-a": 30.0}),
+    ]
+    scoped = AsyncMock(return_value=scoped_rows)
 
     with patch.object(settings, "BUDGET_ALERT_MAX_LOOKBACK_DAYS", 30):
-        with _patch_litellm(rows, [_key_state("sk-a")]):
+        with patch.multiple(
+            "app.core.budget_alert_service.LiteLLMService",
+            get_all_team_daily_activity=AsyncMock(return_value=wide_rows),
+            get_team_daily_activity=scoped,
+            list_keys_for_team=AsyncMock(return_value=[_key_state("sk-a")]),
+        ):
+            result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    # The scoped call asked for the team's own window, not the floor.
+    assert scoped.await_args.args[0] == lite
+    assert (
+        date.fromisoformat(scoped.await_args.args[1])
+        == (datetime.now(UTC) - timedelta(days=200)).date()
+    )
+
+    event = next(e for e in result.events if e.subject_type == SUBJECT_TEAM)
+    assert event.spend == 92.0  # the whole window, not just the visible $30
+    assert event.threshold_pct == 90
+
+
+@pytest.mark.asyncio
+async def test_team_is_dropped_when_the_back_fill_fails(db, region):
+    """If the exact number cannot be fetched, report none rather than a wrong one."""
+    team = _make_team(db)
+    _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=200)
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
+
+    with patch.object(settings, "BUDGET_ALERT_MAX_LOOKBACK_DAYS", 30):
+        with patch.multiple(
+            "app.core.budget_alert_service.LiteLLMService",
+            get_all_team_daily_activity=AsyncMock(
+                return_value=_active(lite, keys={"sk-a": 30.0})
+            ),
+            get_team_daily_activity=AsyncMock(side_effect=RuntimeError("boom")),
+            list_keys_for_team=AsyncMock(return_value=[_key_state("sk-a")]),
+        ):
             result = await evaluate_region(db, region, thresholds=THRESHOLDS)
 
     assert result.events == []
     assert result.subjects_evaluated == 0
+
+
+@pytest.mark.asyncio
+async def test_budget_less_team_costs_no_extra_call(db, region):
+    """The 673 ledger-less POOL teams must not each trigger a back-fill.
+
+    They anchor on team.created_at, which is routinely older than the window, but
+    they have no budget to be a percentage of, so there is nothing to fetch.
+    """
+    team = _make_team(db)  # no ledger entry at all
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
+    scoped = AsyncMock(return_value=[])
+
+    with patch.object(settings, "BUDGET_ALERT_MAX_LOOKBACK_DAYS", 1):
+        with patch.multiple(
+            "app.core.budget_alert_service.LiteLLMService",
+            get_all_team_daily_activity=AsyncMock(
+                return_value=_active(lite, keys={"sk-a": 5.0})
+            ),
+            get_team_daily_activity=scoped,
+            list_keys_for_team=AsyncMock(return_value=[_key_state("sk-a")]),
+        ):
+            result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    scoped.assert_not_awaited()
+    assert result.events == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_budget_alerts.py
+++ b/tests/test_budget_alerts.py
@@ -1526,3 +1526,177 @@ async def test_re_crossing_a_band_in_one_period_gets_a_new_event_id(db, region):
     assert third_event.period_key == first_event.period_key
     # Same subject, same period, same band -- but a genuinely new warning.
     assert third_event.event_id != first_event.event_id
+
+
+# --------------------------------------------------------------------------- #
+# Caps are per cycle, so they are measured over their own cycle
+# --------------------------------------------------------------------------- #
+
+
+def test_current_cycle_start_rolls_forward_to_contain_now():
+    """A stale anchor must not hand back a window that already closed.
+
+    PROD has keys whose LiteLLM budget_reset_at is a month in the past, so the
+    cycle has to be stepped forward the way LiteLLM steps it on reset.
+    """
+    from app.core.spend_period_service import current_cycle_start
+
+    now = datetime(2026, 7, 30, 12, 0, tzinfo=UTC)
+    anchor = datetime(2026, 1, 1, tzinfo=UTC)  # 210 days back
+
+    start = current_cycle_start("31d", anchor, now)
+    assert start is not None
+    # 210 // 31 = 6 whole cycles -> 186 days after the anchor.
+    assert start == anchor + timedelta(days=186)
+    assert start <= now < start + timedelta(days=31)
+
+    # 1mo snaps to the calendar month, matching LiteLLM's own boundary.
+    assert current_cycle_start("1mo", anchor, now) == datetime(2026, 7, 1, tzinfo=UTC)
+    # An anchor in the future is left alone, and junk yields nothing.
+    future = now + timedelta(days=5)
+    assert current_cycle_start("31d", future, now) == future
+    assert current_cycle_start("weekly", anchor, now) is None
+    assert current_cycle_start(None, anchor, now) is None
+
+
+@pytest.mark.asyncio
+async def test_capped_key_is_measured_over_the_cap_cycle_not_the_pool(db, region):
+    """195 of 196 key caps on PROD sit on top-up-only teams.
+
+    The team's cycle can be far longer than the cap's, so summing the team window
+    against a monthly cap would read hundreds of percent and fire immediately.
+    """
+    team = _make_team(db)
+    # Top-up-only team whose cycle opened 90 days ago, holding $250.
+    _add_topup(db, team, region, amount_cents=25_000, purchased_days_ago=90)
+    key = _make_key(db, team, region, token="sk-a")
+    db.add(
+        DBSpendCap(
+            scope="key",
+            region_id=region.id,
+            team_id=team.id,
+            key_id=key.id,
+            max_budget=100.0,
+            budget_duration="1mo",
+        )
+    )
+    db.commit()
+    lite = f"{region.name}_{team.id}"
+
+    # $200 spent 60 days ago (an earlier cap cycle) and $30 spent today.
+    rows = [
+        _day(lite, 200.0, days_ago=60, keys={"sk-a": 200.0}),
+        _day(lite, 30.0, days_ago=0, keys={"sk-a": 30.0}),
+    ]
+
+    with _patch_litellm(rows, [_key_state("sk-a")]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    key_events = [e for e in result.events if e.subject_type == SUBJECT_KEY]
+    # $30 of the $100 monthly cap is 30% -> no band. Measured over the team's
+    # 90-day window it would have been $230/$100 = 230% and fired 100.
+    assert key_events == []
+
+    # The team subject still uses the team cycle and sees everything: $230 of the
+    # $250 pool is 92%, so the team is warned even though the key is not.
+    team_event = next(e for e in result.events if e.subject_type == SUBJECT_TEAM)
+    assert team_event.spend == 230.0
+    assert team_event.threshold_pct == 90
+
+
+@pytest.mark.asyncio
+async def test_capped_key_crossing_inside_its_own_cycle_still_fires(db, region):
+    """The narrower window must not suppress a real crossing."""
+    team = _make_team(db)
+    _add_topup(db, team, region, amount_cents=100_000, purchased_days_ago=90)
+    key = _make_key(db, team, region, token="sk-a")
+    db.add(
+        DBSpendCap(
+            scope="key",
+            region_id=region.id,
+            team_id=team.id,
+            key_id=key.id,
+            max_budget=100.0,
+            budget_duration="1mo",
+        )
+    )
+    db.commit()
+    lite = f"{region.name}_{team.id}"
+
+    # $92 spent today, inside the current calendar month.
+    rows = [_day(lite, 92.0, days_ago=0, keys={"sk-a": 92.0})]
+
+    with _patch_litellm(rows, [_key_state("sk-a")]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    event = next(e for e in result.events if e.subject_type == SUBJECT_KEY)
+    assert event.threshold_pct == 90
+    assert event.spend == 92.0
+    assert event.max_budget == 100.0
+    assert event.budget_source == "key_cap"
+    assert event.budget_duration == "1mo"
+    # The cap's cycle, not the team's, so a new month re-arms the key alert.
+    assert event.period_key.startswith("key_cap:1mo:")
+
+
+@pytest.mark.asyncio
+async def test_member_cap_is_measured_over_the_cap_cycle(db, region):
+    """All 38 team-member caps on PROD are 1mo, same rule as key caps."""
+    team = _make_team(db)
+    _add_topup(db, team, region, amount_cents=100_000, purchased_days_ago=90)
+    user = _make_user(db, team)
+    _make_key(db, team, region, token="sk-a", owner=user)
+    db.add(
+        DBSpendCap(
+            scope="team_member",
+            region_id=region.id,
+            team_id=team.id,
+            user_id=user.id,
+            max_budget=50.0,
+            budget_duration="1mo",
+        )
+    )
+    db.commit()
+    lite = f"{region.name}_{team.id}"
+
+    rows = [
+        _day(lite, 300.0, days_ago=60, keys={"sk-a": 300.0}),  # earlier cycle
+        _day(lite, 26.0, days_ago=0, keys={"sk-a": 26.0}),  # this cycle
+    ]
+
+    with _patch_litellm(rows, [_key_state("sk-a")]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    event = next(e for e in result.events if e.subject_type == SUBJECT_TEAM_MEMBER)
+    # $26 of $50 is 52% -> crosses 50 only. Over the team window it would have
+    # been $326/$50 and fired 100 on spend that belongs to earlier months.
+    assert event.spend == 26.0
+    assert event.threshold_pct == 50
+
+
+@pytest.mark.asyncio
+async def test_uncapped_key_keeps_the_team_cycle(db, region):
+    """A key bounded by the pool has no cycle of its own."""
+    team = _make_team(db)
+    _add_topup(db, team, region, amount_cents=20_000, purchased_days_ago=90)
+    _make_key(db, team, region, token="sk-a", name="a")
+    _make_key(db, team, region, token="sk-b", name="b")
+    lite = f"{region.name}_{team.id}"
+
+    rows = [
+        _day(lite, 100.0, days_ago=60, keys={"sk-a": 100.0}),
+        _day(lite, 90.0, days_ago=0, keys={"sk-a": 90.0}),
+    ]
+
+    with _patch_litellm(rows, [_key_state("sk-a"), _key_state("sk-b")]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    event = next(
+        e
+        for e in result.events
+        if e.subject_type == SUBJECT_KEY and e.budget_source == "team_pool"
+    )
+    # Both days count: the pool window is the team's, opened by the last top-up.
+    assert event.spend == 190.0
+    assert event.max_budget == 200.0
+    assert event.threshold_pct == 90

--- a/tests/test_budget_alerts.py
+++ b/tests/test_budget_alerts.py
@@ -702,6 +702,69 @@ async def test_delivery_failure_returns_no_delivered_ids(db, region):
 
 
 @pytest.mark.asyncio
+async def test_audit_log_records_delivered_and_undelivered_crossings(db, region):
+    """budget_alert_state only holds the current band, so the audit log is the
+    only durable answer to "was this customer warned"."""
+    from app.core.budget_alert_service import write_audit_logs
+    from app.db.models import DBAuditLog
+
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=10_000)
+    lite_team_id = f"{region.name}_{team.id}"
+
+    with _patch_litellm([_activity(lite_team_id, 92.0)]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    event = next(e for e in result.events if e.subject_type == SUBJECT_TEAM)
+
+    # Delivered.
+    assert write_audit_logs(db, [event], {event.event_id}) == 1
+    row = (
+        db.query(DBAuditLog)
+        .filter(DBAuditLog.action == "budget.threshold_reached")
+        .one()
+    )
+    assert row.resource_type == SUBJECT_TEAM
+    assert row.resource_id == f"team:{team.id}:{region.id}"
+    assert row.details["delivered"] is True
+    assert row.details["threshold_percent"] == 90
+    assert row.details["team_id"] == team.id
+    assert row.event_type == "WORKER"
+
+    # Undelivered crossings are recorded too, flagged as such.
+    write_audit_logs(db, [event], set())
+    rows = (
+        db.query(DBAuditLog)
+        .filter(DBAuditLog.action == "budget.threshold_reached")
+        .all()
+    )
+    assert sorted(r.details["delivered"] for r in rows) == [False, True]
+
+
+def test_audit_log_write_failure_does_not_raise(db):
+    """Auditing is a side effect; it must never break the sweep."""
+    from app.core.budget_alert_service import BudgetAlertEvent, write_audit_logs
+
+    event = BudgetAlertEvent(
+        event_id="evt_audit",
+        subject_type=SUBJECT_TEAM,
+        subject_key="team:1:1",
+        threshold_pct=50,
+        percent_used=55.0,
+        spend=55.0,
+        max_budget=100.0,
+        region_id=1,
+        region_name="r",
+        period_key="k",
+        period_start=None,
+        period_end=None,
+        budget_duration=None,
+    )
+    with patch.object(db, "commit", side_effect=RuntimeError("db gone")):
+        assert write_audit_logs(db, [event], set()) == 0
+
+
+@pytest.mark.asyncio
 async def test_delivery_without_url_configured_is_a_no_op(db, region):
     from app.services.budget_alert_webhook import deliver_events
     from app.core.budget_alert_service import BudgetAlertEvent

--- a/tests/test_budget_alerts.py
+++ b/tests/test_budget_alerts.py
@@ -701,6 +701,47 @@ async def test_delivery_failure_returns_no_delivered_ids(db, region):
     assert delivered == set()
 
 
+# --------------------------------------------------------------------------- #
+# Which regions get swept
+# --------------------------------------------------------------------------- #
+
+
+def test_inactive_region_holding_keys_is_still_swept(db, region):
+    """PROD region 5 is inactive but holds 85% of all keys.
+
+    is_active governs new provisioning, not whether existing keys serve traffic.
+    Filtering on it would exclude the anonymous trial fleet -- the population most
+    likely to hit a budget limit -- from every alert.
+    """
+    from app.core.budget_alert_service import regions_to_sweep
+
+    team = _make_team(db)
+    region.is_active = False
+    db.commit()
+    _make_key(db, team, region, token="sk-inactive-region-key")
+
+    assert [r.id for r in regions_to_sweep(db)] == [region.id]
+
+
+def test_region_without_keys_is_not_swept(db, region):
+    """An empty region has nothing to alert on, active or not."""
+    from app.core.budget_alert_service import regions_to_sweep
+
+    assert regions_to_sweep(db) == []
+
+
+def test_region_without_litellm_credentials_is_not_swept(db, region):
+    """A region we cannot reach must not be attempted every 5 minutes."""
+    from app.core.budget_alert_service import regions_to_sweep
+
+    team = _make_team(db)
+    _make_key(db, team, region, token="sk-no-creds")
+    region.litellm_api_url = ""
+    db.commit()
+
+    assert regions_to_sweep(db) == []
+
+
 @pytest.mark.asyncio
 async def test_audit_log_records_delivered_and_undelivered_crossings(db, region):
     """budget_alert_state only holds the current band, so the audit log is the

--- a/tests/test_budget_alerts.py
+++ b/tests/test_budget_alerts.py
@@ -433,11 +433,14 @@ async def test_spend_against_an_expired_topup_is_not_counted(db, region):
 
 
 @pytest.mark.asyncio
-async def test_topup_only_team_counts_from_the_last_purchase(db, region):
-    """For a top-up-only team the cycle starts at the last top-up purchase.
+async def test_topup_only_team_counts_from_the_oldest_valid_purchase(db, region):
+    """The window opens at the OLDEST still-valid purchase, not the newest.
 
-    Spend from before it belongs to an earlier cycle and is not counted again,
-    even when the older top-up is still valid and still funding the balance.
+    The budget is the full face value of every valid entry, because
+    ``consumed_cents`` is only written at invoice close and a team with no
+    subscription never has one. Opening the window at the newest purchase would
+    leave spend against the older entries counted nowhere — absent from the
+    numerator and not deducted from the budget either.
     """
     team = _make_team(db)
     # Both still valid: $100 bought 100 days ago, $100 bought 10 days ago.
@@ -447,20 +450,19 @@ async def test_topup_only_team_counts_from_the_last_purchase(db, region):
     lite = f"{region.name}_{team.id}"
 
     rows = [
-        _day(lite, 85.0, days_ago=90, keys={"sk-a": 85.0}),  # previous cycle
-        _day(lite, 120.0, days_ago=1, keys={"sk-a": 120.0}),  # this cycle
+        _day(lite, 85.0, days_ago=90, keys={"sk-a": 85.0}),
+        _day(lite, 120.0, days_ago=1, keys={"sk-a": 120.0}),
     ]
 
     with _patch_litellm(rows, [_key_state("sk-a")]):
         result = await evaluate_region(db, region, thresholds=THRESHOLDS)
 
     event = next(e for e in result.events if e.subject_type == SUBJECT_TEAM)
-    # Only the $120 spent since the last purchase counts, against the $200 still on
-    # the books -> 60%. Including the older $85 would read 102.5% and fire 100.
-    assert event.spend == 120.0
+    # All $205 spent against the $200 the team still holds -> over 100%. Anchored on
+    # the newest purchase this read $120 of $200 (60%) and the $85 vanished.
+    assert event.spend == 205.0
     assert event.max_budget == 200.0
-    assert event.threshold_pct == 50
-    assert 59.9 < event.percent_used < 60.1
+    assert event.threshold_pct == 100
 
 
 @pytest.mark.asyncio
@@ -494,8 +496,15 @@ async def test_subscription_cycle_wins_over_an_older_topup(db, region):
 
 
 @pytest.mark.asyncio
-async def test_new_topup_re_arms_the_bands(db, region):
-    """Alerts are per budget cycle, and a purchase starts a new one."""
+async def test_new_topup_walks_the_band_back_without_changing_the_period(db, region):
+    """A purchase re-arms through ``arm_seq``, not through a new period.
+
+    The window is anchored on the oldest still-valid purchase, so buying more does
+    not move ``period_start`` and ``period_key`` is unchanged. What changes is the
+    budget: it rises, the percentage falls, and the band is rewritten silently so a
+    genuine re-crossing later still notifies. Bands are not blanket-reset to 0 —
+    a team still above 50% is not warned about 50% a second time.
+    """
     team = _make_team(db)
     _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=5)  # $100
     _make_key(db, team, region, token="sk-a")
@@ -508,7 +517,6 @@ async def test_new_topup_re_arms_the_bands(db, region):
     assert first_event.threshold_pct == 90
     mark_notified(db, region, first, {e.event_id for e in first.events})
 
-    # Buying more moves the pool window anchor, so period_key changes.
     _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=0)  # +$100
     with _patch_litellm(rows, [_key_state("sk-a")]):
         second = await evaluate_region(db, region, thresholds=THRESHOLDS)
@@ -521,8 +529,9 @@ async def test_new_topup_re_arms_the_bands(db, region):
         .filter(DBBudgetAlertState.subject_key == f"team:{team.id}:{region.id}")
         .one()
     )
-    assert state.last_threshold_pct == 0
-    assert state.period_key != first_event.period_key
+    assert state.period_key == first_event.period_key  # same pool, same window
+    assert state.last_threshold_pct == 0  # 46% crosses nothing
+    assert state.arm_seq == 1  # re-armed, so a second 90% gets a fresh event_id
 
 
 # --------------------------------------------------------------------------- #
@@ -616,7 +625,7 @@ def test_future_expiry_is_not_a_candidate_yet(db, region):
     assert denominator_change_candidates(db, region.id, datetime.now(UTC)) == set()
 
 
-def test_spend_window_start_is_the_last_topup_for_a_topup_only_team(db, region):
+def test_spend_window_start_is_the_oldest_valid_topup(db, region):
     """Directly pin the rule, since everything downstream depends on it."""
     from app.core.budget_alert_service import spend_window_start
 
@@ -627,8 +636,11 @@ def test_spend_window_start_is_the_last_topup_for_a_topup_only_team(db, region):
 
     window = resolve_team_period_window(db, team, region.id, now=now)
     start = spend_window_start(window, now)
-    # The most recent purchase opens the cycle, not the older still-valid one.
-    assert 4 <= (now - start).days <= 6
+    # The oldest still-valid purchase opens the window, not the most recent one.
+    assert 39 <= (now - start).days <= 41
+    # ...while the window closes 365 days after the NEWEST purchase.
+    assert window.period_end is not None
+    assert 359 <= (window.period_end - now).days <= 361
 
 
 def test_spend_window_start_is_the_cycle_start_when_subscribed(db, region):

--- a/tests/test_budget_alerts.py
+++ b/tests/test_budget_alerts.py
@@ -1700,3 +1700,46 @@ async def test_uncapped_key_keeps_the_team_cycle(db, region):
     assert event.spend == 190.0
     assert event.max_budget == 200.0
     assert event.threshold_pct == 90
+
+
+@pytest.mark.asyncio
+async def test_rolling_cap_cycle_is_anchored_on_the_cap_not_the_team(db, region):
+    """A cap set months after the team must count from *its* cycle.
+
+    Verified against PROD: for a team whose cap was set well after the team, the
+    cap's created_at reproduces LiteLLM's budget_reset_at to the time of day while
+    team creation was 18.7 days out. 29 of the 130 rolling 31d caps were set more
+    than a day after their team, by up to 420 days.
+    """
+    now = datetime.now(UTC)
+    team = _make_team(db)
+    team.created_at = now - timedelta(days=60)
+    _add_topup(db, team, region, amount_cents=100_000, purchased_days_ago=50)
+    key = _make_key(db, team, region, token="sk-a")
+    db.add(
+        DBSpendCap(
+            scope="key",
+            region_id=region.id,
+            team_id=team.id,
+            key_id=key.id,
+            max_budget=100.0,
+            budget_duration="31d",
+            # Set 40 days ago -> one whole cycle elapsed -> current cycle opened 9
+            # days ago. Anchored on the team it would have opened 29 days ago.
+            created_at=now - timedelta(days=40),
+        )
+    )
+    db.commit()
+    lite = f"{region.name}_{team.id}"
+
+    rows = [
+        _day(lite, 80.0, days_ago=20, keys={"sk-a": 80.0}),  # previous cap cycle
+        _day(lite, 30.0, days_ago=1, keys={"sk-a": 30.0}),  # current cap cycle
+    ]
+
+    with _patch_litellm(rows, [_key_state("sk-a")]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    # $30 of $100 is 30% -> silent. Anchored on the team it would have summed
+    # $110, read 110%, and fired 100 on spend from the previous cycle.
+    assert [e for e in result.events if e.subject_type == SUBJECT_KEY] == []

--- a/tests/test_budget_alerts.py
+++ b/tests/test_budget_alerts.py
@@ -4,6 +4,12 @@ The important cases here are the ones where the maths is easy to get wrong:
 LiteLLM's compounding team counter, POOL's moving denominator, and cycle
 rollover. A percentage that is silently wrong is worse than no alert at all,
 because it teaches customers to ignore the warnings.
+
+Note the split of responsibilities in the fakes below, which mirrors the engine:
+daily-activity day-rows carry the *spend* (summed from the oldest still-valid
+ledger entry), while key state carries only the *denominator*. LiteLLM's key spend
+counters are lifetime totals a top-up never resets, so they are never the
+numerator.
 """
 
 from datetime import UTC, datetime, timedelta
@@ -32,6 +38,7 @@ from app.db.models import (
     DBUser,
 )
 from app.schemas.models import BudgetType
+from app.services.litellm import LiteLLMService
 
 THRESHOLDS = [50, 75, 90, 100]
 
@@ -58,7 +65,7 @@ def test_highest_crossed_band_returns_only_the_top_band():
 
 
 # --------------------------------------------------------------------------- #
-# Fixtures
+# Fixtures and fakes
 # --------------------------------------------------------------------------- #
 
 
@@ -112,12 +119,7 @@ def _make_key(db, team, region, *, name="k1", token="sk-key-1", owner=None):
 
 
 def _make_user(db, team, email="member@example.com"):
-    user = DBUser(
-        email=email,
-        hashed_password="x",
-        is_active=True,
-        team_id=team.id,
-    )
+    user = DBUser(email=email, hashed_password="x", is_active=True, team_id=team.id)
     db.add(user)
     db.commit()
     db.refresh(user)
@@ -142,29 +144,63 @@ def _add_subscription(db, team, region, *, amount_cents, days_left=20):
     return entry
 
 
-def _activity(lite_team_id, spend, *, day_offset=0, hashed_keys=None):
-    """Build one day of LiteLLM daily-activity output."""
-    day = (datetime.now(UTC) - timedelta(days=day_offset)).date().isoformat()
-    api_keys = {
-        hashed: {"metrics": {"spend": value}}
-        for hashed, value in (hashed_keys or {}).items()
-    }
+def _add_topup(
+    db, team, region, *, amount_cents, purchased_days_ago=1, expires_at=None
+):
+    now = datetime.now(UTC)
+    entry = DBPeriodicBudgetLedgerEntry(
+        team_id=team.id,
+        region_id=region.id,
+        entry_type="topup",
+        amount_cents=amount_cents,
+        consumed_cents=0,
+        is_active=True,
+        purchased_at=now - timedelta(days=purchased_days_ago),
+        expires_at=expires_at if expires_at is not None else now + timedelta(days=364),
+    )
+    db.add(entry)
+    db.commit()
+    return entry
+
+
+def _day(lite_team_id, spend, *, days_ago=0, keys=None):
+    """One UTC day of activity, optionally with a per-key breakdown."""
     return {
-        "date": day,
+        "date": (datetime.now(UTC) - timedelta(days=days_ago)).date().isoformat(),
         "metrics": {"spend": spend},
         "breakdown": {
             "entities": {lite_team_id: {"metrics": {"spend": spend}}},
-            "api_keys": api_keys,
+            "api_keys": {
+                LiteLLMService.hash_token(token): {"metrics": {"spend": value}}
+                for token, value in (keys or {}).items()
+            },
         },
     }
 
 
-def _patch_litellm(team_rows, user_rows=None, team_keys=None):
-    """Patch the three LiteLLM reads the engine can make."""
+def _active(lite_team_id, spend=0.0, *, keys=None, days_ago=0):
+    """Today's activity for one team."""
+    return [_day(lite_team_id, spend, days_ago=days_ago, keys=keys)]
+
+
+def _key_state(token, *, max_budget=None, budget_duration="365d"):
+    """One entry of LiteLLM's /key/list response.
+
+    Carries the *denominator* only. Spend deliberately comes from the day-rows, so
+    a test cannot accidentally assert against LiteLLM's lifetime counter.
+    """
+    return {
+        "token": LiteLLMService.hash_token(token),
+        "max_budget": max_budget,
+        "budget_duration": budget_duration,
+    }
+
+
+def _patch_litellm(team_rows, team_keys=None):
+    """Patch the two LiteLLM reads the engine makes."""
     return patch.multiple(
         "app.core.budget_alert_service.LiteLLMService",
         get_all_team_daily_activity=AsyncMock(return_value=team_rows),
-        get_all_user_daily_activity=AsyncMock(return_value=user_rows or []),
         list_keys_for_team=AsyncMock(return_value=team_keys or []),
     )
 
@@ -179,10 +215,11 @@ async def test_pool_team_percentage_uses_ledger_not_litellm_max_budget(db, regio
     """The denominator is our ledger, and one crossing yields one event."""
     team = _make_team(db)
     _add_subscription(db, team, region, amount_cents=10_000)  # $100
-    lite_team_id = f"{region.name}_{team.id}"
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
 
     # $92 spent of $100 -> 92% -> crosses the 90 band.
-    with _patch_litellm([_activity(lite_team_id, 92.0)]):
+    with _patch_litellm(_active(lite, keys={"sk-a": 92.0}), [_key_state("sk-a")]):
         result = await evaluate_region(db, region, thresholds=THRESHOLDS)
 
     team_events = [e for e in result.events if e.subject_type == SUBJECT_TEAM]
@@ -193,6 +230,49 @@ async def test_pool_team_percentage_uses_ledger_not_litellm_max_budget(db, regio
     assert event.spend == 92.0
     assert 91.9 < event.percent_used < 92.1
     assert event.team_id == team.id
+    assert event.budget_source == "team_ledger"
+
+
+@pytest.mark.asyncio
+async def test_team_spend_is_the_sum_of_its_keys(db, region):
+    """Team and key percentages must come from the same numbers."""
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=10_000)  # $100
+    _make_key(db, team, region, token="sk-a", name="a")
+    _make_key(db, team, region, token="sk-b", name="b")
+    lite = f"{region.name}_{team.id}"
+
+    with _patch_litellm(
+        _active(lite, keys={"sk-a": 60.0, "sk-b": 32.0}),
+        [_key_state("sk-a"), _key_state("sk-b")],
+    ):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    event = next(e for e in result.events if e.subject_type == SUBJECT_TEAM)
+    assert event.spend == 92.0
+    assert event.threshold_pct == 90
+
+
+@pytest.mark.asyncio
+async def test_team_total_comes_from_keys_not_the_entity_figure(db, region):
+    """The team numerator is built from the per-key breakdown.
+
+    Using the entity figure directly would attribute spend we cannot tie to any of
+    our keys, so team and key percentages could disagree.
+    """
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=10_000)  # $100
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
+
+    rows = _active(lite, spend=99999.0, keys={"sk-a": 55.0})
+
+    with _patch_litellm(rows, [_key_state("sk-a")]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    event = next(e for e in result.events if e.subject_type == SUBJECT_TEAM)
+    assert event.spend == 55.0
+    assert event.threshold_pct == 50
 
 
 @pytest.mark.asyncio
@@ -204,10 +284,11 @@ async def test_team_cap_tightens_the_denominator(db, region):
         DBSpendCap(scope="team", region_id=region.id, team_id=team.id, max_budget=50.0)
     )
     db.commit()
-    lite_team_id = f"{region.name}_{team.id}"
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
 
     # $46 is 46% of $100 but 92% of the $50 cap.
-    with _patch_litellm([_activity(lite_team_id, 46.0)]):
+    with _patch_litellm(_active(lite, keys={"sk-a": 46.0}), [_key_state("sk-a")]):
         result = await evaluate_region(db, region, thresholds=THRESHOLDS)
 
     event = next(e for e in result.events if e.subject_type == SUBJECT_TEAM)
@@ -219,23 +300,25 @@ async def test_team_cap_tightens_the_denominator(db, region):
 async def test_no_budget_means_no_event(db, region):
     """A team with no ledger and no limit has nothing to be a percentage of."""
     team = _make_team(db)
-    lite_team_id = f"{region.name}_{team.id}"
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
 
-    with _patch_litellm([_activity(lite_team_id, 500.0)]):
+    with _patch_litellm(_active(lite, keys={"sk-a": 500.0}), [_key_state("sk-a")]):
         result = await evaluate_region(db, region, thresholds=THRESHOLDS)
 
-    assert [e for e in result.events if e.subject_type == SUBJECT_TEAM] == []
+    assert result.events == []
 
 
 @pytest.mark.asyncio
 async def test_soft_deleted_team_is_skipped(db, region):
     team = _make_team(db)
     _add_subscription(db, team, region, amount_cents=10_000)
+    _make_key(db, team, region, token="sk-a")
     team.deleted_at = datetime.now(UTC)
     db.commit()
-    lite_team_id = f"{region.name}_{team.id}"
+    lite = f"{region.name}_{team.id}"
 
-    with _patch_litellm([_activity(lite_team_id, 99.0)]):
+    with _patch_litellm(_active(lite, keys={"sk-a": 99.0}), [_key_state("sk-a")]):
         result = await evaluate_region(db, region, thresholds=THRESHOLDS)
 
     assert result.events == []
@@ -243,13 +326,25 @@ async def test_soft_deleted_team_is_skipped(db, region):
 
 @pytest.mark.asyncio
 async def test_empty_activity_sweep_produces_nothing(db, region):
-    _make_team(db)
+    """No traffic and no budget change -> no per-team key calls at all.
 
-    with _patch_litellm([]):
+    This is the property that makes a 5-minute cadence affordable: a quiet region
+    costs exactly one request.
+    """
+    _make_team(db)
+    list_keys = AsyncMock(return_value=[])
+
+    with patch.multiple(
+        "app.core.budget_alert_service.LiteLLMService",
+        get_all_team_daily_activity=AsyncMock(return_value=[]),
+        list_keys_for_team=list_keys,
+    ):
         result = await evaluate_region(db, region, thresholds=THRESHOLDS)
 
     assert result.events == []
     assert result.subjects_evaluated == 0
+    assert result.litellm_calls == 1
+    list_keys.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -257,94 +352,127 @@ async def test_unknown_entities_are_ignored(db, region):
     """LiteLLM's own bookkeeping team is not one of ours."""
     _make_team(db)
 
-    with _patch_litellm([_activity("litellm-dashboard", 100.0)]):
+    with _patch_litellm(_active("litellm-dashboard", spend=100.0)):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert result.events == []
+
+
+@pytest.mark.asyncio
+async def test_periodic_team_is_out_of_scope(db, region):
+    """PERIODIC is excluded: on PROD every PERIODIC key belongs to the anonymous
+    trial team, which has no MOAD workspace and nobody to notify."""
+    team = _make_team(db, budget_type=BudgetType.PERIODIC, name="periodic-team")
+    _add_subscription(db, team, region, amount_cents=10_000)
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
+
+    with _patch_litellm(_active(lite, keys={"sk-a": 99.0}), [_key_state("sk-a")]):
         result = await evaluate_region(db, region, thresholds=THRESHOLDS)
 
     assert result.events == []
 
 
 # --------------------------------------------------------------------------- #
-# Dedup, re-arm, and the POOL moving denominator
+# Top-up windows: which spend counts against the current budget
 # --------------------------------------------------------------------------- #
 
 
 @pytest.mark.asyncio
-async def test_same_band_is_not_notified_twice(db, region):
-    team = _make_team(db)
-    _add_subscription(db, team, region, amount_cents=10_000)
-    lite_team_id = f"{region.name}_{team.id}"
-    rows = [_activity(lite_team_id, 92.0)]
+async def test_spend_against_an_expired_topup_is_not_counted(db, region):
+    """The top-up-only case, and the reason spend is not read from key counters.
 
-    with _patch_litellm(rows):
-        first = await evaluate_region(db, region, thresholds=THRESHOLDS)
-    delivered = {e.event_id for e in first.events}
-    mark_notified(db, region, first, delivered)
+    A top-up never resets key spend (purchase_periodic_topup only raises the team
+    max_budget), so LiteLLM's counters are lifetime totals. The denominator counts
+    only unexpired entries. Taking spend from the counters would therefore leave an
+    expired top-up's spend in the numerator after its money left the denominator:
 
-    with _patch_litellm(rows):
-        second = await evaluate_region(db, region, thresholds=THRESHOLDS)
-
-    assert [e for e in second.events if e.subject_type == SUBJECT_TEAM] == []
-
-
-@pytest.mark.asyncio
-async def test_higher_band_notifies_again_in_the_same_period(db, region):
-    team = _make_team(db)
-    _add_subscription(db, team, region, amount_cents=10_000)
-    lite_team_id = f"{region.name}_{team.id}"
-
-    with _patch_litellm([_activity(lite_team_id, 60.0)]):
-        first = await evaluate_region(db, region, thresholds=THRESHOLDS)
-    assert (
-        next(e for e in first.events if e.subject_type == SUBJECT_TEAM).threshold_pct
-        == 50
-    )
-    mark_notified(db, region, first, {e.event_id for e in first.events})
-
-    with _patch_litellm([_activity(lite_team_id, 91.0)]):
-        second = await evaluate_region(db, region, thresholds=THRESHOLDS)
-
-    assert (
-        next(e for e in second.events if e.subject_type == SUBJECT_TEAM).threshold_pct
-        == 90
-    )
-
-
-@pytest.mark.asyncio
-async def test_topup_lowering_the_percentage_does_not_alert_but_re_arms(db, region):
-    """The POOL moving-denominator case.
-
-    Crossing 90%, then buying budget, must not emit anything on the way down --
-    but the band has to be rewritten, or the genuine second crossing of 90% is
-    suppressed forever.
+        $100 expired (of which $80 spent) + $100 bought 10 days ago, $2 spent
+        lifetime $82 / remaining $100 -> 82%   (wrong, would alert at 75)
+        windowed  $2 / remaining $100 ->  2%   (right, no alert)
     """
     team = _make_team(db)
-    _add_subscription(db, team, region, amount_cents=10_000)  # $100
-    lite_team_id = f"{region.name}_{team.id}"
+    now = datetime.now(UTC)
+    # Old money, now expired: $100 purchased 100 days ago, $80 spent against it.
+    _add_topup(
+        db,
+        team,
+        region,
+        amount_cents=10_000,
+        purchased_days_ago=100,
+        expires_at=now - timedelta(days=2),
+    )
+    # Current money: $100 purchased 10 days ago.
+    _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=10)
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
 
-    with _patch_litellm([_activity(lite_team_id, 92.0)]):
+    rows = [
+        _day(lite, 80.0, days_ago=90, keys={"sk-a": 80.0}),  # spent on the old money
+        _day(lite, 2.0, days_ago=1, keys={"sk-a": 2.0}),  # spent on the new money
+    ]
+
+    with _patch_litellm(rows, [_key_state("sk-a")]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    # Only the $2 counts, so nothing crosses 50%.
+    assert result.events == []
+
+
+@pytest.mark.asyncio
+async def test_spend_against_an_older_but_still_valid_topup_is_counted(db, region):
+    """The other direction: valid money keeps its spend.
+
+    Anchoring on the *newest* purchase would have dropped the $85 spent against the
+    still-valid older top-up and reported ~2% instead of ~43%.
+    """
+    team = _make_team(db)
+    # Both still valid: $100 bought 100 days ago, $100 bought 10 days ago.
+    _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=100)
+    _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=10)
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
+
+    rows = [
+        _day(lite, 85.0, days_ago=90, keys={"sk-a": 85.0}),
+        _day(lite, 20.0, days_ago=1, keys={"sk-a": 20.0}),
+    ]
+
+    with _patch_litellm(rows, [_key_state("sk-a")]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    event = next(e for e in result.events if e.subject_type == SUBJECT_TEAM)
+    # All $105 counts against the $200 still on the books -> 52.5%, crossing 50.
+    # Anchoring on the newest purchase would have seen only $20 (10%) and stayed
+    # silent, which is the failure this test exists to catch.
+    assert event.spend == 105.0
+    assert event.max_budget == 200.0
+    assert event.threshold_pct == 50
+    assert 52.4 < event.percent_used < 52.6
+
+
+@pytest.mark.asyncio
+async def test_new_topup_re_arms_the_bands(db, region):
+    """Alerts are per budget cycle, and a purchase starts a new one."""
+    team = _make_team(db)
+    _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=5)  # $100
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
+    rows = [_day(lite, 92.0, days_ago=1, keys={"sk-a": 92.0})]
+
+    with _patch_litellm(rows, [_key_state("sk-a")]):
         first = await evaluate_region(db, region, thresholds=THRESHOLDS)
+    first_event = next(e for e in first.events if e.subject_type == SUBJECT_TEAM)
+    assert first_event.threshold_pct == 90
     mark_notified(db, region, first, {e.event_id for e in first.events})
 
-    # Top-up: budget becomes $300, so $92 is now ~31%.
-    db.add(
-        DBPeriodicBudgetLedgerEntry(
-            team_id=team.id,
-            region_id=region.id,
-            entry_type="topup",
-            amount_cents=20_000,
-            consumed_cents=0,
-            is_active=True,
-            purchased_at=datetime.now(UTC),
-        )
-    )
-    db.commit()
-
-    with _patch_litellm([_activity(lite_team_id, 92.0)]):
+    # Buying more moves the pool window anchor, so period_key changes.
+    _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=0)  # +$100
+    with _patch_litellm(rows, [_key_state("sk-a")]):
         second = await evaluate_region(db, region, thresholds=THRESHOLDS)
 
-    # Nothing announced on the decrease...
+    # $92 of $200 is 46%, below the band already sent -- silent walk-back, no event.
     assert [e for e in second.events if e.subject_type == SUBJECT_TEAM] == []
-    # ...but the band was walked back.
     apply_resets(db, region, second)
     state = (
         db.query(DBBudgetAlertState)
@@ -352,353 +480,130 @@ async def test_topup_lowering_the_percentage_does_not_alert_but_re_arms(db, regi
         .one()
     )
     assert state.last_threshold_pct == 0
+    assert state.period_key != first_event.period_key
 
-    # Spending up to 90% of the larger budget alerts again.
-    with _patch_litellm([_activity(lite_team_id, 275.0)]):
-        third = await evaluate_region(db, region, thresholds=THRESHOLDS)
 
-    assert (
-        next(e for e in third.events if e.subject_type == SUBJECT_TEAM).threshold_pct
-        == 90
-    )
+# --------------------------------------------------------------------------- #
+# Budget decreases with no recent traffic
+# --------------------------------------------------------------------------- #
 
 
 @pytest.mark.asyncio
-async def test_new_period_re_arms_the_same_band(db, region):
+async def test_expired_topup_raises_the_percentage(db, region):
+    """A lapsing top-up shrinks the denominator, with no new traffic at all."""
     team = _make_team(db)
-    subscription = _add_subscription(db, team, region, amount_cents=10_000)
-    lite_team_id = f"{region.name}_{team.id}"
-
-    with _patch_litellm([_activity(lite_team_id, 92.0)]):
-        first = await evaluate_region(db, region, thresholds=THRESHOLDS)
-    mark_notified(db, region, first, {e.event_id for e in first.events})
-    old_period_key = next(
-        e for e in first.events if e.subject_type == SUBJECT_TEAM
-    ).period_key
-
-    # Roll the cycle: a new window means a new period_key.
     now = datetime.now(UTC)
-    subscription.effective_period_start = now - timedelta(days=1)
-    subscription.effective_period_end = now + timedelta(days=30)
-    db.commit()
-
-    with _patch_litellm([_activity(lite_team_id, 92.0)]):
-        second = await evaluate_region(db, region, thresholds=THRESHOLDS)
-
-    event = next(e for e in second.events if e.subject_type == SUBJECT_TEAM)
-    assert event.threshold_pct == 90
-    assert event.period_key != old_period_key
-
-
-@pytest.mark.asyncio
-async def test_failed_delivery_leaves_state_unadvanced_and_retries(db, region):
-    """No outbox: an undelivered event must be re-detected next tick."""
-    team = _make_team(db)
-    _add_subscription(db, team, region, amount_cents=10_000)
-    lite_team_id = f"{region.name}_{team.id}"
-    rows = [_activity(lite_team_id, 92.0)]
-
-    with _patch_litellm(rows):
-        first = await evaluate_region(db, region, thresholds=THRESHOLDS)
-    assert len(first.events) >= 1
-
-    # Delivery failed -> nothing is marked.
-    advanced = mark_notified(db, region, first, set())
-    assert advanced == 0
-
-    with _patch_litellm(rows):
-        second = await evaluate_region(db, region, thresholds=THRESHOLDS)
-
-    assert (
-        next(e for e in second.events if e.subject_type == SUBJECT_TEAM).threshold_pct
-        == 90
+    # $100 still valid, purchased 20 days ago.
+    _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=20)
+    # $200 that lapsed an hour ago -- was purchased *after* the valid one, so the
+    # window start stays at 20 days ago and the $92 below still counts.
+    _add_topup(
+        db,
+        team,
+        region,
+        amount_cents=20_000,
+        purchased_days_ago=15,
+        expires_at=now - timedelta(hours=1),
     )
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
+    rows = [_day(lite, 92.0, days_ago=10, keys={"sk-a": 92.0})]
 
+    with _patch_litellm(rows, [_key_state("sk-a")]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
 
-# --------------------------------------------------------------------------- #
-# Key scope
-# --------------------------------------------------------------------------- #
+    event = next(e for e in result.events if e.subject_type == SUBJECT_TEAM)
+    # Budget was $300, is now $100 -> $92 jumps from 31% to 92%.
+    assert event.max_budget == 100.0
+    assert event.spend == 92.0
+    assert event.threshold_pct == 90
 
 
 @pytest.mark.asyncio
-async def test_key_cap_drives_key_scope_alert(db, region):
+async def test_recent_cap_change_rechecks_a_silent_team(db, region):
+    """Lowering a cap shrinks the denominator as effectively as an expiry."""
     team = _make_team(db)
-    _add_subscription(db, team, region, amount_cents=100_000)  # big team budget
-    key = _make_key(db, team, region, token="sk-key-a")
-    db.add(DBSpendCap(scope="key", region_id=region.id, key_id=key.id, max_budget=10.0))
-    db.commit()
-
-    from app.services.litellm import LiteLLMService
-
-    hashed = LiteLLMService.hash_token("sk-key-a")
-    lite_team_id = f"{region.name}_{team.id}"
-    rows = [_activity(lite_team_id, 7.6, hashed_keys={hashed: 7.6})]
-
-    with _patch_litellm(rows):
-        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
-
-    key_events = [e for e in result.events if e.subject_type == SUBJECT_KEY]
-    assert len(key_events) == 1
-    assert key_events[0].key_id == key.id
-    assert key_events[0].max_budget == 10.0
-    assert key_events[0].threshold_pct == 75
-
-
-@pytest.mark.asyncio
-async def test_key_without_any_budget_emits_nothing(db, region):
-    """POOL keys carry no max_budget unless explicitly capped."""
-    team = _make_team(db)
-    _add_subscription(db, team, region, amount_cents=100_000)
-    _make_key(db, team, region, token="sk-key-b")
-
-    from app.services.litellm import LiteLLMService
-
-    hashed = LiteLLMService.hash_token("sk-key-b")
-    lite_team_id = f"{region.name}_{team.id}"
-
-    with _patch_litellm([_activity(lite_team_id, 900.0, hashed_keys={hashed: 900.0})]):
-        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
-
-    assert [e for e in result.events if e.subject_type == SUBJECT_KEY] == []
-
-
-@pytest.mark.asyncio
-async def test_zero_budget_key_is_skipped(db, region):
-    """A pool-gated key is born with max_budget 0; that is not 100% used."""
-    team = _make_team(db)
-    _add_subscription(db, team, region, amount_cents=100_000)
-    key = _make_key(db, team, region, token="sk-key-c")
-    db.add(DBSpendCap(scope="key", region_id=region.id, key_id=key.id, max_budget=0.0))
-    db.commit()
-
-    from app.services.litellm import LiteLLMService
-
-    hashed = LiteLLMService.hash_token("sk-key-c")
-    lite_team_id = f"{region.name}_{team.id}"
-
-    with _patch_litellm([_activity(lite_team_id, 0.0, hashed_keys={hashed: 0.0})]):
-        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
-
-    assert [e for e in result.events if e.subject_type == SUBJECT_KEY] == []
-
-
-@pytest.mark.asyncio
-async def test_expiring_key_is_skipped(db, region):
-    """A key being expired (budget_duration 0d) is not a budget warning."""
-    team = _make_team(db, budget_type=BudgetType.PERIODIC)
-    _add_subscription(db, team, region, amount_cents=100_000)
-    _make_key(db, team, region, token="sk-key-d")
-
-    from app.services.litellm import LiteLLMService
-
-    hashed = LiteLLMService.hash_token("sk-key-d")
-    lite_team_id = f"{region.name}_{team.id}"
-    # PERIODIC teams take the exact-key path, which is where 0d is visible.
-    team_keys = [
-        {
-            "token": hashed,
-            "spend": 95.0,
-            "max_budget": 100.0,
-            "budget_duration": "0d",
-        }
-    ]
-
-    with _patch_litellm([_activity(lite_team_id, 95.0)], team_keys=team_keys):
-        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
-
-    assert [e for e in result.events if e.subject_type == SUBJECT_KEY] == []
-
-
-@pytest.mark.asyncio
-async def test_periodic_key_uses_litellm_max_budget(db, region):
-    """PERIODIC key budgets live in LiteLLM, and its key spend does reset."""
-    team = _make_team(db, budget_type=BudgetType.PERIODIC)
-    _add_subscription(db, team, region, amount_cents=100_000)
-    key = _make_key(db, team, region, token="sk-key-e")
-
-    from app.services.litellm import LiteLLMService
-
-    hashed = LiteLLMService.hash_token("sk-key-e")
-    lite_team_id = f"{region.name}_{team.id}"
-    team_keys = [
-        {
-            "token": hashed,
-            "spend": 51.0,
-            "max_budget": 100.0,
-            "budget_duration": "31d",
-        }
-    ]
-
-    with _patch_litellm([_activity(lite_team_id, 51.0)], team_keys=team_keys):
-        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
-
-    key_events = [e for e in result.events if e.subject_type == SUBJECT_KEY]
-    assert len(key_events) == 1
-    assert key_events[0].key_id == key.id
-    assert key_events[0].max_budget == 100.0
-    assert key_events[0].threshold_pct == 50
-
-
-@pytest.mark.asyncio
-async def test_periodic_team_spend_comes_from_key_sum_not_team_counter(db, region):
-    """The compounding-counter trap.
-
-    LiteLLM's team entity reports a lifetime figure. For a PERIODIC team the
-    engine must use the per-key spends instead, which are what the cycle resets.
-    """
-    team = _make_team(db, budget_type=BudgetType.PERIODIC)
-    _add_subscription(db, team, region, amount_cents=10_000)  # $100 this cycle
-    _make_key(db, team, region, token="sk-key-f", name="f")
-
-    from app.services.litellm import LiteLLMService
-
-    hashed = LiteLLMService.hash_token("sk-key-f")
-    lite_team_id = f"{region.name}_{team.id}"
-    # Team entity claims $4,000 of lifetime spend; the key holds $55 this cycle.
-    team_keys = [
-        {
-            "token": hashed,
-            "spend": 55.0,
-            "max_budget": 100.0,
-            "budget_duration": "31d",
-        }
-    ]
-
-    with _patch_litellm([_activity(lite_team_id, 4000.0)], team_keys=team_keys):
-        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
-
-    team_event = next(e for e in result.events if e.subject_type == SUBJECT_TEAM)
-    # $55 of $100 -> 50 band, not the 100 band a lifetime total would produce.
-    assert team_event.spend == 55.0
-    assert team_event.threshold_pct == 50
-
-
-# --------------------------------------------------------------------------- #
-# Team-member scope
-# --------------------------------------------------------------------------- #
-
-
-@pytest.mark.asyncio
-async def test_team_member_cap_drives_member_alert(db, region):
-    team = _make_team(db)
-    _add_subscription(db, team, region, amount_cents=100_000)
-    user = _make_user(db, team)
-    _make_key(db, team, region, token="sk-key-g", owner=user)
+    _add_subscription(db, team, region, amount_cents=100_000)  # $1000
+    _make_key(db, team, region, token="sk-a")
     db.add(
         DBSpendCap(
-            scope="team_member",
+            scope="team",
             region_id=region.id,
             team_id=team.id,
-            user_id=user.id,
-            max_budget=20.0,
+            max_budget=50.0,
+            updated_at=datetime.now(UTC) - timedelta(minutes=5),
         )
     )
     db.commit()
+    lite = f"{region.name}_{team.id}"
 
-    from app.services.litellm import LiteLLMService
-
-    hashed = LiteLLMService.hash_token("sk-key-g")
-    lite_team_id = f"{region.name}_{team.id}"
-
-    with _patch_litellm([_activity(lite_team_id, 19.0, hashed_keys={hashed: 19.0})]):
+    with _patch_litellm(
+        [_day(lite, 48.0, days_ago=3, keys={"sk-a": 48.0})], [_key_state("sk-a")]
+    ):
         result = await evaluate_region(db, region, thresholds=THRESHOLDS)
 
-    member_events = [e for e in result.events if e.subject_type == SUBJECT_TEAM_MEMBER]
-    assert len(member_events) == 1
-    assert member_events[0].user_id == user.id
-    assert member_events[0].max_budget == 20.0
-    assert member_events[0].threshold_pct == 90
+    event = next(e for e in result.events if e.subject_type == SUBJECT_TEAM)
+    assert event.max_budget == 50.0
+    assert event.threshold_pct == 90
 
 
-@pytest.mark.asyncio
-async def test_member_without_cap_emits_nothing(db, region):
-    team = _make_team(db)
-    _add_subscription(db, team, region, amount_cents=100_000)
-    user = _make_user(db, team, email="nocap@example.com")
-    _make_key(db, team, region, token="sk-key-h", owner=user)
-
-    from app.services.litellm import LiteLLMService
-
-    hashed = LiteLLMService.hash_token("sk-key-h")
-    lite_team_id = f"{region.name}_{team.id}"
-
-    with _patch_litellm([_activity(lite_team_id, 900.0, hashed_keys={hashed: 900.0})]):
-        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
-
-    assert [e for e in result.events if e.subject_type == SUBJECT_TEAM_MEMBER] == []
-
-
-# --------------------------------------------------------------------------- #
-# Delivery payload
-# --------------------------------------------------------------------------- #
-
-
-@pytest.mark.asyncio
-async def test_webhook_payload_excludes_the_litellm_token(db, region):
-    from app.services.budget_alert_webhook import serialize_event
+def test_old_expiry_does_not_recheck_forever(db, region):
+    """The recheck window is bounded, so it cannot grow into a full table scan."""
+    from app.core.budget_alert_service import denominator_change_candidates
 
     team = _make_team(db)
-    _add_subscription(db, team, region, amount_cents=10_000)
-    lite_team_id = f"{region.name}_{team.id}"
-
-    with _patch_litellm([_activity(lite_team_id, 92.0)]):
-        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
-
-    payload = serialize_event(
-        next(e for e in result.events if e.subject_type == SUBJECT_TEAM)
-    )
-    assert payload["type"] == "budget.threshold_reached"
-    assert payload["data"]["threshold_percent"] == 90
-    assert payload["data"]["team"]["id"] == team.id
-    assert "sk-" not in str(payload)
-    assert "token" not in payload["data"]
-
-
-@pytest.mark.asyncio
-async def test_delivery_failure_returns_no_delivered_ids(db, region):
-    """A non-2xx must not be reported as delivered, or the alert is lost."""
-    from app.services.budget_alert_webhook import deliver_events
-    from app.core.budget_alert_service import BudgetAlertEvent
-
-    event = BudgetAlertEvent(
-        event_id="evt_test",
-        subject_type=SUBJECT_TEAM,
-        subject_key="team:1:1",
-        threshold_pct=90,
-        percent_used=92.0,
-        spend=92.0,
-        max_budget=100.0,
-        region_id=region.id,
-        region_name=region.name,
-        period_key="subscription_ledger:x",
-        period_start=None,
-        period_end=None,
-        budget_duration="31d",
-        team_id=1,
+    _add_topup(
+        db,
+        team,
+        region,
+        amount_cents=5_000,
+        purchased_days_ago=400,
+        expires_at=datetime.now(UTC) - timedelta(days=35),
     )
 
-    class _Resp:
-        status_code = 500
-        text = "boom"
+    assert denominator_change_candidates(db, region.id, datetime.now(UTC)) == set()
 
-    class _Client:
-        def __init__(self, *args, **kwargs):
-            pass
 
-        async def __aenter__(self):
-            return self
+def test_future_expiry_is_not_a_candidate_yet(db, region):
+    """Nothing has changed until the entry actually lapses."""
+    from app.core.budget_alert_service import denominator_change_candidates
 
-        async def __aexit__(self, *args):
-            return False
+    team = _make_team(db)
+    _add_topup(db, team, region, amount_cents=5_000)
 
-        async def post(self, *args, **kwargs):
-            return _Resp()
+    assert denominator_change_candidates(db, region.id, datetime.now(UTC)) == set()
 
-    with patch.object(settings, "BUDGET_ALERT_WEBHOOK_URL", "http://moad.test/hook"):
-        with patch("app.services.budget_alert_webhook.httpx.AsyncClient", _Client):
-            delivered = await deliver_events([event])
 
-    assert delivered == set()
+def test_spend_window_start_uses_oldest_valid_entry(db, region):
+    """Directly pin the rule, since everything downstream depends on it."""
+    from app.core.budget_alert_service import spend_window_start
+
+    team = _make_team(db)
+    now = datetime.now(UTC)
+    # Expired: must NOT set the window.
+    _add_topup(
+        db,
+        team,
+        region,
+        amount_cents=10_000,
+        purchased_days_ago=200,
+        expires_at=now - timedelta(days=1),
+    )
+    _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=40)
+    _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=5)
+
+    start = spend_window_start(db, team, region.id, now)
+    assert 39 <= (now - start).days <= 41
+
+
+def test_spend_window_start_falls_back_to_team_creation(db, region):
+    """A team with no ledger at all still needs a defined window."""
+    from app.core.budget_alert_service import spend_window_start
+
+    team = _make_team(db)
+    now = datetime.now(UTC)
+    start = spend_window_start(db, team, region.id, now)
+    assert 4 <= (now - start).days <= 6
 
 
 # --------------------------------------------------------------------------- #
@@ -742,6 +647,377 @@ def test_region_without_litellm_credentials_is_not_swept(db, region):
     assert regions_to_sweep(db) == []
 
 
+# --------------------------------------------------------------------------- #
+# Dedup, re-arm, and the moving denominator
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_same_band_is_not_notified_twice(db, region):
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=10_000)
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
+    rows, keys = _active(lite, keys={"sk-a": 92.0}), [_key_state("sk-a")]
+
+    with _patch_litellm(rows, keys):
+        first = await evaluate_region(db, region, thresholds=THRESHOLDS)
+    mark_notified(db, region, first, {e.event_id for e in first.events})
+
+    with _patch_litellm(rows, keys):
+        second = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert [e for e in second.events if e.subject_type == SUBJECT_TEAM] == []
+
+
+@pytest.mark.asyncio
+async def test_higher_band_notifies_again_in_the_same_period(db, region):
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=10_000)
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
+
+    with _patch_litellm(_active(lite, keys={"sk-a": 60.0}), [_key_state("sk-a")]):
+        first = await evaluate_region(db, region, thresholds=THRESHOLDS)
+    assert (
+        next(e for e in first.events if e.subject_type == SUBJECT_TEAM).threshold_pct
+        == 50
+    )
+    mark_notified(db, region, first, {e.event_id for e in first.events})
+
+    with _patch_litellm(_active(lite, keys={"sk-a": 91.0}), [_key_state("sk-a")]):
+        second = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert (
+        next(e for e in second.events if e.subject_type == SUBJECT_TEAM).threshold_pct
+        == 90
+    )
+
+
+@pytest.mark.asyncio
+async def test_new_period_re_arms_the_same_band(db, region):
+    team = _make_team(db)
+    subscription = _add_subscription(db, team, region, amount_cents=10_000)
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
+    rows, keys = _active(lite, keys={"sk-a": 92.0}), [_key_state("sk-a")]
+
+    with _patch_litellm(rows, keys):
+        first = await evaluate_region(db, region, thresholds=THRESHOLDS)
+    mark_notified(db, region, first, {e.event_id for e in first.events})
+    old_period_key = next(
+        e for e in first.events if e.subject_type == SUBJECT_TEAM
+    ).period_key
+
+    # Roll the cycle: a new window means a new period_key.
+    now = datetime.now(UTC)
+    subscription.effective_period_start = now - timedelta(days=1)
+    subscription.effective_period_end = now + timedelta(days=30)
+    db.commit()
+
+    with _patch_litellm(rows, keys):
+        second = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    event = next(e for e in second.events if e.subject_type == SUBJECT_TEAM)
+    assert event.threshold_pct == 90
+    assert event.period_key != old_period_key
+
+
+@pytest.mark.asyncio
+async def test_failed_delivery_leaves_state_unadvanced_and_retries(db, region):
+    """No outbox: an undelivered event must be re-detected next tick."""
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=10_000)
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
+    rows, keys = _active(lite, keys={"sk-a": 92.0}), [_key_state("sk-a")]
+
+    with _patch_litellm(rows, keys):
+        first = await evaluate_region(db, region, thresholds=THRESHOLDS)
+    assert len(first.events) >= 1
+
+    # Delivery failed -> nothing is marked.
+    assert mark_notified(db, region, first, set()) == 0
+
+    with _patch_litellm(rows, keys):
+        second = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert (
+        next(e for e in second.events if e.subject_type == SUBJECT_TEAM).threshold_pct
+        == 90
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Key scope
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_key_cap_drives_key_scope_alert(db, region):
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=100_000)  # big team budget
+    key = _make_key(db, team, region, token="sk-a")
+    db.add(DBSpendCap(scope="key", region_id=region.id, key_id=key.id, max_budget=10.0))
+    db.commit()
+    lite = f"{region.name}_{team.id}"
+
+    with _patch_litellm(_active(lite, keys={"sk-a": 7.6}), [_key_state("sk-a")]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    key_events = [e for e in result.events if e.subject_type == SUBJECT_KEY]
+    assert len(key_events) == 1
+    assert key_events[0].key_id == key.id
+    assert key_events[0].max_budget == 10.0
+    assert key_events[0].threshold_pct == 75
+    assert key_events[0].budget_source == "key_cap"
+
+
+@pytest.mark.asyncio
+async def test_service_key_and_user_key_both_alert(db, region):
+    """A key is in scope for having a team, not for having an owner.
+
+    PROD POOL teams hold 405 service keys (no owner) and 929 user keys; both must
+    produce key-scope alerts, and the event says which it is so the consumer can
+    route it to the workspace or to the individual.
+    """
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=100_000)
+    user = _make_user(db, team, email="both@example.com")
+    svc = _make_key(db, team, region, token="sk-svc", name="svc")  # owner_id None
+    usr = _make_key(db, team, region, token="sk-usr", name="usr", owner=user)
+    for k in (svc, usr):
+        db.add(
+            DBSpendCap(scope="key", region_id=region.id, key_id=k.id, max_budget=10.0)
+        )
+    db.commit()
+    lite = f"{region.name}_{team.id}"
+
+    with _patch_litellm(
+        _active(lite, keys={"sk-svc": 9.5, "sk-usr": 9.5}),
+        [_key_state("sk-svc"), _key_state("sk-usr")],
+    ):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    by_key = {e.key_id: e for e in result.events if e.subject_type == SUBJECT_KEY}
+    assert set(by_key) == {svc.id, usr.id}
+    assert by_key[svc.id].is_service_key is True
+    assert by_key[usr.id].is_service_key is False
+    assert all(e.threshold_pct == 90 for e in by_key.values())
+
+
+@pytest.mark.asyncio
+async def test_uncapped_key_covered_by_the_team_alert_on_a_single_key_team(db, region):
+    """An uncapped key has no key-level budget, but the customer is still warned.
+
+    44.7% of team-attached keys on PROD carry no max_budget: for POOL, only an
+    explicit cap sets one, and everything else is bounded by the team pool. On a
+    one-key team the key percentage would equal the team's, so only the team event
+    fires -- the spend is routed, not dropped.
+    """
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=100_000)  # $1000
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
+
+    with _patch_litellm(_active(lite, keys={"sk-a": 900.0}), [_key_state("sk-a")]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert [e for e in result.events if e.subject_type == SUBJECT_KEY] == []
+    team_event = next(e for e in result.events if e.subject_type == SUBJECT_TEAM)
+    assert team_event.spend == 900.0
+    assert team_event.max_budget == 1000.0
+    assert team_event.threshold_pct == 90
+
+
+@pytest.mark.asyncio
+async def test_uncapped_key_measured_against_pool_when_team_has_several(db, region):
+    """With more than one key, an uncapped key is measured against the pool.
+
+    Legitimate rather than a proxy: worker.py leaves uncapped POOL keys with
+    max_budget=None and enforces at team level, so the pool *is* that key's limit.
+    """
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=10_000)  # $100 pool
+    hog = _make_key(db, team, region, token="sk-hog", name="hog")
+    _make_key(db, team, region, token="sk-quiet", name="quiet")
+    lite = f"{region.name}_{team.id}"
+
+    with _patch_litellm(
+        _active(lite, keys={"sk-hog": 92.0, "sk-quiet": 1.0}),
+        [_key_state("sk-hog"), _key_state("sk-quiet")],
+    ):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    key_events = {e.key_id: e for e in result.events if e.subject_type == SUBJECT_KEY}
+    # The hog crossed 90% of the pool; the quiet key crossed nothing.
+    assert set(key_events) == {hog.id}
+    assert key_events[hog.id].max_budget == 100.0
+    assert key_events[hog.id].budget_source == "team_pool"
+    assert key_events[hog.id].threshold_pct == 90
+
+
+@pytest.mark.asyncio
+async def test_distributed_burn_is_team_scope_only(db, region):
+    """Three keys at ~31% each trip the team but no individual key.
+
+    With a shared pool there is no per-key line to cross, so per-key events are
+    attribution on top of the team alert rather than independent coverage.
+    """
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=10_000)  # $100
+    for name in ("a", "b", "c"):
+        _make_key(db, team, region, token=f"sk-{name}", name=name)
+    lite = f"{region.name}_{team.id}"
+
+    with _patch_litellm(
+        _active(lite, keys={f"sk-{n}": 31.0 for n in ("a", "b", "c")}),
+        [_key_state(f"sk-{n}") for n in ("a", "b", "c")],
+    ):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert [e for e in result.events if e.subject_type == SUBJECT_KEY] == []
+    assert (
+        next(e for e in result.events if e.subject_type == SUBJECT_TEAM).threshold_pct
+        == 90
+    )
+
+
+@pytest.mark.asyncio
+async def test_zero_budget_key_is_skipped(db, region):
+    """A pool-gated key is born with max_budget 0; that is not 100% used."""
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=100_000)
+    _make_key(db, team, region, token="sk-a", name="a")
+    _make_key(db, team, region, token="sk-b", name="b")
+    lite = f"{region.name}_{team.id}"
+
+    with _patch_litellm(
+        _active(lite, keys={"sk-a": 0.0, "sk-b": 1.0}),
+        [_key_state("sk-a", max_budget=0.0), _key_state("sk-b")],
+    ):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert [e for e in result.events if e.subject_type == SUBJECT_KEY] == []
+
+
+@pytest.mark.asyncio
+async def test_expiring_key_is_skipped(db, region):
+    """A key being expired (budget_duration 0d) is not a budget warning."""
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=100_000)
+    key = _make_key(db, team, region, token="sk-a")
+    db.add(
+        DBSpendCap(scope="key", region_id=region.id, key_id=key.id, max_budget=100.0)
+    )
+    db.commit()
+    lite = f"{region.name}_{team.id}"
+
+    with _patch_litellm(
+        _active(lite, keys={"sk-a": 95.0}),
+        [_key_state("sk-a", max_budget=100.0, budget_duration="0d")],
+    ):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert [e for e in result.events if e.subject_type == SUBJECT_KEY] == []
+    # Its spend is excluded from the team total too -- the key is going away.
+    assert [e for e in result.events if e.subject_type == SUBJECT_TEAM] == []
+
+
+@pytest.mark.asyncio
+async def test_litellm_key_budget_used_when_no_db_cap_exists(db, region):
+    """With no spend_caps row, whatever LiteLLM enforces is the key's budget."""
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=100_000)
+    key = _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
+
+    with _patch_litellm(
+        _active(lite, keys={"sk-a": 51.0}), [_key_state("sk-a", max_budget=100.0)]
+    ):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    key_events = [e for e in result.events if e.subject_type == SUBJECT_KEY]
+    assert len(key_events) == 1
+    assert key_events[0].key_id == key.id
+    assert key_events[0].max_budget == 100.0
+    assert key_events[0].threshold_pct == 50
+    assert key_events[0].budget_source == "litellm_key_budget"
+
+
+@pytest.mark.asyncio
+async def test_key_without_team_id_is_out_of_scope(db, region):
+    """Only keys carrying both a team and a region are in scope (MOAD's shape)."""
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=10_000)
+    user = _make_user(db, team, email="orphan@example.com")
+    key = _make_key(db, team, region, token="sk-orphan", owner=user)
+    key.team_id = None  # owner only, no team
+    db.commit()
+    db.add(DBSpendCap(scope="key", region_id=region.id, key_id=key.id, max_budget=1.0))
+    db.commit()
+    lite = f"{region.name}_{team.id}"
+
+    with _patch_litellm(
+        _active(lite, keys={"sk-orphan": 5.0}), [_key_state("sk-orphan")]
+    ):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert [e for e in result.events if e.subject_type == SUBJECT_KEY] == []
+
+
+# --------------------------------------------------------------------------- #
+# Team-member scope
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_team_member_cap_drives_member_alert(db, region):
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=100_000)
+    user = _make_user(db, team)
+    _make_key(db, team, region, token="sk-a", owner=user)
+    db.add(
+        DBSpendCap(
+            scope="team_member",
+            region_id=region.id,
+            team_id=team.id,
+            user_id=user.id,
+            max_budget=20.0,
+        )
+    )
+    db.commit()
+    lite = f"{region.name}_{team.id}"
+
+    with _patch_litellm(_active(lite, keys={"sk-a": 19.0}), [_key_state("sk-a")]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    member_events = [e for e in result.events if e.subject_type == SUBJECT_TEAM_MEMBER]
+    assert len(member_events) == 1
+    assert member_events[0].user_id == user.id
+    assert member_events[0].max_budget == 20.0
+    assert member_events[0].threshold_pct == 90
+
+
+@pytest.mark.asyncio
+async def test_member_without_cap_emits_nothing(db, region):
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=100_000)
+    user = _make_user(db, team, email="nocap@example.com")
+    _make_key(db, team, region, token="sk-a", owner=user)
+    lite = f"{region.name}_{team.id}"
+
+    with _patch_litellm(_active(lite, keys={"sk-a": 900.0}), [_key_state("sk-a")]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert [e for e in result.events if e.subject_type == SUBJECT_TEAM_MEMBER] == []
+
+
+# --------------------------------------------------------------------------- #
+# Audit trail
+# --------------------------------------------------------------------------- #
+
+
 @pytest.mark.asyncio
 async def test_audit_log_records_delivered_and_undelivered_crossings(db, region):
     """budget_alert_state only holds the current band, so the audit log is the
@@ -751,9 +1027,10 @@ async def test_audit_log_records_delivered_and_undelivered_crossings(db, region)
 
     team = _make_team(db)
     _add_subscription(db, team, region, amount_cents=10_000)
-    lite_team_id = f"{region.name}_{team.id}"
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
 
-    with _patch_litellm([_activity(lite_team_id, 92.0)]):
+    with _patch_litellm(_active(lite, keys={"sk-a": 92.0}), [_key_state("sk-a")]):
         result = await evaluate_region(db, region, thresholds=THRESHOLDS)
 
     event = next(e for e in result.events if e.subject_type == SUBJECT_TEAM)
@@ -805,10 +1082,85 @@ def test_audit_log_write_failure_does_not_raise(db):
         assert write_audit_logs(db, [event], set()) == 0
 
 
+# --------------------------------------------------------------------------- #
+# Delivery payload
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_webhook_payload_excludes_the_litellm_token(db, region):
+    from app.services.budget_alert_webhook import serialize_event
+
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=10_000)
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
+
+    with _patch_litellm(_active(lite, keys={"sk-a": 92.0}), [_key_state("sk-a")]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    payload = serialize_event(
+        next(e for e in result.events if e.subject_type == SUBJECT_TEAM)
+    )
+    assert payload["type"] == "budget.threshold_reached"
+    assert payload["data"]["threshold_percent"] == 90
+    assert payload["data"]["team"]["id"] == team.id
+    assert payload["data"]["budget_source"] == "team_ledger"
+    assert "sk-" not in str(payload)
+    assert "token" not in payload["data"]
+
+
+@pytest.mark.asyncio
+async def test_delivery_failure_returns_no_delivered_ids(db, region):
+    """A non-2xx must not be reported as delivered, or the alert is lost."""
+    from app.core.budget_alert_service import BudgetAlertEvent
+    from app.services.budget_alert_webhook import deliver_events
+
+    event = BudgetAlertEvent(
+        event_id="evt_test",
+        subject_type=SUBJECT_TEAM,
+        subject_key="team:1:1",
+        threshold_pct=90,
+        percent_used=92.0,
+        spend=92.0,
+        max_budget=100.0,
+        region_id=region.id,
+        region_name=region.name,
+        period_key="subscription_ledger:x",
+        period_start=None,
+        period_end=None,
+        budget_duration="31d",
+        team_id=1,
+    )
+
+    class _Resp:
+        status_code = 500
+        text = "boom"
+
+    class _Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def post(self, *args, **kwargs):
+            return _Resp()
+
+    with patch.object(settings, "BUDGET_ALERT_WEBHOOK_URL", "http://moad.test/hook"):
+        with patch("app.services.budget_alert_webhook.httpx.AsyncClient", _Client):
+            delivered = await deliver_events([event])
+
+    assert delivered == set()
+
+
 @pytest.mark.asyncio
 async def test_delivery_without_url_configured_is_a_no_op(db, region):
-    from app.services.budget_alert_webhook import deliver_events
     from app.core.budget_alert_service import BudgetAlertEvent
+    from app.services.budget_alert_webhook import deliver_events
 
     event = BudgetAlertEvent(
         event_id="evt_test2",

--- a/tests/test_budget_alerts.py
+++ b/tests/test_budget_alerts.py
@@ -1,0 +1,725 @@
+"""Tests for budget threshold alerts (AI-448).
+
+The important cases here are the ones where the maths is easy to get wrong:
+LiteLLM's compounding team counter, POOL's moving denominator, and cycle
+rollover. A percentage that is silently wrong is worse than no alert at all,
+because it teaches customers to ignore the warnings.
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.core.budget_alert_service import (
+    SUBJECT_KEY,
+    SUBJECT_TEAM,
+    SUBJECT_TEAM_MEMBER,
+    apply_resets,
+    evaluate_region,
+    highest_crossed_band,
+    mark_notified,
+    parse_thresholds,
+)
+from app.core.config import settings
+from app.db.models import (
+    DBBudgetAlertState,
+    DBPeriodicBudgetLedgerEntry,
+    DBPrivateAIKey,
+    DBRegion,
+    DBSpendCap,
+    DBTeam,
+    DBUser,
+)
+from app.schemas.models import BudgetType
+
+THRESHOLDS = [50, 75, 90, 100]
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_thresholds_sorts_dedupes_and_drops_junk():
+    assert parse_thresholds("90, 50,75,50, ,abc,100") == [50, 75, 90, 100]
+
+
+def test_parse_thresholds_rejects_out_of_range():
+    assert parse_thresholds("0,-5,50,99999") == [50]
+
+
+def test_highest_crossed_band_returns_only_the_top_band():
+    # A jump straight past three bands must not produce three alerts.
+    assert highest_crossed_band(95.0, THRESHOLDS) == 90
+    assert highest_crossed_band(49.9, THRESHOLDS) == 0
+    assert highest_crossed_band(50.0, THRESHOLDS) == 50
+    assert highest_crossed_band(140.0, THRESHOLDS) == 100
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def region(db):
+    region = DBRegion(
+        name="test-region",
+        postgres_host="localhost",
+        postgres_port=5432,
+        postgres_admin_user="postgres",
+        postgres_admin_password="postgres",
+        litellm_api_url="http://litellm.test",
+        litellm_api_key="sk-test",
+        is_active=True,
+    )
+    db.add(region)
+    db.commit()
+    db.refresh(region)
+    return region
+
+
+def _make_team(db, budget_type=BudgetType.POOL, name="alerts-team"):
+    team = DBTeam(
+        name=name,
+        admin_email=f"{name}@example.com",
+        budget_type=budget_type,
+        # Pool gating off keeps these teams on the plain POOL path; the gate is a
+        # separate concern from budget percentage.
+        require_purchase_for_requests=False,
+        created_at=datetime.now(UTC) - timedelta(days=5),
+    )
+    db.add(team)
+    db.commit()
+    db.refresh(team)
+    return team
+
+
+def _make_key(db, team, region, *, name="k1", token="sk-key-1", owner=None):
+    key = DBPrivateAIKey(
+        name=name,
+        litellm_token=token,
+        litellm_api_url=region.litellm_api_url,
+        region_id=region.id,
+        team_id=team.id,
+        owner_id=owner.id if owner else None,
+    )
+    db.add(key)
+    db.commit()
+    db.refresh(key)
+    return key
+
+
+def _make_user(db, team, email="member@example.com"):
+    user = DBUser(
+        email=email,
+        hashed_password="x",
+        is_active=True,
+        team_id=team.id,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _add_subscription(db, team, region, *, amount_cents, days_left=20):
+    now = datetime.now(UTC)
+    entry = DBPeriodicBudgetLedgerEntry(
+        team_id=team.id,
+        region_id=region.id,
+        entry_type="subscription",
+        amount_cents=amount_cents,
+        consumed_cents=0,
+        is_active=True,
+        purchased_at=now - timedelta(days=31 - days_left),
+        effective_period_start=now - timedelta(days=31 - days_left),
+        effective_period_end=now + timedelta(days=days_left),
+    )
+    db.add(entry)
+    db.commit()
+    return entry
+
+
+def _activity(lite_team_id, spend, *, day_offset=0, hashed_keys=None):
+    """Build one day of LiteLLM daily-activity output."""
+    day = (datetime.now(UTC) - timedelta(days=day_offset)).date().isoformat()
+    api_keys = {
+        hashed: {"metrics": {"spend": value}}
+        for hashed, value in (hashed_keys or {}).items()
+    }
+    return {
+        "date": day,
+        "metrics": {"spend": spend},
+        "breakdown": {
+            "entities": {lite_team_id: {"metrics": {"spend": spend}}},
+            "api_keys": api_keys,
+        },
+    }
+
+
+def _patch_litellm(team_rows, user_rows=None, team_keys=None):
+    """Patch the three LiteLLM reads the engine can make."""
+    return patch.multiple(
+        "app.core.budget_alert_service.LiteLLMService",
+        get_all_team_daily_activity=AsyncMock(return_value=team_rows),
+        get_all_user_daily_activity=AsyncMock(return_value=user_rows or []),
+        list_keys_for_team=AsyncMock(return_value=team_keys or []),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Team scope
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_pool_team_percentage_uses_ledger_not_litellm_max_budget(db, region):
+    """The denominator is our ledger, and one crossing yields one event."""
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=10_000)  # $100
+    lite_team_id = f"{region.name}_{team.id}"
+
+    # $92 spent of $100 -> 92% -> crosses the 90 band.
+    with _patch_litellm([_activity(lite_team_id, 92.0)]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    team_events = [e for e in result.events if e.subject_type == SUBJECT_TEAM]
+    assert len(team_events) == 1
+    event = team_events[0]
+    assert event.threshold_pct == 90
+    assert event.max_budget == 100.0
+    assert event.spend == 92.0
+    assert 91.9 < event.percent_used < 92.1
+    assert event.team_id == team.id
+
+
+@pytest.mark.asyncio
+async def test_team_cap_tightens_the_denominator(db, region):
+    """An operator team cap lowers the budget, so the same spend crosses higher."""
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=10_000)  # $100
+    db.add(
+        DBSpendCap(scope="team", region_id=region.id, team_id=team.id, max_budget=50.0)
+    )
+    db.commit()
+    lite_team_id = f"{region.name}_{team.id}"
+
+    # $46 is 46% of $100 but 92% of the $50 cap.
+    with _patch_litellm([_activity(lite_team_id, 46.0)]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    event = next(e for e in result.events if e.subject_type == SUBJECT_TEAM)
+    assert event.max_budget == 50.0
+    assert event.threshold_pct == 90
+
+
+@pytest.mark.asyncio
+async def test_no_budget_means_no_event(db, region):
+    """A team with no ledger and no limit has nothing to be a percentage of."""
+    team = _make_team(db)
+    lite_team_id = f"{region.name}_{team.id}"
+
+    with _patch_litellm([_activity(lite_team_id, 500.0)]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert [e for e in result.events if e.subject_type == SUBJECT_TEAM] == []
+
+
+@pytest.mark.asyncio
+async def test_soft_deleted_team_is_skipped(db, region):
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=10_000)
+    team.deleted_at = datetime.now(UTC)
+    db.commit()
+    lite_team_id = f"{region.name}_{team.id}"
+
+    with _patch_litellm([_activity(lite_team_id, 99.0)]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert result.events == []
+
+
+@pytest.mark.asyncio
+async def test_empty_activity_sweep_produces_nothing(db, region):
+    _make_team(db)
+
+    with _patch_litellm([]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert result.events == []
+    assert result.subjects_evaluated == 0
+
+
+@pytest.mark.asyncio
+async def test_unknown_entities_are_ignored(db, region):
+    """LiteLLM's own bookkeeping team is not one of ours."""
+    _make_team(db)
+
+    with _patch_litellm([_activity("litellm-dashboard", 100.0)]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert result.events == []
+
+
+# --------------------------------------------------------------------------- #
+# Dedup, re-arm, and the POOL moving denominator
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_same_band_is_not_notified_twice(db, region):
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=10_000)
+    lite_team_id = f"{region.name}_{team.id}"
+    rows = [_activity(lite_team_id, 92.0)]
+
+    with _patch_litellm(rows):
+        first = await evaluate_region(db, region, thresholds=THRESHOLDS)
+    delivered = {e.event_id for e in first.events}
+    mark_notified(db, region, first, delivered)
+
+    with _patch_litellm(rows):
+        second = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert [e for e in second.events if e.subject_type == SUBJECT_TEAM] == []
+
+
+@pytest.mark.asyncio
+async def test_higher_band_notifies_again_in_the_same_period(db, region):
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=10_000)
+    lite_team_id = f"{region.name}_{team.id}"
+
+    with _patch_litellm([_activity(lite_team_id, 60.0)]):
+        first = await evaluate_region(db, region, thresholds=THRESHOLDS)
+    assert (
+        next(e for e in first.events if e.subject_type == SUBJECT_TEAM).threshold_pct
+        == 50
+    )
+    mark_notified(db, region, first, {e.event_id for e in first.events})
+
+    with _patch_litellm([_activity(lite_team_id, 91.0)]):
+        second = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert (
+        next(e for e in second.events if e.subject_type == SUBJECT_TEAM).threshold_pct
+        == 90
+    )
+
+
+@pytest.mark.asyncio
+async def test_topup_lowering_the_percentage_does_not_alert_but_re_arms(db, region):
+    """The POOL moving-denominator case.
+
+    Crossing 90%, then buying budget, must not emit anything on the way down --
+    but the band has to be rewritten, or the genuine second crossing of 90% is
+    suppressed forever.
+    """
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=10_000)  # $100
+    lite_team_id = f"{region.name}_{team.id}"
+
+    with _patch_litellm([_activity(lite_team_id, 92.0)]):
+        first = await evaluate_region(db, region, thresholds=THRESHOLDS)
+    mark_notified(db, region, first, {e.event_id for e in first.events})
+
+    # Top-up: budget becomes $300, so $92 is now ~31%.
+    db.add(
+        DBPeriodicBudgetLedgerEntry(
+            team_id=team.id,
+            region_id=region.id,
+            entry_type="topup",
+            amount_cents=20_000,
+            consumed_cents=0,
+            is_active=True,
+            purchased_at=datetime.now(UTC),
+        )
+    )
+    db.commit()
+
+    with _patch_litellm([_activity(lite_team_id, 92.0)]):
+        second = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    # Nothing announced on the decrease...
+    assert [e for e in second.events if e.subject_type == SUBJECT_TEAM] == []
+    # ...but the band was walked back.
+    apply_resets(db, region, second)
+    state = (
+        db.query(DBBudgetAlertState)
+        .filter(DBBudgetAlertState.subject_key == f"team:{team.id}:{region.id}")
+        .one()
+    )
+    assert state.last_threshold_pct == 0
+
+    # Spending up to 90% of the larger budget alerts again.
+    with _patch_litellm([_activity(lite_team_id, 275.0)]):
+        third = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert (
+        next(e for e in third.events if e.subject_type == SUBJECT_TEAM).threshold_pct
+        == 90
+    )
+
+
+@pytest.mark.asyncio
+async def test_new_period_re_arms_the_same_band(db, region):
+    team = _make_team(db)
+    subscription = _add_subscription(db, team, region, amount_cents=10_000)
+    lite_team_id = f"{region.name}_{team.id}"
+
+    with _patch_litellm([_activity(lite_team_id, 92.0)]):
+        first = await evaluate_region(db, region, thresholds=THRESHOLDS)
+    mark_notified(db, region, first, {e.event_id for e in first.events})
+    old_period_key = next(
+        e for e in first.events if e.subject_type == SUBJECT_TEAM
+    ).period_key
+
+    # Roll the cycle: a new window means a new period_key.
+    now = datetime.now(UTC)
+    subscription.effective_period_start = now - timedelta(days=1)
+    subscription.effective_period_end = now + timedelta(days=30)
+    db.commit()
+
+    with _patch_litellm([_activity(lite_team_id, 92.0)]):
+        second = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    event = next(e for e in second.events if e.subject_type == SUBJECT_TEAM)
+    assert event.threshold_pct == 90
+    assert event.period_key != old_period_key
+
+
+@pytest.mark.asyncio
+async def test_failed_delivery_leaves_state_unadvanced_and_retries(db, region):
+    """No outbox: an undelivered event must be re-detected next tick."""
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=10_000)
+    lite_team_id = f"{region.name}_{team.id}"
+    rows = [_activity(lite_team_id, 92.0)]
+
+    with _patch_litellm(rows):
+        first = await evaluate_region(db, region, thresholds=THRESHOLDS)
+    assert len(first.events) >= 1
+
+    # Delivery failed -> nothing is marked.
+    advanced = mark_notified(db, region, first, set())
+    assert advanced == 0
+
+    with _patch_litellm(rows):
+        second = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert (
+        next(e for e in second.events if e.subject_type == SUBJECT_TEAM).threshold_pct
+        == 90
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Key scope
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_key_cap_drives_key_scope_alert(db, region):
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=100_000)  # big team budget
+    key = _make_key(db, team, region, token="sk-key-a")
+    db.add(DBSpendCap(scope="key", region_id=region.id, key_id=key.id, max_budget=10.0))
+    db.commit()
+
+    from app.services.litellm import LiteLLMService
+
+    hashed = LiteLLMService.hash_token("sk-key-a")
+    lite_team_id = f"{region.name}_{team.id}"
+    rows = [_activity(lite_team_id, 7.6, hashed_keys={hashed: 7.6})]
+
+    with _patch_litellm(rows):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    key_events = [e for e in result.events if e.subject_type == SUBJECT_KEY]
+    assert len(key_events) == 1
+    assert key_events[0].key_id == key.id
+    assert key_events[0].max_budget == 10.0
+    assert key_events[0].threshold_pct == 75
+
+
+@pytest.mark.asyncio
+async def test_key_without_any_budget_emits_nothing(db, region):
+    """POOL keys carry no max_budget unless explicitly capped."""
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=100_000)
+    _make_key(db, team, region, token="sk-key-b")
+
+    from app.services.litellm import LiteLLMService
+
+    hashed = LiteLLMService.hash_token("sk-key-b")
+    lite_team_id = f"{region.name}_{team.id}"
+
+    with _patch_litellm([_activity(lite_team_id, 900.0, hashed_keys={hashed: 900.0})]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert [e for e in result.events if e.subject_type == SUBJECT_KEY] == []
+
+
+@pytest.mark.asyncio
+async def test_zero_budget_key_is_skipped(db, region):
+    """A pool-gated key is born with max_budget 0; that is not 100% used."""
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=100_000)
+    key = _make_key(db, team, region, token="sk-key-c")
+    db.add(DBSpendCap(scope="key", region_id=region.id, key_id=key.id, max_budget=0.0))
+    db.commit()
+
+    from app.services.litellm import LiteLLMService
+
+    hashed = LiteLLMService.hash_token("sk-key-c")
+    lite_team_id = f"{region.name}_{team.id}"
+
+    with _patch_litellm([_activity(lite_team_id, 0.0, hashed_keys={hashed: 0.0})]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert [e for e in result.events if e.subject_type == SUBJECT_KEY] == []
+
+
+@pytest.mark.asyncio
+async def test_expiring_key_is_skipped(db, region):
+    """A key being expired (budget_duration 0d) is not a budget warning."""
+    team = _make_team(db, budget_type=BudgetType.PERIODIC)
+    _add_subscription(db, team, region, amount_cents=100_000)
+    _make_key(db, team, region, token="sk-key-d")
+
+    from app.services.litellm import LiteLLMService
+
+    hashed = LiteLLMService.hash_token("sk-key-d")
+    lite_team_id = f"{region.name}_{team.id}"
+    # PERIODIC teams take the exact-key path, which is where 0d is visible.
+    team_keys = [
+        {
+            "token": hashed,
+            "spend": 95.0,
+            "max_budget": 100.0,
+            "budget_duration": "0d",
+        }
+    ]
+
+    with _patch_litellm([_activity(lite_team_id, 95.0)], team_keys=team_keys):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert [e for e in result.events if e.subject_type == SUBJECT_KEY] == []
+
+
+@pytest.mark.asyncio
+async def test_periodic_key_uses_litellm_max_budget(db, region):
+    """PERIODIC key budgets live in LiteLLM, and its key spend does reset."""
+    team = _make_team(db, budget_type=BudgetType.PERIODIC)
+    _add_subscription(db, team, region, amount_cents=100_000)
+    key = _make_key(db, team, region, token="sk-key-e")
+
+    from app.services.litellm import LiteLLMService
+
+    hashed = LiteLLMService.hash_token("sk-key-e")
+    lite_team_id = f"{region.name}_{team.id}"
+    team_keys = [
+        {
+            "token": hashed,
+            "spend": 51.0,
+            "max_budget": 100.0,
+            "budget_duration": "31d",
+        }
+    ]
+
+    with _patch_litellm([_activity(lite_team_id, 51.0)], team_keys=team_keys):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    key_events = [e for e in result.events if e.subject_type == SUBJECT_KEY]
+    assert len(key_events) == 1
+    assert key_events[0].key_id == key.id
+    assert key_events[0].max_budget == 100.0
+    assert key_events[0].threshold_pct == 50
+
+
+@pytest.mark.asyncio
+async def test_periodic_team_spend_comes_from_key_sum_not_team_counter(db, region):
+    """The compounding-counter trap.
+
+    LiteLLM's team entity reports a lifetime figure. For a PERIODIC team the
+    engine must use the per-key spends instead, which are what the cycle resets.
+    """
+    team = _make_team(db, budget_type=BudgetType.PERIODIC)
+    _add_subscription(db, team, region, amount_cents=10_000)  # $100 this cycle
+    _make_key(db, team, region, token="sk-key-f", name="f")
+
+    from app.services.litellm import LiteLLMService
+
+    hashed = LiteLLMService.hash_token("sk-key-f")
+    lite_team_id = f"{region.name}_{team.id}"
+    # Team entity claims $4,000 of lifetime spend; the key holds $55 this cycle.
+    team_keys = [
+        {
+            "token": hashed,
+            "spend": 55.0,
+            "max_budget": 100.0,
+            "budget_duration": "31d",
+        }
+    ]
+
+    with _patch_litellm([_activity(lite_team_id, 4000.0)], team_keys=team_keys):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    team_event = next(e for e in result.events if e.subject_type == SUBJECT_TEAM)
+    # $55 of $100 -> 50 band, not the 100 band a lifetime total would produce.
+    assert team_event.spend == 55.0
+    assert team_event.threshold_pct == 50
+
+
+# --------------------------------------------------------------------------- #
+# Team-member scope
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_team_member_cap_drives_member_alert(db, region):
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=100_000)
+    user = _make_user(db, team)
+    _make_key(db, team, region, token="sk-key-g", owner=user)
+    db.add(
+        DBSpendCap(
+            scope="team_member",
+            region_id=region.id,
+            team_id=team.id,
+            user_id=user.id,
+            max_budget=20.0,
+        )
+    )
+    db.commit()
+
+    from app.services.litellm import LiteLLMService
+
+    hashed = LiteLLMService.hash_token("sk-key-g")
+    lite_team_id = f"{region.name}_{team.id}"
+
+    with _patch_litellm([_activity(lite_team_id, 19.0, hashed_keys={hashed: 19.0})]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    member_events = [e for e in result.events if e.subject_type == SUBJECT_TEAM_MEMBER]
+    assert len(member_events) == 1
+    assert member_events[0].user_id == user.id
+    assert member_events[0].max_budget == 20.0
+    assert member_events[0].threshold_pct == 90
+
+
+@pytest.mark.asyncio
+async def test_member_without_cap_emits_nothing(db, region):
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=100_000)
+    user = _make_user(db, team, email="nocap@example.com")
+    _make_key(db, team, region, token="sk-key-h", owner=user)
+
+    from app.services.litellm import LiteLLMService
+
+    hashed = LiteLLMService.hash_token("sk-key-h")
+    lite_team_id = f"{region.name}_{team.id}"
+
+    with _patch_litellm([_activity(lite_team_id, 900.0, hashed_keys={hashed: 900.0})]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert [e for e in result.events if e.subject_type == SUBJECT_TEAM_MEMBER] == []
+
+
+# --------------------------------------------------------------------------- #
+# Delivery payload
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_webhook_payload_excludes_the_litellm_token(db, region):
+    from app.services.budget_alert_webhook import serialize_event
+
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=10_000)
+    lite_team_id = f"{region.name}_{team.id}"
+
+    with _patch_litellm([_activity(lite_team_id, 92.0)]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    payload = serialize_event(
+        next(e for e in result.events if e.subject_type == SUBJECT_TEAM)
+    )
+    assert payload["type"] == "budget.threshold_reached"
+    assert payload["data"]["threshold_percent"] == 90
+    assert payload["data"]["team"]["id"] == team.id
+    assert "sk-" not in str(payload)
+    assert "token" not in payload["data"]
+
+
+@pytest.mark.asyncio
+async def test_delivery_failure_returns_no_delivered_ids(db, region):
+    """A non-2xx must not be reported as delivered, or the alert is lost."""
+    from app.services.budget_alert_webhook import deliver_events
+    from app.core.budget_alert_service import BudgetAlertEvent
+
+    event = BudgetAlertEvent(
+        event_id="evt_test",
+        subject_type=SUBJECT_TEAM,
+        subject_key="team:1:1",
+        threshold_pct=90,
+        percent_used=92.0,
+        spend=92.0,
+        max_budget=100.0,
+        region_id=region.id,
+        region_name=region.name,
+        period_key="subscription_ledger:x",
+        period_start=None,
+        period_end=None,
+        budget_duration="31d",
+        team_id=1,
+    )
+
+    class _Resp:
+        status_code = 500
+        text = "boom"
+
+    class _Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def post(self, *args, **kwargs):
+            return _Resp()
+
+    with patch.object(settings, "BUDGET_ALERT_WEBHOOK_URL", "http://moad.test/hook"):
+        with patch("app.services.budget_alert_webhook.httpx.AsyncClient", _Client):
+            delivered = await deliver_events([event])
+
+    assert delivered == set()
+
+
+@pytest.mark.asyncio
+async def test_delivery_without_url_configured_is_a_no_op(db, region):
+    from app.services.budget_alert_webhook import deliver_events
+    from app.core.budget_alert_service import BudgetAlertEvent
+
+    event = BudgetAlertEvent(
+        event_id="evt_test2",
+        subject_type=SUBJECT_TEAM,
+        subject_key="team:1:1",
+        threshold_pct=50,
+        percent_used=55.0,
+        spend=55.0,
+        max_budget=100.0,
+        region_id=region.id,
+        region_name=region.name,
+        period_key="k",
+        period_start=None,
+        period_end=None,
+        budget_duration=None,
+    )
+    with patch.object(settings, "BUDGET_ALERT_WEBHOOK_URL", ""):
+        assert await deliver_events([event]) == set()

--- a/tests/test_budget_alerts.py
+++ b/tests/test_budget_alerts.py
@@ -29,6 +29,7 @@ from app.core.budget_alert_service import (
     parse_thresholds,
 )
 from app.core.config import settings
+from app.core.spend_period_service import resolve_team_period_window
 from app.db.models import (
     DBBudgetAlertState,
     DBLimitedResource,
@@ -429,11 +430,11 @@ async def test_spend_against_an_expired_topup_is_not_counted(db, region):
 
 
 @pytest.mark.asyncio
-async def test_spend_against_an_older_but_still_valid_topup_is_counted(db, region):
-    """The other direction: valid money keeps its spend.
+async def test_topup_only_team_counts_from_the_last_purchase(db, region):
+    """For a top-up-only team the cycle starts at the last top-up purchase.
 
-    Anchoring on the *newest* purchase would have dropped the $85 spent against the
-    still-valid older top-up and reported ~2% instead of ~43%.
+    Spend from before it belongs to an earlier cycle and is not counted again,
+    even when the older top-up is still valid and still funding the balance.
     """
     team = _make_team(db)
     # Both still valid: $100 bought 100 days ago, $100 bought 10 days ago.
@@ -443,21 +444,50 @@ async def test_spend_against_an_older_but_still_valid_topup_is_counted(db, regio
     lite = f"{region.name}_{team.id}"
 
     rows = [
-        _day(lite, 85.0, days_ago=90, keys={"sk-a": 85.0}),
-        _day(lite, 20.0, days_ago=1, keys={"sk-a": 20.0}),
+        _day(lite, 85.0, days_ago=90, keys={"sk-a": 85.0}),  # previous cycle
+        _day(lite, 120.0, days_ago=1, keys={"sk-a": 120.0}),  # this cycle
     ]
 
     with _patch_litellm(rows, [_key_state("sk-a")]):
         result = await evaluate_region(db, region, thresholds=THRESHOLDS)
 
     event = next(e for e in result.events if e.subject_type == SUBJECT_TEAM)
-    # All $105 counts against the $200 still on the books -> 52.5%, crossing 50.
-    # Anchoring on the newest purchase would have seen only $20 (10%) and stayed
-    # silent, which is the failure this test exists to catch.
-    assert event.spend == 105.0
+    # Only the $120 spent since the last purchase counts, against the $200 still on
+    # the books -> 60%. Including the older $85 would read 102.5% and fire 100.
+    assert event.spend == 120.0
     assert event.max_budget == 200.0
     assert event.threshold_pct == 50
-    assert 52.4 < event.percent_used < 52.6
+    assert 59.9 < event.percent_used < 60.1
+
+
+@pytest.mark.asyncio
+async def test_subscription_cycle_wins_over_an_older_topup(db, region):
+    """A team holding both is measured over its current subscription cycle.
+
+    The budget is still the whole available balance — subscription remaining plus
+    top-up remaining — but spend from before the cycle opened has already been
+    settled into ``consumed_cents``, so counting it again would double count.
+    """
+    team = _make_team(db)
+    # $100 subscription, cycle opened 11 days ago; plus a $100 top-up from before.
+    _add_subscription(db, team, region, amount_cents=10_000, days_left=20)
+    _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=60)
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
+
+    rows = [
+        _day(lite, 70.0, days_ago=40, keys={"sk-a": 70.0}),  # before the cycle
+        _day(lite, 105.0, days_ago=1, keys={"sk-a": 105.0}),  # inside the cycle
+    ]
+
+    with _patch_litellm(rows, [_key_state("sk-a")]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    event = next(e for e in result.events if e.subject_type == SUBJECT_TEAM)
+    assert event.spend == 105.0  # not 175.0
+    assert event.max_budget == 200.0  # subscription + top-up remaining
+    assert event.threshold_pct == 50
+    assert event.budget_duration == "31d"
 
 
 @pytest.mark.asyncio
@@ -583,26 +613,36 @@ def test_future_expiry_is_not_a_candidate_yet(db, region):
     assert denominator_change_candidates(db, region.id, datetime.now(UTC)) == set()
 
 
-def test_spend_window_start_uses_oldest_valid_entry(db, region):
+def test_spend_window_start_is_the_last_topup_for_a_topup_only_team(db, region):
     """Directly pin the rule, since everything downstream depends on it."""
     from app.core.budget_alert_service import spend_window_start
 
     team = _make_team(db)
     now = datetime.now(UTC)
-    # Expired: must NOT set the window.
-    _add_topup(
-        db,
-        team,
-        region,
-        amount_cents=10_000,
-        purchased_days_ago=200,
-        expires_at=now - timedelta(days=1),
-    )
     _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=40)
     _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=5)
 
-    start = spend_window_start(db, team, region.id, now)
-    assert 39 <= (now - start).days <= 41
+    window = resolve_team_period_window(db, team, region.id, now=now)
+    start = spend_window_start(window, now)
+    # The most recent purchase opens the cycle, not the older still-valid one.
+    assert 4 <= (now - start).days <= 6
+
+
+def test_spend_window_start_is_the_cycle_start_when_subscribed(db, region):
+    """A subscription defines the cycle, whatever top-ups sit alongside it."""
+    from app.core.budget_alert_service import spend_window_start
+
+    team = _make_team(db)
+    now = datetime.now(UTC)
+    # Cycle opened 11 days ago (31d window, 20 days left).
+    _add_subscription(db, team, region, amount_cents=10_000, days_left=20)
+    # An older top-up must not drag the window back before the cycle.
+    _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=60)
+
+    window = resolve_team_period_window(db, team, region.id, now=now)
+    start = spend_window_start(window, now)
+    assert 10 <= (now - start).days <= 12
+    assert window.source == "subscription_ledger"
 
 
 def test_spend_window_start_falls_back_to_team_creation(db, region):
@@ -611,7 +651,8 @@ def test_spend_window_start_falls_back_to_team_creation(db, region):
 
     team = _make_team(db)
     now = datetime.now(UTC)
-    start = spend_window_start(db, team, region.id, now)
+    window = resolve_team_period_window(db, team, region.id, now=now)
+    start = spend_window_start(window, now)
     assert 4 <= (now - start).days <= 6
 
 

--- a/tests/test_budget_alerts.py
+++ b/tests/test_budget_alerts.py
@@ -12,7 +12,7 @@ counters are lifetime totals a top-up never resets, so they are never the
 numerator.
 """
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -23,6 +23,7 @@ from app.core.budget_alert_service import (
     SUBJECT_TEAM_MEMBER,
     apply_resets,
     evaluate_region,
+    event_id_for,
     highest_crossed_band,
     mark_notified,
     parse_thresholds,
@@ -1179,3 +1180,116 @@ async def test_delivery_without_url_configured_is_a_no_op(db, region):
     )
     with patch.object(settings, "BUDGET_ALERT_WEBHOOK_URL", ""):
         assert await deliver_events([event]) == set()
+
+
+# --------------------------------------------------------------------------- #
+# Retry identity and lookback coverage
+# --------------------------------------------------------------------------- #
+
+
+def test_event_id_identifies_the_crossing_not_the_attempt():
+    """The same crossing must always produce the same id.
+
+    Delivery is at-least-once: if a response is lost after the consumer accepted
+    the batch, the next tick re-sends. A random id would defeat the consumer's
+    de-duplication and the customer would be notified twice.
+    """
+    first = event_id_for("team:7:2", "2026-07-01:2026-08-01", 90)
+    second = event_id_for("team:7:2", "2026-07-01:2026-08-01", 90)
+    assert first == second
+    assert first.startswith("evt_")
+
+    # A different band, period or subject is a different crossing.
+    assert event_id_for("team:7:2", "2026-07-01:2026-08-01", 100) != first
+    assert event_id_for("team:7:2", "2026-08-01:2026-09-01", 90) != first
+    assert event_id_for("team:8:2", "2026-07-01:2026-08-01", 90) != first
+
+
+@pytest.mark.asyncio
+async def test_undelivered_event_keeps_its_id_on_the_next_tick(db, region):
+    """A failed delivery is retried under the original id, so it dedups."""
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=10_000)  # $100
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
+    rows = _active(lite, keys={"sk-a": 92.0})
+
+    with _patch_litellm(rows, [_key_state("sk-a")]):
+        first = await evaluate_region(db, region, thresholds=THRESHOLDS)
+    # Nothing is marked notified: this stands for a POST that did not confirm.
+    with _patch_litellm(rows, [_key_state("sk-a")]):
+        second = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    ids_first = {e.event_id for e in first.events}
+    assert ids_first == {e.event_id for e in second.events}
+    assert len(ids_first) == len(first.events)  # ids are unique within a tick
+
+
+@pytest.mark.asyncio
+async def test_sweep_reaches_back_to_the_oldest_valid_purchase(db, region):
+    """The request window is derived from the ledger, not from a fixed span.
+
+    A top-up bought 200 days ago is still valid, so its spend counts. Asking
+    LiteLLM for a shorter span would return part of the spend and understate the
+    percentage for as long as the entry lives.
+    """
+    team = _make_team(db)
+    _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=200)
+    _make_key(db, team, region, token="sk-a")
+
+    activity = AsyncMock(return_value=[])
+    with patch.multiple(
+        "app.core.budget_alert_service.LiteLLMService",
+        get_all_team_daily_activity=activity,
+        list_keys_for_team=AsyncMock(return_value=[]),
+    ):
+        await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    start = date.fromisoformat(activity.await_args.args[0])
+    expected = (datetime.now(UTC) - timedelta(days=200)).date()
+    assert start == expected
+
+
+@pytest.mark.asyncio
+async def test_sweep_does_not_reach_past_the_lookback_floor(db, region):
+    """The floor still bounds the request, however old the ledger is."""
+    team = _make_team(db)
+    _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=200)
+    _make_key(db, team, region, token="sk-a")
+
+    activity = AsyncMock(return_value=[])
+    with patch.object(settings, "BUDGET_ALERT_MAX_LOOKBACK_DAYS", 30):
+        with patch.multiple(
+            "app.core.budget_alert_service.LiteLLMService",
+            get_all_team_daily_activity=activity,
+            list_keys_for_team=AsyncMock(return_value=[]),
+        ):
+            await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    start = date.fromisoformat(activity.await_args.args[0])
+    assert start == (datetime.now(UTC) - timedelta(days=30)).date()
+
+
+@pytest.mark.asyncio
+async def test_team_is_skipped_when_its_window_predates_the_floor(db, region):
+    """Better no alert than a confidently wrong one.
+
+    With the window truncated, the visible spend is only part of the total, so the
+    percentage would sit permanently low — a team at 92% would be told it is at
+    30%. The team is dropped and logged instead.
+    """
+    team = _make_team(db)
+    _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=200)
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
+
+    # Only the spend inside the floor is visible; the rest of the 200-day window
+    # is not returned at all.
+    rows = _active(lite, keys={"sk-a": 30.0})
+
+    with patch.object(settings, "BUDGET_ALERT_MAX_LOOKBACK_DAYS", 30):
+        with _patch_litellm(rows, [_key_state("sk-a")]):
+            result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert result.events == []
+    assert result.subjects_evaluated == 0

--- a/tests/test_budget_alerts.py
+++ b/tests/test_budget_alerts.py
@@ -1940,3 +1940,63 @@ async def test_a_rebased_rollover_is_not_double_counted(db, region):
     assert event.spend == 200.0
     assert event.max_budget == 263.30
     assert event.threshold_pct == 75
+
+
+@pytest.mark.asyncio
+async def test_idle_team_with_a_window_before_the_sweep_is_still_found(db, region):
+    """Spending nothing inside the swept range must not hide a crossing.
+
+    The wide request returns no row for such a team, so traffic-based discovery
+    misses it — and with it the scoped back-fill that exists for exactly this case.
+    The team is found from the ledger instead.
+    """
+    team = _make_team(db)
+    # Window opened 200 days ago; the sweep floor is 30, so the wide request covers
+    # only the last 30 days -- in which this team spent nothing at all.
+    _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=200)
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
+
+    # Nothing in the wide response; the scoped call carries the real history.
+    scoped_rows = [_day(lite, 92.0, days_ago=150, keys={"sk-a": 92.0})]
+    scoped = AsyncMock(return_value=scoped_rows)
+
+    with patch.object(settings, "BUDGET_ALERT_MAX_LOOKBACK_DAYS", 30):
+        with patch.multiple(
+            "app.core.budget_alert_service.LiteLLMService",
+            get_all_team_daily_activity=AsyncMock(return_value=[]),
+            get_team_daily_activity=scoped,
+            list_keys_for_team=AsyncMock(return_value=[_key_state("sk-a")]),
+        ):
+            result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    scoped.assert_awaited()
+    event = next(e for e in result.events if e.subject_type == SUBJECT_TEAM)
+    assert event.spend == 92.0
+    assert event.threshold_pct == 90
+
+
+def test_window_before_sweep_candidates_is_empty_under_the_default_lookback(db, region):
+    """With the shipped settings no valid window can predate the sweep.
+
+    The floor is longer than a purchase can stay valid, so this returns nothing —
+    which is why the query is a safety net rather than a hot path.
+    """
+    from app.core.budget_alert_service import (
+        region_sweep_start,
+        window_before_sweep_candidates,
+    )
+
+    now = datetime.now(UTC)
+    team = _make_team(db)
+    _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=300)
+
+    sweep_start = region_sweep_start(db, region.id, now)
+    assert window_before_sweep_candidates(db, region.id, sweep_start, now) == set()
+
+    # Lower the floor below the purchase age and the team surfaces.
+    with patch.object(settings, "BUDGET_ALERT_MAX_LOOKBACK_DAYS", 30):
+        sweep_start = region_sweep_start(db, region.id, now)
+        assert window_before_sweep_candidates(db, region.id, sweep_start, now) == {
+            team.id
+        }

--- a/tests/test_budget_alerts.py
+++ b/tests/test_budget_alerts.py
@@ -31,12 +31,20 @@ from app.core.budget_alert_service import (
 from app.core.config import settings
 from app.db.models import (
     DBBudgetAlertState,
+    DBLimitedResource,
     DBPeriodicBudgetLedgerEntry,
     DBPrivateAIKey,
     DBRegion,
     DBSpendCap,
     DBTeam,
     DBUser,
+)
+from app.schemas.limits import (
+    LimitSource,
+    LimitType,
+    OwnerType,
+    ResourceType,
+    UnitType,
 )
 from app.schemas.models import BudgetType
 from app.services.litellm import LiteLLMService
@@ -1194,15 +1202,16 @@ def test_event_id_identifies_the_crossing_not_the_attempt():
     the batch, the next tick re-sends. A random id would defeat the consumer's
     de-duplication and the customer would be notified twice.
     """
-    first = event_id_for("team:7:2", "2026-07-01:2026-08-01", 90)
-    second = event_id_for("team:7:2", "2026-07-01:2026-08-01", 90)
+    first = event_id_for("team:7:2", "2026-07-01:2026-08-01", 90, 0)
+    second = event_id_for("team:7:2", "2026-07-01:2026-08-01", 90, 0)
     assert first == second
     assert first.startswith("evt_")
 
-    # A different band, period or subject is a different crossing.
-    assert event_id_for("team:7:2", "2026-07-01:2026-08-01", 100) != first
-    assert event_id_for("team:7:2", "2026-08-01:2026-09-01", 90) != first
-    assert event_id_for("team:8:2", "2026-07-01:2026-08-01", 90) != first
+    # A different band, period, subject or arming is a different crossing.
+    assert event_id_for("team:7:2", "2026-07-01:2026-08-01", 100, 0) != first
+    assert event_id_for("team:7:2", "2026-08-01:2026-09-01", 90, 0) != first
+    assert event_id_for("team:8:2", "2026-07-01:2026-08-01", 90, 0) != first
+    assert event_id_for("team:7:2", "2026-07-01:2026-08-01", 90, 1) != first
 
 
 @pytest.mark.asyncio
@@ -1293,3 +1302,118 @@ async def test_team_is_skipped_when_its_window_predates_the_floor(db, region):
 
     assert result.events == []
     assert result.subjects_evaluated == 0
+
+
+@pytest.mark.asyncio
+async def test_pool_team_budget_limit_is_not_a_pool_denominator(db, region):
+    """A POOL team's budget is the money it bought, not its BUDGET limit.
+
+    673 POOL teams on PROD hold no valid ledger entry but do carry a
+    ``limited_resources`` BUDGET row (mostly $27). That row is a provisioning
+    allowance, not available credit, and with no purchase to anchor on the spend
+    window would stretch back to team creation. Measuring against it would invent
+    a percentage, so such a team gets no team event.
+    """
+    team = _make_team(db)
+    db.add(
+        DBLimitedResource(
+            owner_type=OwnerType.TEAM,
+            owner_id=team.id,
+            resource=ResourceType.BUDGET,
+            limit_type=LimitType.DATA_PLANE,
+            unit=UnitType.DOLLAR,
+            max_value=27.0,
+            current_value=0.0,
+            limited_by=LimitSource.MANUAL,
+            set_by="test",
+        )
+    )
+    db.commit()
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
+
+    # Spend that would be 92% of the $27 limit if it were treated as a budget.
+    with _patch_litellm(_active(lite, keys={"sk-a": 25.0}), [_key_state("sk-a")]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    assert [e for e in result.events if e.subject_type == SUBJECT_TEAM] == []
+
+
+@pytest.mark.asyncio
+async def test_periodic_team_still_uses_its_budget_limit(db, region):
+    """The limit fallback stays available to PERIODIC teams, which is its purpose."""
+    from app.core.budget_alert_service import _team_budget
+
+    team = _make_team(db, budget_type=BudgetType.PERIODIC, name="periodic-team")
+    db.add(
+        DBLimitedResource(
+            owner_type=OwnerType.TEAM,
+            owner_id=team.id,
+            resource=ResourceType.BUDGET,
+            limit_type=LimitType.DATA_PLANE,
+            unit=UnitType.DOLLAR,
+            max_value=27.0,
+            current_value=0.0,
+            limited_by=LimitSource.MANUAL,
+            set_by="test",
+        )
+    )
+    db.commit()
+
+    assert _team_budget(db, team, region.id) == 27.0
+
+
+@pytest.mark.asyncio
+async def test_re_crossing_a_band_in_one_period_gets_a_new_event_id(db, region):
+    """A re-armed band must not reuse the id of the crossing already sent.
+
+    A subscription-backed POOL team keeps one ``period_key`` for the whole
+    subscription window, so a top-up inside it lowers the percentage without
+    starting a new period. The band is silently re-armed, and when spend climbs
+    back through it that is a real second warning. Keyed on
+    (subject, period, band) alone the two crossings would share an id and the
+    consumer would discard the second as a duplicate.
+    """
+    team = _make_team(db)
+    _add_subscription(db, team, region, amount_cents=10_000, days_left=20)  # $100
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
+    subject_key = f"team:{team.id}:{region.id}"
+
+    # 1. $92 of $100 -> crosses 90, delivered.
+    rows = [_day(lite, 92.0, days_ago=2, keys={"sk-a": 92.0})]
+    with _patch_litellm(rows, [_key_state("sk-a")]):
+        first = await evaluate_region(db, region, thresholds=THRESHOLDS)
+    first_event = next(e for e in first.events if e.subject_type == SUBJECT_TEAM)
+    assert first_event.threshold_pct == 90
+    mark_notified(db, region, first, {e.event_id for e in first.events})
+
+    # 2. A top-up doubles the pool: $92 of $200 is 46%, so the band walks back
+    #    silently. The subscription still defines the period.
+    _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=0)
+    with _patch_litellm(rows, [_key_state("sk-a")]):
+        second = await evaluate_region(db, region, thresholds=THRESHOLDS)
+    assert [e for e in second.events if e.subject_type == SUBJECT_TEAM] == []
+    apply_resets(db, region, second)
+
+    state = (
+        db.query(DBBudgetAlertState)
+        .filter(DBBudgetAlertState.subject_key == subject_key)
+        .one()
+    )
+    assert state.period_key == first_event.period_key  # same subscription period
+    assert state.arm_seq == 1  # the reset re-armed the bands
+
+    # 3. Spend climbs to $185 of $200 -> crosses 90 again, in the same period.
+    rows_after = [
+        _day(lite, 92.0, days_ago=2, keys={"sk-a": 92.0}),
+        _day(lite, 93.0, days_ago=0, keys={"sk-a": 93.0}),
+    ]
+    with _patch_litellm(rows_after, [_key_state("sk-a")]):
+        third = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    third_event = next(e for e in third.events if e.subject_type == SUBJECT_TEAM)
+    assert third_event.threshold_pct == 90
+    assert third_event.period_key == first_event.period_key
+    # Same subject, same period, same band -- but a genuinely new warning.
+    assert third_event.event_id != first_event.event_id

--- a/tests/test_budget_alerts.py
+++ b/tests/test_budget_alerts.py
@@ -373,7 +373,7 @@ async def test_unknown_entities_are_ignored(db, region):
 
 @pytest.mark.asyncio
 async def test_periodic_team_is_out_of_scope(db, region):
-    """PERIODIC is excluded: on PROD every PERIODIC key belongs to the anonymous
+    """PERIODIC is excluded: those keys belong to the anonymous
     trial team, which has no MOAD workspace and nobody to notify."""
     team = _make_team(db, budget_type=BudgetType.PERIODIC, name="periodic-team")
     _add_subscription(db, team, region, amount_cents=10_000)
@@ -677,7 +677,7 @@ def test_spend_window_start_falls_back_to_team_creation(db, region):
 
 
 def test_inactive_region_holding_keys_is_still_swept(db, region):
-    """PROD region 5 is inactive but holds 85% of all keys.
+    """An inactive region can still hold the large majority of a fleet's keys.
 
     is_active governs new provisioning, not whether existing keys serve traffic.
     Filtering on it would exclude the anonymous trial fleet -- the population most
@@ -842,7 +842,7 @@ async def test_key_cap_drives_key_scope_alert(db, region):
 async def test_service_key_and_user_key_both_alert(db, region):
     """A key is in scope for having a team, not for having an owner.
 
-    PROD POOL teams hold 405 service keys (no owner) and 929 user keys; both must
+    POOL teams hold both service keys (no owner) and user keys; both must
     produce key-scope alerts, and the event says which it is so the consumer can
     route it to the workspace or to the individual.
     """
@@ -875,7 +875,7 @@ async def test_service_key_and_user_key_both_alert(db, region):
 async def test_uncapped_key_covered_by_the_team_alert_on_a_single_key_team(db, region):
     """An uncapped key has no key-level budget, but the customer is still warned.
 
-    44.7% of team-attached keys on PROD carry no max_budget: for POOL, only an
+    Many team-attached keys carry no max_budget: for POOL, only an
     explicit cap sets one, and everything else is bounded by the team pool. On a
     one-key team the key percentage would equal the team's, so only the team event
     fires -- the spend is routed, not dropped.
@@ -1403,7 +1403,7 @@ async def test_team_is_dropped_when_the_back_fill_fails(db, region):
 
 @pytest.mark.asyncio
 async def test_budget_less_team_costs_no_extra_call(db, region):
-    """The 673 ledger-less POOL teams must not each trigger a back-fill.
+    """Ledger-less POOL teams must not each trigger a back-fill.
 
     They anchor on team.created_at, which is routinely older than the window, but
     they have no budget to be a percentage of, so there is nothing to fetch.
@@ -1432,7 +1432,7 @@ async def test_budget_less_team_costs_no_extra_call(db, region):
 async def test_pool_team_budget_limit_is_not_a_pool_denominator(db, region):
     """A POOL team's budget is the money it bought, not its BUDGET limit.
 
-    673 POOL teams on PROD hold no valid ledger entry but do carry a
+    Many POOL teams hold no valid ledger entry but do carry a
     ``limited_resources`` BUDGET row (mostly $27). That row is a provisioning
     allowance, not available credit, and with no purchase to anchor on the spend
     window would stretch back to team creation. Measuring against it would invent
@@ -1551,7 +1551,7 @@ async def test_re_crossing_a_band_in_one_period_gets_a_new_event_id(db, region):
 def test_current_cycle_start_rolls_forward_to_contain_now():
     """A stale anchor must not hand back a window that already closed.
 
-    PROD has keys whose LiteLLM budget_reset_at is a month in the past, so the
+    A key's LiteLLM budget_reset_at can sit a month in the past, so the
     cycle has to be stepped forward the way LiteLLM steps it on reset.
     """
     from app.core.spend_period_service import current_cycle_start
@@ -1576,7 +1576,7 @@ def test_current_cycle_start_rolls_forward_to_contain_now():
 
 @pytest.mark.asyncio
 async def test_capped_key_is_measured_over_the_cap_cycle_not_the_pool(db, region):
-    """195 of 196 key caps on PROD sit on top-up-only teams.
+    """Nearly every key cap sits on a top-up-only team.
 
     The team's cycle can be far longer than the cap's, so summing the team window
     against a monthly cap would read hundreds of percent and fire immediately.
@@ -1656,7 +1656,7 @@ async def test_capped_key_crossing_inside_its_own_cycle_still_fires(db, region):
 
 @pytest.mark.asyncio
 async def test_member_cap_is_measured_over_the_cap_cycle(db, region):
-    """All 38 team-member caps on PROD are 1mo, same rule as key caps."""
+    """Team-member caps are written as 1mo, same rule as key caps."""
     team = _make_team(db)
     _add_topup(db, team, region, amount_cents=100_000, purchased_days_ago=90)
     user = _make_user(db, team)
@@ -1721,10 +1721,9 @@ async def test_uncapped_key_keeps_the_team_cycle(db, region):
 async def test_rolling_cap_cycle_is_anchored_on_the_cap_not_the_team(db, region):
     """A cap set months after the team must count from *its* cycle.
 
-    Verified against PROD: for a team whose cap was set well after the team, the
-    cap's created_at reproduces LiteLLM's budget_reset_at to the time of day while
-    team creation was 18.7 days out. 29 of the 130 rolling 31d caps were set more
-    than a day after their team, by up to 420 days.
+    A cap set well after its team is common, and the two dates can be hundreds of
+    days apart. The cap's own created_at reproduces LiteLLM's budget_reset_at, while
+    team creation can be weeks out.
     """
     now = datetime.now(UTC)
     team = _make_team(db)
@@ -1842,3 +1841,102 @@ async def test_cap_cycle_ignores_a_litellm_reset_for_a_different_duration(db, re
 
     # Window opened 9 days ago -> only $5 of $100 -> nothing to say.
     assert [e for e in result.events if e.subject_type == SUBJECT_KEY] == []
+
+
+# --------------------------------------------------------------------------- #
+# Cancellation: FIFO settles without re-basing
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_cancelled_subscription_falls_back_to_the_topup_window(db, region):
+    """Cancelling deactivates the subscription rows, so the top-up rule takes over."""
+    now = datetime.now(UTC)
+    team = _make_team(db)
+    sub = _add_subscription(db, team, region, amount_cents=10_000, days_left=20)
+    _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=40)
+    _make_key(db, team, region, token="sk-a")
+
+    window = resolve_team_period_window(db, team, region.id, now=now)
+    assert window.source == "subscription_ledger"
+
+    # Cancellation sets is_active = False on every subscription row.
+    sub.is_active = False
+    db.commit()
+
+    window = resolve_team_period_window(db, team, region.id, now=now)
+    assert window.source == "pool_topup"
+    assert 39 <= (now - window.period_start).days <= 41
+
+
+@pytest.mark.asyncio
+async def test_consumed_on_a_still_valid_entry_is_added_back(db, region):
+    """Cancellation runs FIFO without re-basing, so the budget must be face value.
+
+    ``allocate_period_spend_fifo`` increments ``consumed_cents`` on entries that
+    stay valid, while ``materialize_topup_rollovers`` — which would deactivate and
+    replace them — is only called on the invoice path. Left uncorrected the budget
+    drops by spend the numerator still counts, and the percentage reads high.
+    """
+    team = _make_team(db)
+    entry = _add_topup(db, team, region, amount_cents=10_000, purchased_days_ago=40)
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
+    rows = [_day(lite, 60.0, days_ago=30, keys={"sk-a": 60.0})]
+
+    # FIFO settled $60 against this entry but left it valid.
+    entry.consumed_cents = 6_000
+    db.commit()
+
+    with _patch_litellm(rows, [_key_state("sk-a")]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    event = next(e for e in result.events if e.subject_type == SUBJECT_TEAM)
+    # $60 of the $100 bought -> 60%, crossing 50. Against the $40 "remaining" it
+    # would have read 150% and fired 100.
+    assert event.spend == 60.0
+    assert event.max_budget == 100.0
+    assert event.threshold_pct == 50
+
+
+@pytest.mark.asyncio
+async def test_a_rebased_rollover_is_not_double_counted(db, region):
+    """The normal settlement shape.
+
+    A partly-consumed top-up is deactivated and replaced by a rollover holding the
+    remainder with ``consumed_cents = 0``. The window must open at the rollover, so
+    the already-settled spend is counted on neither side.
+    """
+    now = datetime.now(UTC)
+    team = _make_team(db)
+    spent = _add_topup(db, team, region, amount_cents=100_000, purchased_days_ago=45)
+    spent.consumed_cents = 73_670
+    spent.is_active = False  # re-based, so out of scope
+    rollover = DBPeriodicBudgetLedgerEntry(
+        team_id=team.id,
+        region_id=region.id,
+        entry_type="topup_rollover",
+        amount_cents=26_330,
+        consumed_cents=0,
+        is_active=True,
+        purchased_at=now - timedelta(days=4),
+        expires_at=now + timedelta(days=320),
+    )
+    db.add(rollover)
+    db.commit()
+    _make_key(db, team, region, token="sk-a")
+    lite = f"{region.name}_{team.id}"
+
+    rows = [
+        _day(lite, 736.70, days_ago=20, keys={"sk-a": 736.70}),  # already settled
+        _day(lite, 200.0, days_ago=1, keys={"sk-a": 200.0}),  # since the rollover
+    ]
+
+    with _patch_litellm(rows, [_key_state("sk-a")]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    event = next(e for e in result.events if e.subject_type == SUBJECT_TEAM)
+    # Only the $200 since the rollover, against the $263.30 it holds -> 76%.
+    assert event.spend == 200.0
+    assert event.max_budget == 263.30
+    assert event.threshold_pct == 75

--- a/tests/test_budget_alerts.py
+++ b/tests/test_budget_alerts.py
@@ -193,17 +193,20 @@ def _active(lite_team_id, spend=0.0, *, keys=None, days_ago=0):
     return [_day(lite_team_id, spend, days_ago=days_ago, keys=keys)]
 
 
-def _key_state(token, *, max_budget=None, budget_duration="365d"):
+def _key_state(token, *, max_budget=None, budget_duration="365d", budget_reset_at=None):
     """One entry of LiteLLM's /key/list response.
 
     Carries the *denominator* only. Spend deliberately comes from the day-rows, so
     a test cannot accidentally assert against LiteLLM's lifetime counter.
     """
-    return {
+    state = {
         "token": LiteLLMService.hash_token(token),
         "max_budget": max_budget,
         "budget_duration": budget_duration,
     }
+    if budget_reset_at is not None:
+        state["budget_reset_at"] = budget_reset_at.isoformat()
+    return state
 
 
 def _patch_litellm(team_rows, team_keys=None):
@@ -1742,4 +1745,88 @@ async def test_rolling_cap_cycle_is_anchored_on_the_cap_not_the_team(db, region)
 
     # $30 of $100 is 30% -> silent. Anchored on the team it would have summed
     # $110, read 110%, and fired 100 on spend from the previous cycle.
+    assert [e for e in result.events if e.subject_type == SUBJECT_KEY] == []
+
+
+@pytest.mark.asyncio
+async def test_cap_cycle_phase_comes_from_litellm_reset_date(db, region):
+    """LiteLLM owns where the boundary actually falls, so it owns the phase.
+
+    Its reset job recomputes each boundary from the day it runs, so
+    budget_reset_at absorbs any lateness. Our created_at only predicts the
+    boundary for as long as that job stays punctual, so it is the fallback.
+    """
+    now = datetime.now(UTC)
+    team = _make_team(db)
+    _add_topup(db, team, region, amount_cents=100_000, purchased_days_ago=60)
+    key = _make_key(db, team, region, token="sk-a")
+    db.add(
+        DBSpendCap(
+            scope="key",
+            region_id=region.id,
+            team_id=team.id,
+            key_id=key.id,
+            max_budget=100.0,
+            budget_duration="31d",
+            # Anchored here the cycle would have opened 9 days ago (40 - 31).
+            created_at=now - timedelta(days=40),
+        )
+    )
+    db.commit()
+    lite = f"{region.name}_{team.id}"
+
+    # LiteLLM says the cycle ends in 3 days, so it opened 28 days ago.
+    key_state = _key_state(
+        "sk-a", budget_duration="31d", budget_reset_at=now + timedelta(days=3)
+    )
+    rows = [
+        _day(lite, 80.0, days_ago=20, keys={"sk-a": 80.0}),
+        _day(lite, 5.0, days_ago=1, keys={"sk-a": 5.0}),
+    ]
+
+    with _patch_litellm(rows, [key_state]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    event = next(e for e in result.events if e.subject_type == SUBJECT_KEY)
+    # $85 of $100 -> 75 band. Anchored on created_at the window would have opened
+    # 9 days ago, seen only $5, and stayed silent through an 85% cycle.
+    assert event.spend == 85.0
+    assert event.threshold_pct == 75
+
+
+@pytest.mark.asyncio
+async def test_cap_cycle_ignores_a_litellm_reset_for_a_different_duration(db, region):
+    """A 1mo reset date must not be read as though it were a 31d one."""
+    now = datetime.now(UTC)
+    team = _make_team(db)
+    _add_topup(db, team, region, amount_cents=100_000, purchased_days_ago=60)
+    key = _make_key(db, team, region, token="sk-a")
+    db.add(
+        DBSpendCap(
+            scope="key",
+            region_id=region.id,
+            team_id=team.id,
+            key_id=key.id,
+            max_budget=100.0,
+            budget_duration="31d",
+            created_at=now - timedelta(days=40),  # cycle opened 9 days ago
+        )
+    )
+    db.commit()
+    lite = f"{region.name}_{team.id}"
+
+    # LiteLLM is on a calendar month here, so its reset date says nothing about
+    # where our 31d cycle falls; created_at has to be used instead.
+    key_state = _key_state(
+        "sk-a", budget_duration="1mo", budget_reset_at=now + timedelta(days=3)
+    )
+    rows = [
+        _day(lite, 80.0, days_ago=20, keys={"sk-a": 80.0}),
+        _day(lite, 5.0, days_ago=1, keys={"sk-a": 5.0}),
+    ]
+
+    with _patch_litellm(rows, [key_state]):
+        result = await evaluate_region(db, region, thresholds=THRESHOLDS)
+
+    # Window opened 9 days ago -> only $5 of $100 -> nothing to say.
     assert [e for e in result.events if e.subject_type == SUBJECT_KEY] == []

--- a/tests/test_spend_period_service.py
+++ b/tests/test_spend_period_service.py
@@ -1,7 +1,16 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
-from app.core.spend_period_service import upsert_team_spend_period
-from app.db.models import DBTeamSpendPeriod, DBTeamSpendPeriodKey
+from app.core.config import settings
+from app.core.spend_period_service import (
+    resolve_team_period_window,
+    upsert_team_spend_period,
+)
+from app.db.models import (
+    DBPeriodicBudgetLedgerEntry,
+    DBTeamSpendPeriod,
+    DBTeamSpendPeriodKey,
+)
+from app.schemas.models import BudgetType
 
 
 def test_upsert_team_spend_period_creates_parent_and_keys(
@@ -120,3 +129,100 @@ def test_upsert_team_spend_period_keeps_original_snapshot_for_same_window(
     )
     assert len(rows) == 1
     assert rows[0].total_spend == 5.0
+
+
+def _topup(db, team, region, *, amount_cents, days_ago):
+    now = datetime.now(UTC)
+    entry = DBPeriodicBudgetLedgerEntry(
+        team_id=team.id,
+        region_id=region.id,
+        entry_type="topup",
+        amount_cents=amount_cents,
+        consumed_cents=0,
+        is_active=True,
+        purchased_at=now - timedelta(days=days_ago),
+        expires_at=now + timedelta(days=settings.POOL_PURCHASE_EXPIRY_DAYS - days_ago),
+    )
+    db.add(entry)
+    db.commit()
+    return entry
+
+
+def test_pool_topup_window_opens_at_the_oldest_valid_purchase(
+    db, test_team, test_region
+):
+    """The window spans the life of the credit the team still holds.
+
+    It opens at the oldest still-valid purchase because the budget is the full face
+    value of every valid entry: ``consumed_cents`` is only written by FIFO at
+    invoice close, which a team with no subscription never has. Opening at the
+    newest purchase would leave spend against the older entries counted nowhere —
+    missing from the numerator and never deducted from the budget.
+
+    It closes 365 days after the NEWEST purchase, since that is when the last of
+    the credit lapses.
+    """
+    test_team.budget_type = BudgetType.POOL
+    db.commit()
+    now = datetime.now(UTC)
+    _topup(db, test_team, test_region, amount_cents=10_000, days_ago=100)
+    _topup(db, test_team, test_region, amount_cents=10_000, days_ago=10)
+
+    window = resolve_team_period_window(db, test_team, test_region.id, now=now)
+
+    assert window.source == "pool_topup"
+    assert 99 <= (now - window.period_start).days <= 101
+    expected_end = (
+        now - timedelta(days=10) + timedelta(days=settings.POOL_PURCHASE_EXPIRY_DAYS)
+    )
+    assert abs((window.period_end - expected_end).total_seconds()) < 5
+    assert window.budget_duration == f"{settings.POOL_PURCHASE_EXPIRY_DAYS}d"
+
+
+def test_pool_topup_window_is_unchanged_for_a_single_purchase(
+    db, test_team, test_region
+):
+    """215 of 222 top-up team+regions hold one entry: nothing moves for them."""
+    test_team.budget_type = BudgetType.POOL
+    db.commit()
+    now = datetime.now(UTC)
+    _topup(db, test_team, test_region, amount_cents=10_000, days_ago=30)
+
+    window = resolve_team_period_window(db, test_team, test_region.id, now=now)
+
+    # Oldest and newest are the same row, so both ends derive from it.
+    assert 29 <= (now - window.period_start).days <= 31
+    expected_end = (
+        now - timedelta(days=30) + timedelta(days=settings.POOL_PURCHASE_EXPIRY_DAYS)
+    )
+    assert abs((window.period_end - expected_end).total_seconds()) < 5
+
+
+def test_pool_window_ignores_topups_when_a_subscription_is_active(
+    db, test_team, test_region
+):
+    """The subscription branch wins, so top-up dates do not touch the window."""
+    test_team.budget_type = BudgetType.POOL
+    db.commit()
+    now = datetime.now(UTC)
+    _topup(db, test_team, test_region, amount_cents=10_000, days_ago=100)
+    db.add(
+        DBPeriodicBudgetLedgerEntry(
+            team_id=test_team.id,
+            region_id=test_region.id,
+            entry_type="subscription",
+            amount_cents=10_000,
+            consumed_cents=0,
+            is_active=True,
+            purchased_at=now - timedelta(days=11),
+            effective_period_start=now - timedelta(days=11),
+            effective_period_end=now + timedelta(days=20),
+        )
+    )
+    db.commit()
+
+    window = resolve_team_period_window(db, test_team, test_region.id, now=now)
+
+    assert window.source == "subscription_ledger"
+    assert 10 <= (now - window.period_start).days <= 12
+    assert window.budget_duration == "31d"

--- a/tests/test_spend_period_service.py
+++ b/tests/test_spend_period_service.py
@@ -182,7 +182,7 @@ def test_pool_topup_window_opens_at_the_oldest_valid_purchase(
 def test_pool_topup_window_is_unchanged_for_a_single_purchase(
     db, test_team, test_region
 ):
-    """215 of 222 top-up team+regions hold one entry: nothing moves for them."""
+    """Most top-up team+regions hold one entry: nothing moves for them."""
     test_team.budget_type = BudgetType.POOL
     db.commit()
     now = datetime.now(UTC)


### PR DESCRIPTION
Customers get no warning before their AI budget runs out — keys simply stop working when
LiteLLM's `max_budget` is reached. This adds an amazee.ai-side job that detects when spend
crosses 50 / 75 / 90 / 100 % of budget and POSTs a batch of events to MOAD.

**MOAD's consumer endpoint and the customer-facing notification are a separate ticket.** This
PR only produces and delivers the events. It ships disabled (`BUDGET_ALERT_ENABLED=false`).

## Why amazee.ai computes the percentage instead of LiteLLM

LiteLLM has native budget alerting, but it cannot produce the right number for our teams:

- **Wrong numerator.** LiteLLM's team-level `spend` counter is never reset; our billing cycle
  zeroes the *per-key* spends instead. A lifetime total over a one-cycle budget sits
  permanently above 100 %.
- **Moving denominator.** POOL budgets are owned by our ledger. Buying a top-up raises the
  budget, so a percentage can fall back below a band it already crossed. LiteLLM's TTL-based
  dedup would then suppress the genuine second crossing.
- Its thresholds are hardcoded to 85 % / 95 %, and there is one webhook URL per proxy.

So LiteLLM is the source of *spend*, and every budget number comes from our DB.

## How a tick works

`monitor-budget-thresholds` runs every 5 minutes (`.lagoon.yml`, prod + dev) via
`scripts/trigger_budget_alerts_job.py`, guarded by the `budget_alerts` advisory lock.

1. **Pick regions** — `regions_to_sweep()`: regions with at least one live key and LiteLLM
   credentials. Deliberately *not* filtered on `is_active`; PROD region 5 is inactive but
   holds 11,859 of 13,930 keys.
2. **One wide read per region** — unfiltered `/team/daily/activity` over the window that
   `region_sweep_start()` derives from the ledger. LiteLLM writes no daily rows for idle
   entities, so an 11,859-key region reports 42 active teams and 351 active keys.
3. **One scoped read per active team** — `/key/list?team_id=` for `max_budget`, cap duration
   and reset date. Its `spend` figures are deliberately ignored.
4. **Compute, compare, fire** — only the highest newly-crossed band per subject.
5. **POST the batch**, then advance state only for the events the POST accepted.
6. **Audit + metrics** — a `DBAuditLog` row per delivered crossing, 5 Prometheus series.

Subjects do not share a window, so the daily rows are indexed once per tick as a per-day series
and each subject sums only the days its own cycle covers.

Cost is `pages + active_teams` calls per region, independent of idle key count. Measured ~1 s
per region. Sweeping every key instead — the shape of the existing hourly reconciler, ~40 min
at 13.9k keys — is what does not survive 100k.

## Scope

POOL teams only, and keys carrying **both** a team and a region — the shape MOAD provisions
and can address. Both service keys and user keys. PERIODIC is excluded because all 12,098
PERIODIC keys on PROD belong to the single anonymous Drupal trial team, which has no MOAD
workspace and no addressable owner.

Subjects: **team per region**, **key**, **team member**.

## Windows: alerts are per cycle

Every percentage is spend over the **current cycle** divided by that cycle's budget. Which
cycle depends on the subject, because a team and a capped key are not on the same clock.

| Subject | Window |
| --- | --- |
| Team with a subscription | the subscription cycle (`effective_period_start` → now) |
| Team with top-ups only | the **oldest still-valid** purchase → now (window closes 365d after the *newest* purchase) |
| Team with **both** | the **subscription** cycle, against the whole available balance |
| Key or member **with a cap** | that cap's own current cycle |
| Key bounded by the pool | the team's window — it has no cycle of its own |

PROD: 88 subscription-backed POOL team+regions, 222 top-up-only.

**Subscriptions — never wider than the cycle**, because the denominator is
`purchased − consumed_cents` and `consumed_cents` is incremented at cycle close while LiteLLM's
spend is reset on the same call (invariant at `app/api/spend.py:982-987`). A closed cycle's spend
is already out of the budget; counting it again inflates the percentage and fires alerts nobody
earned.

**Top-ups — the opposite**, because `consumed_cents` is *never* written for them: FIFO allocation
runs at invoice close and a team with no subscription never has one. On PROD exactly **1 of 233**
top-up entries has it set, so the budget is the full face value of every still-valid purchase. A
window opening at the newest purchase would leave spend against the older entries counted
nowhere — missing from the numerator and never deducted from the budget.

Worked example: $30 bought 6 July with $25 spent against it, then $30 more on 29 July. Anchored on
the newest purchase that reads **$0 of $60** while the team really holds $35, and later reports
50 % when the truth is 92 % — told they are halfway through while their keys are about to stop.
Anchored on the oldest it reads $25 of $60 and keeps counting. Exposure: 7 of 222 top-up
team+regions hold more than one valid entry, only 3 bought on different days.

**Why "still-valid" carries the weight.** Settlement re-bases rather than annotates:
`materialize_topup_rollovers` deactivates a partly-consumed entry and writes a fresh
`topup_rollover` holding the remainder with `consumed_cents = 0`. So among valid entries the
column is 0, face value equals remaining, and the window lines up with the budget by
construction — already-settled spend is counted on neither side.

Cancellation is the exception: `app/api/subscription.py` runs `allocate_period_spend_fifo` but
never calls `materialize_topup_rollovers`, leaving `consumed_cents` on entries that stay valid.
The budget would then drop by spend the numerator still counts — subtracted once and added once —
and read high. `_unsettled_consumed_dollars` adds it back, a no-op unless the column is set, and
logs when it is not. A cancelled subscription otherwise falls through to the top-up window
cleanly, since deactivation sets `is_active = False` on every subscription row.

Cycle starts come from the shared `resolve_team_period_window()` — the same helper the spend API
uses — so an alert cannot quote a different period than the dashboard. `team_spend_periods` was
rejected as the source: 145 rows, only 4 covering the present.

Caps are per-cycle allowances, not absolute budgets: all 196 key caps on PROD are `31d` (130) or
`1mo` (66), and all 38 member caps are `1mo`. A `31d` cycle takes its phase from LiteLLM's
`budget_reset_at` when the durations agree — its reset job recomputes each boundary from the day
it runs, so that date absorbs any lateness — else from the cap row's own `created_at`, rolled
forward to the cycle containing now. `1mo` follows the calendar month, because LiteLLM really
does reset those keys on the 1st and the alert has to predict the enforcement the key is under.

## Other cases worth knowing

| Case | Resolution |
| --- | --- |
| LiteLLM key `spend` counters | Never a numerator — a top-up does not reset them, so they are lifetime totals |
| Subscription cancelled | Subscription rows are deactivated, so the top-up window takes over. Any `consumed_cents` FIFO left on still-valid entries is added back, since the numerator still counts that spend |
| Top-up bought mid-cycle | `period_start` does not move, so `period_key` is stable. The budget rises, the percentage falls, the band walks back silently and `arm_seq` is bumped so a real re-crossing still notifies. Bands are not blanket-reset, so a team still above 50 % is not warned twice |
| Expiring key (`0d`) | Spend still counts towards team and owner; only the key-scope alert is suppressed |
| Team window opens before the sweep floor | Back-filled with a scoped per-team activity call; skipped only if that call fails |
| POOL team with no valid ledger entry | No team budget. A `limited_resources` BUDGET row is a provisioning allowance, not credit (673 such teams) |
| Uncapped key, team has >1 key | Measured against the pool — answers "which key is eating the pool" |
| Uncapped key, team has 1 key | Withheld; arithmetically identical to the team event |
| `max_budget` 0 or null | Skipped — pool-gate-blocked keys would otherwise emit 100 % at creation |
| Idle team whose budget just fell | Found by `denominator_change_candidates`, not by traffic |
| 0 % → 95 % in one tick | One event (90), not three |
| Delivery fails | State unadvanced → retried next tick under the **same** `event_id` |
| Genuine re-crossing after a re-arm | **New** `event_id` via `arm_seq`, so dedup cannot swallow it |

`event_id` is `sha256(subject_key|period_key|band|arm_seq)`, not a uuid: a retry must carry the
id of the attempt it repeats, while a real second crossing of the same band must not.

## Payload

```json
{
  "api_version": "2026-08-01",
  "events": [{
    "event_id": "evt_9f2c…",
    "type": "budget.threshold_reached",
    "created_at": "2026-07-30T10:04:11+00:00",
    "data": {
      "scope": "team",
      "threshold_percent": 90,
      "percent_used": 92.14,
      "spend": 92.14,
      "max_budget": 100.0,
      "budget_source": "team_ledger",
      "currency": "USD",
      "budget_duration": "31d",
      "region": {"id": 6, "name": "amazeeai-us103"},
      "team": {"id": 719, "name": "Acme"},
      "user": null,
      "key": null,
      "period": {"key": "…", "start": "…", "end": "…"}
    }
  }]
}
```

`budget_source` tells the consumer how to word the message: `key_cap` / `litellm_key_budget`
(the key's own limit), `team_pool` (uncapped key measured against the pool), `team_ledger`
(team or member scope). The LiteLLM token is never sent — it is a live credential and `key.id`
identifies the key.

## Anti-drift

`resolve_team_period_window()` moves to `app/core/spend_period_service.py` and `get_team_spend`
now calls it, so the spend API and the alert engine cannot disagree about a period. That step
is behaviour-neutral; existing spend tests pass unchanged.

## Config

| Setting | Default |
| --- | --- |
| `BUDGET_ALERT_ENABLED` | `false` |
| `BUDGET_ALERT_THRESHOLDS` | `50,75,90,100` |
| `BUDGET_ALERT_WEBHOOK_URL` | `""` — full URL, so the route stays MOAD's choice |
| `BUDGET_ALERT_WEBHOOK_TOKEN` | falls back to `MOAD_DASHBOARD_API_TOKEN` |
| `BUDGET_ALERT_BATCH_SIZE` | `200` |
| `BUDGET_ALERT_REGION_CONCURRENCY` | `4` |
| `BUDGET_ALERT_MAX_LOOKBACK_DAYS` | `370` (floor on the one wide request; older windows are back-filled per team) |
| `BUDGET_ALERT_RECHECK_GRACE_HOURS` | `24` |

## Migration

`d1e2f3a4b5c6` adds `budget_alert_state` — **one row per subject**, overwritten in place, so
the table is bounded by subject count rather than growing with events. DEV is still at
`6c201dbaea6e` and the table does not exist yet, so this migration has never run.

## Testing

- 70 tests in `tests/test_budget_alerts.py` plus 3 window tests in
  `tests/test_spend_period_service.py`; full suite 1237 passed / 2 skipped; ruff clean.
- Note: the suite passed *unchanged* before those 3 window tests were added — nothing had been
  pinning the spend API's top-up window, so a customer-visible rule was uncovered by 1231
  tests.
- Comments and docstrings carry no environment specifics (no region names, team ids or key
  counts). The measured figures behind the decisions live in this description and in the
  design notes instead, where they can go stale without misleading anyone reading the code.
- Both numerator paths validated to the cent against the live DEV spend API.
- Sweep cost and the active-entity ratios measured on PROD region 5 (read-only).

## Not done yet

**This has never run end to end.** Every number above is validated against live data, but the
job itself has not executed. Roll out with `BUDGET_ALERT_ENABLED=false`, confirm the logged
percentages against `GET /spend/{region_id}/team/{team_id}`, then set the URL and enable.

Two things worth knowing rather than fixing here:

- **Member alerts will be rare.** PROD has 38 `team_member` spend caps and 54 POOL users with
  a manual USER BUDGET limit, against 1,345 POOL users. No cap means no line to cross.
- **`team`-scope spend caps have no PROD data** (0 rows), so that tightening path is only
  covered by unit tests.

Out of scope: MOAD's consumer endpoint and UI, non-budget COUNT/RPM limits, per-team
thresholds, HMAC signing, a retry outbox, and forecast ("projected to exceed") alerts.

## Follow-ups found while reviewing, deliberately not in this PR

1. **`app/api/spend.py:1334-1357` never rolls its cap anchor**, so for a long-lived team it
   reports a capped key's `period_start` far in the past and a `budget_reset_at` that has
   already passed. The amount is right, the dates are not. Fixing it changes a customer-visible
   number — `current_cycle_start()` is now available to reuse.
2. **104 caps still carry `1mo`/`30d`** (66 key, 38 member) so they reset on the 1st rather than
   from the day they were set. Every `1mo` row stops at 2026-06-15 and every `31d` row starts
   2026-06-17, so it is a clean historical cutover. Migrating them needs no engine change.
3. **Team-cap duration is stored inconsistently**: for a purchase-gated POOL team,
   `app/api/spend.py:1796` stores `"1mo"` while pushing `31d`/`<days-left>d` to LiteLLM. No PROD
   impact today (0 team-scope caps), but the engine reads the stored value.
4. **A top-up does not extend existing credit.** `add_topup_entry` sets the expiry of the new
   entry only, so older credit lapses first — 3 PROD teams hold entries with different expiry
   dates. Reviewed and deliberately left as-is; changing it is a product decision about how long
   credit lives, not an alerting one.

## Behaviour change to the spend API

`GET /spend/{region_id}/team/{team_id}` reports `period_start` earlier, and a higher
`period_spend`, for top-up teams holding more than one still-valid purchase — 3 teams on PROD
(13536, 4863, 7627). That is the correct figure: today those teams are shown a spend number that
omits money they actually spent. `period_end` is unchanged (newest purchase + 365d), and the 215
single-purchase teams see no difference at all.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds periodic budget-threshold monitoring and MOAD event delivery.
- Computes team, key, and member spend against subject-specific budget cycles.
- Uses deterministic event identifiers and persisted arming state for retry-safe delivery and genuine re-crossings.
- Backfills scoped activity for windows older than the regional sweep and discovers historical-only teams from ledger state.
- Adds configuration, scheduling, metrics, audit records, webhook delivery, database state, and coverage for budget-alert behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported retry-identity, re-arming, lookback truncation, backfill suppression, and historical-only discovery issues are addressed in the current implementation.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/core/budget_alert_service.py | Implements regional discovery, cycle-aware spend evaluation, deterministic crossing identity, scoped historical backfill, delivery-state advancement, metrics, and auditing. |
| app/core/spend_period_service.py | Centralizes team period-window and cap-cycle calculations shared by the spend API and alert engine. |
| app/services/budget_alert_webhook.py | Serializes threshold events and delivers bounded batches with all-or-nothing acceptance per HTTP request. |
| app/services/litellm.py | Adds paginated regional activity and team-scoped key/activity reads used by the alert sweep. |
| app/db/models.py | Adds bounded per-subject alert state, including the arming sequence required to distinguish retries from genuine re-crossings. |
| app/migrations/versions/20260729_220000_d1e2f3a4b5c6_add_budget_alert_state.py | Creates the budget alert state table and indexes needed by subject classification. |
| scripts/trigger_budget_alerts_job.py | Adds the lock-guarded scheduled-job entry point for threshold monitoring. |
| tests/test_budget_alerts.py | Covers threshold classification, retry identity, re-arming, historical backfill, delivery handling, and subject-specific budget windows. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Cron
    participant AlertJob
    participant DB
    participant LiteLLM
    participant MOAD

    Cron->>AlertJob: Run every five minutes
    AlertJob->>DB: Acquire budget_alerts lock
    AlertJob->>DB: Resolve regions, budgets, windows, and prior state
    AlertJob->>LiteLLM: Fetch regional daily activity
    opt Window predates regional sweep
        AlertJob->>LiteLLM: Fetch scoped team activity
    end
    AlertJob->>LiteLLM: Fetch active-team key limits
    AlertJob->>AlertJob: Compute highest newly crossed bands
    AlertJob->>DB: Persist silent resets and increment arm sequence
    AlertJob->>MOAD: POST event batches
    MOAD-->>AlertJob: Accept delivered batches
    AlertJob->>DB: Advance only accepted event state and write audit rows
    AlertJob->>DB: Release lock
```
</details>

<sub>Reviews (9): Last reviewed commit: ["fix(budget-alerts): discover teams whose..."](https://github.com/amazeeio/amazee.ai/commit/10fb63231227b9c78309bfe9fd6bc987f4095e17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48594837)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Budgets and Spend Limits](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/budgets-spend.md)
- Knowledge Base — [Database models, session, and migrations](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/database-models.md)
- Knowledge Base — [Private AI Keys and LiteLLM Integration](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/private-ai-keys-litellm.md)
</details>

<!-- /greptile_comment -->