### PR TITLE
fix(vector-db): restrict tenant database connectivity to its owning role

### DIFF
--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -398,7 +398,11 @@ async def _create_private_ai_key(
             if db_info and region:
                 # Delete vector database
                 postgres_manager = PostgresManager(region=region)
-                await postgres_manager.delete_database(db_info.database_name)
+                # Drop the role too — a leftover role keeps valid, unowned
+                # credentials on the shared cluster.
+                await postgres_manager.delete_database(
+                    db_info.database_name, db_info.database_username
+                )
                 logger.info("Cleaned up vector database after failure")
         except Exception as cleanup_error:
             logger.error(

--- a/app/db/postgres.py
+++ b/app/db/postgres.py
@@ -59,6 +59,13 @@ class PostgresManager:
             await conn.execute(
                 f"GRANT ALL PRIVILEGES ON DATABASE {db_name} TO {db_user}"
             )
+            # PostgreSQL grants CONNECT to PUBLIC on every new database, and
+            # every tenant role is a member of PUBLIC — so on a shared cluster
+            # that default lets any tenant role open a session against any
+            # other tenant's database. The GRANT ALL above already gave db_user
+            # its own CONNECT, so revoking PUBLIC leaves exactly one role able
+            # to connect.
+            await conn.execute(f"REVOKE CONNECT ON DATABASE {db_name} FROM PUBLIC")
             logger.info("Database and user created successfully")
 
             # Close the initial connection
@@ -87,6 +94,11 @@ class PostgresManager:
                     f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {db_user}"
                 )
                 await conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
+                # On PostgreSQL < 15 PUBLIC also holds CREATE on the public
+                # schema. db_user owns it (above) and is the only role that
+                # should touch it. No app path connects to a tenant database as
+                # the admin user, so this cannot lock our own tooling out.
+                await conn.execute("REVOKE ALL ON SCHEMA public FROM PUBLIC")
                 logger.info("Schema permissions granted successfully")
             finally:
                 await conn.close()
@@ -100,6 +112,57 @@ class PostgresManager:
         except Exception as e:
             logger.error(f"Error creating database: {str(e)}")
             raise
+        finally:
+            await conn.close()
+
+    async def restrict_connect_to_owner(
+        self, database_name: str, database_username: str
+    ) -> None:
+        """Make *database_name* connectable only by *database_username*.
+
+        Databases provisioned before create_database started revoking it still
+        carry PostgreSQL's default ``CONNECT`` grant to PUBLIC. Grant first,
+        revoke second, so the owning tenant is never locked out even if the run
+        is interrupted.
+        """
+        _validate_identifier(database_name, "database name")
+        _validate_identifier(database_username, "database username")
+
+        conn = await asyncpg.connect(
+            host=self.host,
+            port=self.port,
+            user=self.admin_user,
+            password=self.admin_password,
+        )
+        try:
+            await conn.execute(
+                f"GRANT CONNECT ON DATABASE {database_name} TO {database_username}"
+            )
+            await conn.execute(
+                f"REVOKE CONNECT ON DATABASE {database_name} FROM PUBLIC"
+            )
+        finally:
+            await conn.close()
+
+    async def list_tenant_databases(self) -> list[str]:
+        """Return every ``db_*`` database on the cluster.
+
+        Used by the connect-privilege backfill to spot tenant databases the
+        platform no longer tracks (failed deletes) — those keep PUBLIC
+        connectivity and need an operator decision, so they are reported rather
+        than modified.
+        """
+        conn = await asyncpg.connect(
+            host=self.host,
+            port=self.port,
+            user=self.admin_user,
+            password=self.admin_password,
+        )
+        try:
+            rows = await conn.fetch(
+                "SELECT datname FROM pg_database WHERE datname LIKE 'db\\_%'"
+            )
+            return [row["datname"] for row in rows]
         finally:
             await conn.close()
 

--- a/scripts/lock_vector_db_connect.py
+++ b/scripts/lock_vector_db_connect.py
@@ -62,7 +62,9 @@ def get_vector_dbs_grouped_by_region(session, region_name: str | None):
     for region_id, database_name, database_username in rows:
         keys_by_region[region_id].append((database_name, database_username))
 
-    return [(regions[rid], dbs) for rid, dbs in keys_by_region.items()]
+    # every region, not just ones with tracked keys — a region whose keys were all
+    # deleted without dropping their databases still needs its orphans reported
+    return [(region, keys_by_region.get(rid, [])) for rid, region in regions.items()]
 
 
 async def run(dry_run: bool, region_name: str | None) -> int:

--- a/scripts/lock_vector_db_connect.py
+++ b/scripts/lock_vector_db_connect.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+One-time backfill: revoke PUBLIC CONNECT on existing tenant vector databases.
+
+PostgreSQL grants CONNECT to PUBLIC on every new database, and every tenant role
+is a member of PUBLIC — so on a shared vectordb cluster that default lets any
+tenant role open a session against any other tenant's database.
+`PostgresManager.create_database` now revokes it at provisioning time; this
+script applies the same change to databases created before that.
+
+For each tracked vector DB it runs (in this order, so an interrupted run never
+locks a tenant out of its own database):
+
+    GRANT CONNECT ON DATABASE db_x TO user_x;
+    REVOKE CONNECT ON DATABASE db_x FROM PUBLIC;
+
+Tenant databases present on the cluster but not tracked by the platform (failed
+deletes) are reported, not modified — dropping or locking them is an operator
+decision.
+
+Usage:
+    python scripts/lock_vector_db_connect.py --dry-run
+    python scripts/lock_vector_db_connect.py
+    python scripts/lock_vector_db_connect.py --region eu-central-1
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+from collections import defaultdict
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.db.database import SessionLocal
+from app.db.models import DBPrivateAIKey, DBRegion
+from app.db.postgres import PostgresManager
+
+
+def get_vector_dbs_grouped_by_region(session, region_name: str | None):
+    """Return (region, [(database_name, database_username), ...]) pairs."""
+    regions = {
+        r.id: r
+        for r in session.query(DBRegion)
+        .filter(DBRegion.postgres_host.isnot(None))
+        .all()
+        if region_name is None or r.name == region_name
+    }
+
+    keys_by_region = defaultdict(list)
+    rows = (
+        session.query(
+            DBPrivateAIKey.region_id,
+            DBPrivateAIKey.database_name,
+            DBPrivateAIKey.database_username,
+        )
+        .filter(DBPrivateAIKey.database_name.isnot(None))
+        .filter(DBPrivateAIKey.database_username.isnot(None))
+        .filter(DBPrivateAIKey.region_id.in_(regions.keys()))
+        .all()
+    )
+    for region_id, database_name, database_username in rows:
+        keys_by_region[region_id].append((database_name, database_username))
+
+    return [(regions[rid], dbs) for rid, dbs in keys_by_region.items()]
+
+
+async def run(dry_run: bool, region_name: str | None) -> int:
+    session = SessionLocal()
+    try:
+        work = get_vector_dbs_grouped_by_region(session, region_name)
+    finally:
+        session.close()
+
+    total_locked = 0
+    total_failed = 0
+    total_untracked = 0
+
+    for region, databases in work:
+        manager = PostgresManager(region=region)
+        tracked = {name for name, _ in databases}
+
+        try:
+            on_cluster = set(await manager.list_tenant_databases())
+        except Exception as e:
+            print(f"[FAIL] region={region.name} could not list databases: {e}")
+            total_failed += 1
+            continue
+
+        untracked = sorted(on_cluster - tracked)
+        if untracked:
+            total_untracked += len(untracked)
+            print(
+                f"[WARN] region={region.name} {len(untracked)} untracked tenant "
+                f"database(s) still allow PUBLIC CONNECT (not modified): "
+                f"{', '.join(untracked)}"
+            )
+
+        for database_name, database_username in sorted(databases):
+            if database_name not in on_cluster:
+                print(f"[SKIP] region={region.name} db={database_name} not on cluster")
+                continue
+            if dry_run:
+                print(
+                    f"[DRY-RUN] region={region.name} db={database_name} -> "
+                    f"CONNECT only for {database_username}"
+                )
+                continue
+            try:
+                await manager.restrict_connect_to_owner(
+                    database_name, database_username
+                )
+                total_locked += 1
+                print(f"[OK] region={region.name} db={database_name}")
+            except Exception as e:
+                total_failed += 1
+                print(f"[FAIL] region={region.name} db={database_name} error={e}")
+
+    print(
+        f"Done. locked={total_locked} failed={total_failed} "
+        f"untracked={total_untracked} dry_run={dry_run}"
+    )
+    return 0 if total_failed == 0 else 1
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Revoke PUBLIC CONNECT on existing tenant vector databases"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print planned changes without applying them",
+    )
+    parser.add_argument(
+        "--region",
+        default=None,
+        help="Only process this region name (default: all regions)",
+    )
+    args = parser.parse_args()
+    raise SystemExit(asyncio.run(run(args.dry_run, args.region)))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_postgres_manager.py
+++ b/tests/test_postgres_manager.py
@@ -1,5 +1,8 @@
 """Tenant isolation guarantees of vector-DB provisioning."""
 
+import os
+import sys
+
 import pytest
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -74,3 +77,23 @@ async def test_restrict_connect_to_owner_rejects_bad_identifiers(
                 database_name, database_username
             )
     mock_connect.assert_not_called()
+
+
+def test_backfill_includes_regions_with_no_tracked_keys():
+    """A region whose key rows were deleted without dropping their databases
+    must still be visited, or its orphans are never reported."""
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+    from scripts.lock_vector_db_connect import get_vector_dbs_grouped_by_region
+
+    tracked, orphan_only = Mock(spec=DBRegion), Mock(spec=DBRegion)
+    tracked.id, orphan_only.id = 1, 2
+    session = Mock()
+    query = session.query.return_value
+    query.filter.return_value.all.return_value = [tracked, orphan_only]
+    query.filter.return_value.filter.return_value.filter.return_value.all.return_value = [
+        (1, "db_abc123", "user_abc123")
+    ]
+
+    work = dict(get_vector_dbs_grouped_by_region(session, None))
+    assert work[tracked] == [("db_abc123", "user_abc123")]
+    assert work[orphan_only] == []

--- a/tests/test_postgres_manager.py
+++ b/tests/test_postgres_manager.py
@@ -1,0 +1,76 @@
+"""Tenant isolation guarantees of vector-DB provisioning."""
+
+import pytest
+from unittest.mock import AsyncMock, Mock, patch
+
+from app.db.models import DBRegion
+from app.db.postgres import PostgresManager
+
+
+@pytest.fixture
+def region():
+    region = Mock(spec=DBRegion)
+    region.postgres_host = "vectordb1.test"
+    region.postgres_port = 5432
+    region.postgres_admin_user = "admin"
+    region.postgres_admin_password = "adminpw"
+    return region
+
+
+@pytest.mark.asyncio
+async def test_create_database_revokes_public_connect(region):
+    """A new tenant database must be connectable only by its own role.
+
+    Without the REVOKE, PostgreSQL's default PUBLIC CONNECT grant lets any
+    tenant role on the shared cluster open a session against any other tenant's
+    database using only its own password.
+    """
+    conn = AsyncMock()
+    with patch("asyncpg.connect", AsyncMock(return_value=conn)):
+        result = await PostgresManager(region=region).create_database()
+
+    statements = [call.args[0] for call in conn.execute.call_args_list]
+    db_name = result["database_name"]
+    db_user = result["database_username"]
+
+    assert f"REVOKE CONNECT ON DATABASE {db_name} FROM PUBLIC" in statements
+    assert "REVOKE ALL ON SCHEMA public FROM PUBLIC" in statements
+    # The owning role keeps its own CONNECT (granted with ALL PRIVILEGES), and
+    # gets it before PUBLIC loses it.
+    grant = statements.index(f"GRANT ALL PRIVILEGES ON DATABASE {db_name} TO {db_user}")
+    revoke = statements.index(f"REVOKE CONNECT ON DATABASE {db_name} FROM PUBLIC")
+    assert grant < revoke
+
+
+@pytest.mark.asyncio
+async def test_restrict_connect_to_owner_grants_before_revoking(region):
+    """Backfill order matters: an interrupted run must not lock the tenant out."""
+    conn = AsyncMock()
+    with patch("asyncpg.connect", AsyncMock(return_value=conn)):
+        await PostgresManager(region=region).restrict_connect_to_owner(
+            "db_abc123", "user_abc123"
+        )
+
+    assert [call.args[0] for call in conn.execute.call_args_list] == [
+        "GRANT CONNECT ON DATABASE db_abc123 TO user_abc123",
+        "REVOKE CONNECT ON DATABASE db_abc123 FROM PUBLIC",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "database_name,database_username",
+    [
+        ("db_ok; DROP DATABASE db_other", "user_ok"),
+        ("db_ok", 'user_ok"; DROP ROLE x'),
+    ],
+)
+async def test_restrict_connect_to_owner_rejects_bad_identifiers(
+    region, database_name, database_username
+):
+    with patch("asyncpg.connect", AsyncMock()) as mock_connect:
+        with pytest.raises(ValueError):
+            await PostgresManager(region=region).restrict_connect_to_owner(
+                database_name, database_username
+            )
+    mock_connect.assert_not_called()

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -2738,8 +2738,9 @@ def test_create_private_ai_key_cleanup_on_db_storage_failure(
     assert cleanup_call[0][0] == f"{test_region.litellm_api_url}/key/delete"
     assert cleanup_call[1]["json"]["keys"] == ["test-private-key-123"]
 
-    # Verify vector database was cleaned up
-    mock_delete_db.assert_called_once_with("test_db_123")
+    # Verify vector database AND its role were cleaned up — a leftover role
+    # keeps valid credentials on the shared cluster.
+    mock_delete_db.assert_called_once_with("test_db_123", "test_user")
 
     # Verify no key was stored in the database
     stored_keys = client.get(


### PR DESCRIPTION
## What

Each private AI key gets its own database and role on the region's shared PostgreSQL cluster, but `CREATE DATABASE` grants `CONNECT` to `PUBLIC` and every tenant role is a member of `PUBLIC`. The per-tenant database boundary was therefore never actually enforced: any tenant credential could open a session against any other tenant's database on the same cluster.

Provisioning now revokes that default grant:

```sql
GRANT ALL PRIVILEGES ON DATABASE db_x TO user_x;   -- already includes CONNECT
REVOKE CONNECT ON DATABASE db_x FROM PUBLIC;       -- leaves user_x as the only one
REVOKE ALL ON SCHEMA public FROM PUBLIC;           -- (inside db_x) matters on pre-PG15
```

No application path connects to a tenant database as the region admin user, so revoking `PUBLIC` on the schema cannot lock our own tooling out.

Also drops the tenant role in the create-failure cleanup path, which was dropping the database only and leaving valid unowned credentials on the cluster.

## Verification

Ran the real provisioning statements against `pgvector:pg16` before and after:

| check | before | after |
| --- | --- | --- |
| `user_a` → `db_b` | connects as `user_a` | `FATAL: permission denied for database "db_b"` / `User does not have CONNECT privilege` |
| `user_b` → `db_a` | connects as `user_b` | same denial |
| own DB read/write | ok | ok |
| `CREATE EXTENSION vector`, hnsw index, knn query | ok | ok |
| admin `DROP DATABASE` | ok | ok |

Unit coverage in `tests/test_postgres_manager.py`: the revoke is issued, it comes *after* the owning role's grant, and identifier validation rejects unsafe names. Full backend suite passes.

## Rollout

Existing databases were created before this change and still carry the `PUBLIC` grant. Backfill after deploy:

```bash
python scripts/lock_vector_db_connect.py --dry-run
python scripts/lock_vector_db_connect.py
```

It grants before it revokes, so an interrupted run cannot lock a tenant out, and it reports (does not modify) `db_*` databases the platform no longer tracks — leftovers from failed deletes that need an operator decision.

## Follow-ups outside this repo

- vectordb clusters accept connections from the public internet on 5432 — private networking / SG allowlist would remove the surface in front of these checks
- tenant roles can still read `pg_database` / `pg_roles`
- the cluster's maintenance database keeps its default `PUBLIC` `CONNECT` (revoking needs an explicit grant to the admin user first, so it's an operator call)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR strengthens tenant isolation for shared PostgreSQL vector databases.
- Revokes default `PUBLIC` database and schema privileges during provisioning.
- Adds a backfill that restricts existing tracked databases and reports orphaned databases across every PostgreSQL-backed region.
- Removes tenant roles when private-key creation cleanup drops a newly provisioned database.
- Adds coverage for privilege ordering, identifier validation, cleanup, and orphan-only regions.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported orphan-only-region omission is fixed by returning every PostgreSQL-backed region even when it has no tracked key rows.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/db/postgres.py | Adds provisioning and backfill operations that retain owner connectivity while removing default PUBLIC access. |
| scripts/lock_vector_db_connect.py | Adds an operational backfill that visits every PostgreSQL-backed region, secures tracked databases, and reports untracked databases. |
| app/api/private_ai_keys.py | Extends failed private-key provisioning cleanup to remove both the vector database and its tenant role. |
| tests/test_postgres_manager.py | Covers privilege ordering, identifier rejection, and inclusion of regions without tracked keys. |
| tests/test_private_ai.py | Updates cleanup coverage to require removal of the provisioned tenant role. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Operator
    participant Backfill
    participant AppDB as Application DB
    participant Cluster as Regional PostgreSQL
    Operator->>Backfill: Run lock_vector_db_connect.py
    Backfill->>AppDB: Load every PostgreSQL-backed region and tracked tenant DB
    Backfill->>Cluster: "List db_* databases"
    loop Each tracked database
        Backfill->>Cluster: GRANT CONNECT to owning role
        Backfill->>Cluster: REVOKE CONNECT from PUBLIC
    end
    Backfill-->>Operator: Warn about untracked orphan databases
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(vector-db): backfill regions with no..."](https://github.com/amazeeio/amazee.ai/commit/cd0bc1baec421b10625b9ac2e2891319bc5ed4d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48980574)</sub>

**Context used:**

- Knowledge Base — [Private AI Keys and LiteLLM Integration](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/private-ai-keys-litellm.md)
- Knowledge Base — [Database models, session, and migrations](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/database-models.md)

<!-- /greptile_comment -->