### PR TITLE
fix(trial): scope anonymous-trial LiteLLM keys to inference routes

### DIFF
--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -46,6 +46,7 @@ from app.core.limit_service import (
     DEFAULT_RPM_PER_KEY,
 )
 from app.core.pool_budget_service import pool_team_has_ever_purchased
+from app.core.team_service import is_ai_trial_team
 
 router = APIRouter(tags=["private-ai-keys"])
 
@@ -54,19 +55,6 @@ logger = logging.getLogger(__name__)
 
 # Fake ID for resources not stored in the database
 FAKE_ID = -1
-
-
-def is_ai_trial_team(team: DBTeam | None) -> bool:
-    """True for the single team that pools all anonymous trial users.
-
-    Unlike a customer team, its members are unrelated to each other, so keys
-    minted in it must stay private from the rest of the team.
-    """
-    if team is None or not team.admin_email:
-        return False
-    return normalize_email_for_lookup(team.admin_email) == normalize_email_for_lookup(
-        settings.AI_TRIAL_TEAM_EMAIL
-    )
 
 
 def _validate_permissions_and_get_ownership_info(

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -28,7 +28,7 @@ from app.db.models import (
     DBSpendCap,
 )
 from app.core.email import normalize_email_for_lookup
-from app.services.litellm import LiteLLMService
+from app.services.litellm import INFERENCE_ONLY_ROUTES, LiteLLMService
 from app.core.security import (
     get_current_user_from_auth,
     get_role_min_team_admin,
@@ -54,6 +54,19 @@ logger = logging.getLogger(__name__)
 
 # Fake ID for resources not stored in the database
 FAKE_ID = -1
+
+
+def is_ai_trial_team(team: DBTeam | None) -> bool:
+    """True for the single team that pools all anonymous trial users.
+
+    Unlike a customer team, its members are unrelated to each other, so keys
+    minted in it must stay private from the rest of the team.
+    """
+    if team is None or not team.admin_email:
+        return False
+    return normalize_email_for_lookup(team.admin_email) == normalize_email_for_lookup(
+        settings.AI_TRIAL_TEAM_EMAIL
+    )
 
 
 def _validate_permissions_and_get_ownership_info(
@@ -522,6 +535,14 @@ async def create_llm_token(
             db, effective_team.id, region.id
         )
 
+    # Every anonymous trial lands in ONE shared team (so the keys stay
+    # trackable), and LiteLLM lets any key in a team read that team —
+    # /team/info returns every sibling key with its owner, spend and budget.
+    # Trial keys therefore get LiteLLM's inference-only route group: LLM calls
+    # work, every management route returns 403. Members of a real (customer)
+    # team are colleagues, so this scoping is deliberately trial-only.
+    allowed_routes = INFERENCE_ONLY_ROUTES if is_ai_trial_team(effective_team) else None
+
     if (owner is not None and owner.team_id) or team_id:
         if settings.ENABLE_LIMITS and not is_pool_team:
             limit_service.check_key_limits(owner.team_id or team_id, owner_id)
@@ -582,6 +603,7 @@ async def create_llm_token(
             rpm_limit=max_rpm_limit,
             apply_limits=not is_pool_team,
             blocked=(True if is_pool_team and not has_pool_purchase else None),
+            allowed_routes=allowed_routes,
         )
         if is_pool_team and not has_pool_purchase:
             await litellm_service.update_key_budget(

--- a/app/core/team_service.py
+++ b/app/core/team_service.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from datetime import UTC, datetime
 from typing import Dict, List, Optional
 
+from app.core.config import settings
 from app.core.limit_service import DEFAULT_KEY_DURATION
 from app.db.models import (
     DBAuditLog,
@@ -21,6 +22,21 @@ from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
+
+
+def is_ai_trial_team(team: Optional[DBTeam]) -> bool:
+    """True for the single team that pools all anonymous trial users.
+
+    Unlike a customer team, its members are unrelated to each other, so keys
+    minted in it must stay private from the rest of the team.
+
+    Compared case-insensitively but WITHOUT plus-tag stripping, matching how
+    the trial team is looked up and created in `generate_trial_access` — a
+    plus-tagged address is a different team, not the trial team.
+    """
+    if team is None or not team.admin_email:
+        return False
+    return team.admin_email.lower() == settings.AI_TRIAL_TEAM_EMAIL.lower()
 
 
 def get_team_region_litellm_keys(

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -14,6 +14,15 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+# LiteLLM treats a key's team_id as team membership, so any team key can read
+# the whole team via management routes (/team/info returns every sibling key's
+# owner, spend and budget). `llm_api_routes` is LiteLLM's route
+# group for inference only — /chat/completions, /embeddings, /responses,
+# /v1/messages, /models, pass-through providers — and excludes /team/*, /key/*,
+# /user/* and /spend/*. Used for keys that must stay private from their own
+# team, i.e. the shared anonymous-trial team.
+INFERENCE_ONLY_ROUTES = ["llm_api_routes"]
+
 
 class LiteLLMService:
     def __init__(self, api_url: str, api_key: str):
@@ -124,8 +133,15 @@ class LiteLLMService:
         rpm_limit: Optional[int] = DEFAULT_RPM_PER_KEY,
         apply_limits: bool = True,
         blocked: Optional[bool] = None,
+        allowed_routes: Optional[list[str]] = None,
     ) -> str:
-        """Create a new API key for LiteLLM"""
+        """Create a new API key for LiteLLM
+
+        Args:
+            allowed_routes: Restrict the key to these LiteLLM routes (exact
+                paths, wildcards or route-group names such as
+                ``llm_api_routes``). None means no route restriction.
+        """
         try:
             logger.info(
                 f"Creating new LiteLLM API key for email: {email}, name: {name}, user_id: {user_id}, team_id: {team_id}"
@@ -161,6 +177,8 @@ class LiteLLMService:
             request_data["team_id"] = team_id
             if blocked is not None:
                 request_data["blocked"] = blocked
+            if allowed_routes:
+                request_data["allowed_routes"] = allowed_routes
 
             request_data["duration"] = "365d"  # Sets the key expiry date
             if settings.ENABLE_LIMITS and apply_limits:
@@ -607,6 +625,25 @@ class LiteLLMService:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Failed to set LiteLLM key restrictions: {error_msg}",
+            )
+
+    async def set_key_allowed_routes(
+        self, litellm_token: str, allowed_routes: list[str]
+    ) -> None:
+        """Scope an existing key to *allowed_routes* (used by the backfill)."""
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    f"{self.api_url}/key/update",
+                    headers={"Authorization": f"Bearer {self.master_key}"},
+                    json={"key": litellm_token, "allowed_routes": allowed_routes},
+                )
+                response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            _, error_msg, _ = self._parse_http_error(e)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to set LiteLLM key allowed_routes: {error_msg}",
             )
 
     async def update_key_team_association(self, litellm_token: str, new_team_id: str):

--- a/scripts/restrict_trial_key_routes.py
+++ b/scripts/restrict_trial_key_routes.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+One-time backfill: scope existing anonymous-trial keys to inference routes.
+
+All anonymous trials share one team so their keys stay trackable, but LiteLLM
+treats a key's team_id as team membership: a trial key can call
+`/team/info?team_id=<shared team>` and read every sibling trial's owner, spend
+and budget metadata. New keys are created with `allowed_routes` (see
+`create_llm_token`); this script applies the same scoping to keys minted before
+that.
+
+Usage:
+    python scripts/restrict_trial_key_routes.py --dry-run
+    python scripts/restrict_trial_key_routes.py
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+from collections import defaultdict
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.api.private_ai_keys import is_ai_trial_team
+from app.db.database import SessionLocal
+from app.db.models import DBPrivateAIKey, DBRegion, DBTeam, DBUser
+from app.services.litellm import INFERENCE_ONLY_ROUTES, LiteLLMService
+
+
+def get_trial_keys_grouped_by_region(session):
+    """Return trial-team LiteLLM keys grouped by region_id."""
+    trial_team_ids = [
+        team.id for team in session.query(DBTeam).all() if is_ai_trial_team(team)
+    ]
+    if not trial_team_ids:
+        return defaultdict(list)
+
+    keys = (
+        session.query(DBPrivateAIKey)
+        .outerjoin(DBUser, DBUser.id == DBPrivateAIKey.owner_id)
+        .filter(DBPrivateAIKey.litellm_token.isnot(None))
+        .filter(DBPrivateAIKey.region_id.isnot(None))
+        .filter(
+            (DBPrivateAIKey.team_id.in_(trial_team_ids))
+            | (DBUser.team_id.in_(trial_team_ids))
+        )
+        .all()
+    )
+
+    keys_by_region = defaultdict(list)
+    for key in keys:
+        keys_by_region[key.region_id].append(key)
+    return keys_by_region
+
+
+async def run(dry_run: bool) -> int:
+    session = SessionLocal()
+    try:
+        regions = {r.id: r for r in session.query(DBRegion).all()}
+        keys_by_region = get_trial_keys_grouped_by_region(session)
+
+        total_updated = 0
+        total_failed = 0
+
+        for region_id, keys in keys_by_region.items():
+            region = regions.get(region_id)
+            if region is None:
+                continue
+
+            service = LiteLLMService(
+                api_url=region.litellm_api_url,
+                api_key=region.litellm_api_key,
+            )
+            for key in keys:
+                if dry_run:
+                    print(
+                        f"[DRY-RUN] key_id={key.id} region={region.name} -> "
+                        f"allowed_routes={INFERENCE_ONLY_ROUTES}"
+                    )
+                    continue
+                try:
+                    await service.set_key_allowed_routes(
+                        litellm_token=key.litellm_token,
+                        allowed_routes=INFERENCE_ONLY_ROUTES,
+                    )
+                    total_updated += 1
+                    print(f"[OK] key_id={key.id} region={region.name}")
+                except Exception as e:
+                    total_failed += 1
+                    print(f"[FAIL] key_id={key.id} region={region.name} error={e}")
+
+        print(f"Done. updated={total_updated} failed={total_failed} dry_run={dry_run}")
+        return 0 if total_failed == 0 else 1
+    finally:
+        session.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Restrict existing anonymous-trial LiteLLM keys to inference routes"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print planned updates without applying them",
+    )
+    args = parser.parse_args()
+    raise SystemExit(asyncio.run(run(args.dry_run)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/restrict_trial_key_routes.py
+++ b/scripts/restrict_trial_key_routes.py
@@ -22,7 +22,7 @@ from collections import defaultdict
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from app.api.private_ai_keys import is_ai_trial_team
+from app.core.team_service import is_ai_trial_team
 from app.db.database import SessionLocal
 from app.db.models import DBPrivateAIKey, DBRegion, DBTeam, DBUser
 from app.services.litellm import INFERENCE_ONLY_ROUTES, LiteLLMService

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -1,4 +1,7 @@
 from unittest.mock import patch, Mock, AsyncMock
+
+import pytest
+
 from app.db.models import (
     DBPrivateAIKey,
     DBPeriodicBudgetLedgerEntry,
@@ -1769,17 +1772,31 @@ def test_create_llm_token_for_trial_team_is_inference_only(
     assert payload["allowed_routes"] == ["llm_api_routes"]
 
 
+@pytest.mark.parametrize(
+    "admin_email",
+    [
+        "customer-team-admin@example.com",
+        # A plus-tag of the trial address is a DIFFERENT team (that's how the
+        # trial team is looked up), so it must not inherit the restriction.
+        settings.AI_TRIAL_TEAM_EMAIL.replace("@", "+customer@"),
+    ],
+)
 @patch("httpx.AsyncClient")
 def test_create_llm_token_for_customer_team_is_unrestricted(
     mock_client_class,
+    admin_email,
     client,
     admin_token,
     test_region,
+    db,
     test_team,
     mock_httpx_post_client,
 ):
     """Members of a real team are colleagues — the trial restriction must not
     leak into normal team keys."""
+    test_team.admin_email = admin_email
+    db.commit()
+
     mock_client_class.return_value = mock_httpx_post_client
 
     response = client.post(

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -13,6 +13,7 @@ from datetime import datetime, UTC
 from app.core.security import get_password_hash
 from httpx import HTTPStatusError
 from fastapi import status, HTTPException
+from app.core.config import settings
 from app.core.limit_service import (
     DEFAULT_MAX_SPEND,
     DEFAULT_RPM_PER_KEY,
@@ -1719,6 +1720,81 @@ def test_create_llm_token_for_non_gated_pool_team_is_never_blocked(
     ]
     assert len(key_generate_calls) == 1
     assert "blocked" not in key_generate_calls[0].kwargs["json"]
+
+
+def _key_generate_payload(mock_client, key_name):
+    calls = [
+        call
+        for call in mock_client.post.call_args_list
+        if str(call.args[0]).endswith("/key/generate")
+        and call.kwargs.get("json", {})
+        .get("metadata", {})
+        .get("amazeeai_private_ai_key_name")
+        == key_name
+    ]
+    assert len(calls) == 1
+    return calls[0].kwargs["json"]
+
+
+@patch("httpx.AsyncClient")
+def test_create_llm_token_for_trial_team_is_inference_only(
+    mock_client_class,
+    client,
+    admin_token,
+    test_region,
+    db,
+    test_team,
+    mock_httpx_post_client,
+):
+    """All anonymous trials share one team, and LiteLLM lets any key in a team
+    read that team (/team/info exposes every sibling key's owner, spend and
+    budget). Trial keys must therefore be scoped to inference routes."""
+    test_team.admin_email = settings.AI_TRIAL_TEAM_EMAIL
+    db.commit()
+
+    mock_client_class.return_value = mock_httpx_post_client
+
+    response = client.post(
+        "/private-ai-keys/token",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "region_id": test_region.id,
+            "name": "Trial Key",
+            "team_id": test_team.id,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = _key_generate_payload(mock_httpx_post_client, "Trial Key")
+    assert payload["allowed_routes"] == ["llm_api_routes"]
+
+
+@patch("httpx.AsyncClient")
+def test_create_llm_token_for_customer_team_is_unrestricted(
+    mock_client_class,
+    client,
+    admin_token,
+    test_region,
+    test_team,
+    mock_httpx_post_client,
+):
+    """Members of a real team are colleagues — the trial restriction must not
+    leak into normal team keys."""
+    mock_client_class.return_value = mock_httpx_post_client
+
+    response = client.post(
+        "/private-ai-keys/token",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "region_id": test_region.id,
+            "name": "Customer Key",
+            "team_id": test_team.id,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = _key_generate_payload(mock_httpx_post_client, "Customer Key")
+    assert "allowed_routes" not in payload
 
 
 def test_create_vector_db_as_system_admin(client, admin_token, test_region):

--- a/tests/test_trial_access.py
+++ b/tests/test_trial_access.py
@@ -226,3 +226,46 @@ async def test_generate_trial_access_cleanup_on_key_creation_failure(
     assert exc_info.value.status_code == expected_status
 
     assert mock_db.delete.call_count >= 1
+
+
+@patch("app.db.postgres.PostgresManager.create_database")
+@patch("httpx.AsyncClient")
+def test_trial_key_cannot_read_its_own_litellm_team(
+    mock_client_class, mock_create_db, client, db, test_region
+):
+    """Full provisioning path.
+
+    Every anonymous trial shares one team, and LiteLLM treats a key's team_id as
+    team membership — so an unscoped trial key can GET /team/info and read every
+    other trial's owner, spend and budget. The trial key must therefore be minted
+    with LiteLLM's inference-only route group.
+    """
+    mock_create_db.return_value = {
+        "database_name": "db_trial",
+        "database_host": "pghost",
+        "database_username": "user_trial",
+        "database_password": "pw",
+    }
+
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"key": "sk-trial-test-key"}
+    mock_response.raise_for_status.return_value = None
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+    mock_client_class.return_value = mock_client
+
+    with patch("app.core.config.settings.AI_TRIAL_REGION", test_region.name):
+        response = client.post("/auth/generate-trial-access", json={})
+
+    assert response.status_code == 200, response.text
+
+    key_generate_calls = [
+        call
+        for call in mock_client.post.call_args_list
+        if str(call.args[0]).endswith("/key/generate")
+    ]
+    assert len(key_generate_calls) == 1
+    assert key_generate_calls[0].kwargs["json"]["allowed_routes"] == ["llm_api_routes"]


### PR DESCRIPTION
## What

All anonymous trials deliberately live in one shared team so their keys stay trackable in one place. LiteLLM, however, treats a key's `team_id` as team membership — so any key in that team can call `GET /team/info?team_id=<shared team>` and get the full team object plus a `keys[]` array containing every sibling trial's owner id, `service_account_id`, spend, budget, budget period and expiry. That is reasonable for a team of colleagues; it is not what we want for a pool of unrelated trial users.

Trial-team keys are now minted with LiteLLM's `llm_api_routes` route group via `allowed_routes`:

- **allowed** — `/chat/completions`, `/embeddings`, `/responses`, `/v1/messages`, `/models`, `/v1/models`, rerank, audio, images, batches, provider pass-throughs (179 routes)
- **403** — `/team/*`, `/key/*`, `/user/*`, `/spend/*`

Scoped to the trial team only, via `is_ai_trial_team()` in `app/core/team_service.py` — an exact, case-insensitive `AI_TRIAL_TEAM_EMAIL` match, the same identity rule `generate_trial_access` uses to look up and create that team. A plus-tagged variant is a different team and keeps normal LiteLLM behaviour, as do all customer teams (they're colleagues).

## Verification

Against a live LiteLLM (1.89.2), with a key created exactly the way we create them:

| request | unscoped key | scoped key |
| --- | --- | --- |
| `GET /team/info?team_id=<team>` | 200, full `keys[]` for the team | 403 |
| `GET /key/info`, `/key/list`, `/user/info`, `/spend/logs` | 200 | 403 |
| `POST /v1/chat/completions`, `/v1/embeddings`, `/v1/messages`, `/v1/responses` | auth ok | auth ok |
| `GET /v1/models` | 200 | 200 |

Also confirmed the scoping survives our other `/key/update` calls (budget reset via `set_key_restrictions`, `update_key_team_association`) — budgets and limits update while `allowed_routes` stays in place, so it can't silently decay.

Tests: `tests/test_trial_access.py` covers the full `/auth/generate-trial-access` provisioning path (asserts the `/key/generate` payload), and `tests/test_private_ai.py` covers trial-team vs customer-team key creation. Both fail if the argument is dropped. Full backend suite passes.

## Rollout

Backfill the keys minted before this change:

```bash
python scripts/restrict_trial_key_routes.py --dry-run
python scripts/restrict_trial_key_routes.py
```

Requires a LiteLLM version with key-level `allowed_routes` (confirmed fine for our fleet).

## Note

`/model/info` is not part of `llm_api_routes`. `/v1/models` is, and that's what OpenAI-compatible clients use — but if a trial client needs `/model/info`, add the exact path alongside the group rather than dropping the scoping.

## Not changed

The amazee.ai API side already holds: a trial user's own JWT has `role: user`, and `GET /teams/{id}`, `GET /users` and the team spend endpoints all require team admin or higher, while `GET /private-ai-keys` returns only the caller's own keys plus team-owned (`owner_id IS NULL`) ones.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents anonymous-trial LiteLLM keys from accessing shared-team management data.
- Identifies the shared trial team using an exact, case-insensitive admin-email comparison without plus-tag normalization.
- Restricts newly provisioned trial keys to LiteLLM's inference-only route group while leaving customer-team keys unrestricted.
- Adds a backfill script to apply the same route restriction to existing trial keys.
- Adds provisioning-path and customer-team regression coverage.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the earlier plus-tag misclassification is fixed by exact case-insensitive matching consistent with the trial-team lookup path.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/private_ai_keys.py | Applies inference-only LiteLLM routes when provisioning a key associated with the shared anonymous-trial team. |
| app/core/team_service.py | Centralizes trial-team identification using the same case-insensitive exact-email semantics as trial provisioning. |
| app/services/litellm.py | Adds optional allowed-route payload support for key creation and a focused method for updating existing keys. |
| scripts/restrict_trial_key_routes.py | Backfills inference-only route restrictions onto existing user-owned and team-owned trial keys by region. |
| tests/test_private_ai.py | Verifies trial keys are restricted while ordinary and plus-tagged customer teams remain unrestricted. |
| tests/test_trial_access.py | Verifies the full anonymous-trial provisioning flow sends the inference-only route group to LiteLLM. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Create or backfill private AI key] --> B{Team admin email exactly matches trial email, ignoring case?}
    B -->|Yes| C[Set allowed_routes to llm_api_routes]
    B -->|No| D[Preserve normal LiteLLM route access]
    C --> E[Inference routes remain available]
    C --> F[Team, key, user, and spend management routes return 403]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(trial): match trial team on exact em..."](https://github.com/amazeeio/amazee.ai/commit/7eb6f6813f09af7cba595f95f675fa22c9b5a338) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48980628)</sub>

**Context used:**

- Knowledge Base — [Private AI Keys and LiteLLM Integration](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/private-ai-keys-litellm.md)
- Knowledge Base — [Teams and Users](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/teams-users.md)

<!-- /greptile_comment -->