### PR TITLE
fix(migrations): rebase budget_alert_state onto the audit-log-indexes head

### DIFF
--- a/app/api/users.py
+++ b/app/api/users.py
@@ -759,9 +759,7 @@ async def list_users(
         )
 
     if search:
-        escaped = (
-            search.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-        )
+        escaped = search.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
         query = query.filter(DBUser.email.ilike(f"%{escaped}%", escape="\\"))
     if team:
         escaped = team.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")

--- a/app/migrations/versions/20260729_220000_d1e2f3a4b5c6_add_budget_alert_state.py
+++ b/app/migrations/versions/20260729_220000_d1e2f3a4b5c6_add_budget_alert_state.py
@@ -1,7 +1,7 @@
 """add budget_alert_state table for budget threshold alerts
 
 Revision ID: d1e2f3a4b5c6
-Revises: 6c201dbaea6e
+Revises: e5b8c7d2a941
 Create Date: 2026-07-29 22:00:00.000000+00:00
 
 """
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic (read via module reflection).
 revision: str = "d1e2f3a4b5c6"
-down_revision: Union[str, None] = "6c201dbaea6e"
+down_revision: Union[str, None] = "e5b8c7d2a941"
 
 
 def upgrade() -> None:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -500,7 +500,10 @@ def test_sign_in_reuses_orphaned_team_with_plus_tagged_admin_email(
         mock_sync_litellm.return_value = AsyncMock()
         response = client.post(
             "/auth/sign-in",
-            json={"username": "tagged_orphan+p12@example.com", "verification_code": code},
+            json={
+                "username": "tagged_orphan+p12@example.com",
+                "verification_code": code,
+            },
         )
 
     assert response.status_code == 200


### PR DESCRIPTION
## Problem

The `dev` deploy after merging #649 failed at init:

```
Error during initialization: Multiple head revisions are present for given
argument 'head'; please specify a specific target revision, '<branchname>@head'
to narrow to a specific head, or 'heads' for all heads
```

Build: [lagoon-build-rl9isx](https://dashboard.amazeeio.cloud/projects/amazeeai/amazeeai-dev/deployments/lagoon-build-rl9isx)

Two migrations both declared `down_revision = "6c201dbaea6e"`:

| Revision | From | File |
| --- | --- | --- |
| `e5b8c7d2a941` | #642 admin-pages-pagination | `20260728_120000_..._add_audit_log_indexes.py` |
| `d1e2f3a4b5c6` | #649 AI-448 budget alerts | `20260729_220000_..._add_budget_alert_state.py` |

Each branch had exactly one head on its own, so `test_single_alembic_head`
passed in both PRs. The fork only existed once both were merged.

## Fix

Re-point `d1e2f3a4b5c6` at `e5b8c7d2a941`, giving one linear chain:

```
6c201dbaea6e -> e5b8c7d2a941 -> d1e2f3a4b5c6
```

No merge revision, because `test_migration_history_is_linear` (added in
b4ba1c4d) rejects merges as well as forks.

## Why this order

`dev` has already applied `e5b8c7d2a941` — #642 merged at 08:47 UTC and its
deploy (`lagoon-build-y2c57p`) completed at 08:49, before #649 merged at
12:20. Putting the already-applied revision first means the chain moves
forward only. Nothing needs a downgrade on `dev`, and `prod` (promoted from
`dev`) applies both in order.

The two migrations touch unrelated objects — audit-log indexes vs. the new
`budget_alert_state` table — so the reordering has no behavioural effect.

## Tests

`make backend-test-regex regex="test_migrations"` — 2 passed.
Only a `down_revision` changed; the revision ids appear nowhere outside
`app/migrations/versions/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tUbktH6g3zEGPT3a8Ka2H

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restores a single linear Alembic migration history.
- Reparents the budget-alert-state migration onto the audit-log-indexes revision.
- Applies formatting-only changes in the users API and authentication tests.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the migration dependency corrected and no behavioral defects identified in the changed code.

The substantive change establishes the intended linear revision order, while the remaining edits preserve existing behavior.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/migrations/versions/20260729_220000_d1e2f3a4b5c6_add_budget_alert_state.py | Reparents the budget-alert-state revision onto the audit-log-indexes revision, producing the intended single linear migration chain. |
| app/api/users.py | Contains only a formatting change to the existing search escaping expression. |
| tests/test_auth.py | Contains only formatting changes to an existing sign-in test request payload. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[6c201dbaea6e<br/>team region migration] --> B[e5b8c7d2a941<br/>audit log indexes]
    B --> C[d1e2f3a4b5c6<br/>budget alert state]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["style: Format JSON input for better read..."](https://github.com/amazeeio/amazee.ai/commit/cabcc62223fc6da1e4106f107d660a9a873b3ae6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49028101)</sub>

<!-- /greptile_comment -->