### PR TITLE
hotfix: tenant isolation fixes for vector DBs and trial keys (#650, #651)

### DIFF
--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -46,6 +46,7 @@ from app.core.limit_service import (
     DEFAULT_RPM_PER_KEY,
 )
 from app.core.pool_budget_service import pool_team_has_ever_purchased
+from app.core.team_service import is_ai_trial_team
 
 router = APIRouter(tags=["private-ai-keys"])
 
@@ -54,19 +55,6 @@ logger = logging.getLogger(__name__)
 
 # Fake ID for resources not stored in the database
 FAKE_ID = -1
-
-
-def is_ai_trial_team(team: DBTeam | None) -> bool:
-    """True for the single team that pools all anonymous trial users.
-
-    Unlike a customer team, its members are unrelated to each other, so keys
-    minted in it must stay private from the rest of the team.
-    """
-    if team is None or not team.admin_email:
-        return False
-    return normalize_email_for_lookup(team.admin_email) == normalize_email_for_lookup(
-        settings.AI_TRIAL_TEAM_EMAIL
-    )
 
 
 def _validate_permissions_and_get_ownership_info(

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -28,7 +28,7 @@ from app.db.models import (
     DBSpendCap,
 )
 from app.core.email import normalize_email_for_lookup
-from app.services.litellm import LiteLLMService
+from app.services.litellm import INFERENCE_ONLY_ROUTES, LiteLLMService
 from app.core.security import (
     get_current_user_from_auth,
     get_role_min_team_admin,
@@ -54,6 +54,19 @@ logger = logging.getLogger(__name__)
 
 # Fake ID for resources not stored in the database
 FAKE_ID = -1
+
+
+def is_ai_trial_team(team: DBTeam | None) -> bool:
+    """True for the single team that pools all anonymous trial users.
+
+    Unlike a customer team, its members are unrelated to each other, so keys
+    minted in it must stay private from the rest of the team.
+    """
+    if team is None or not team.admin_email:
+        return False
+    return normalize_email_for_lookup(team.admin_email) == normalize_email_for_lookup(
+        settings.AI_TRIAL_TEAM_EMAIL
+    )
 
 
 def _validate_permissions_and_get_ownership_info(
@@ -526,6 +539,14 @@ async def create_llm_token(
             db, effective_team.id, region.id
         )
 
+    # Every anonymous trial lands in ONE shared team (so the keys stay
+    # trackable), and LiteLLM lets any key in a team read that team —
+    # /team/info returns every sibling key with its owner, spend and budget.
+    # Trial keys therefore get LiteLLM's inference-only route group: LLM calls
+    # work, every management route returns 403. Members of a real (customer)
+    # team are colleagues, so this scoping is deliberately trial-only.
+    allowed_routes = INFERENCE_ONLY_ROUTES if is_ai_trial_team(effective_team) else None
+
     if (owner is not None and owner.team_id) or team_id:
         if settings.ENABLE_LIMITS and not is_pool_team:
             limit_service.check_key_limits(owner.team_id or team_id, owner_id)
@@ -586,6 +607,7 @@ async def create_llm_token(
             rpm_limit=max_rpm_limit,
             apply_limits=not is_pool_team,
             blocked=(True if is_pool_team and not has_pool_purchase else None),
+            allowed_routes=allowed_routes,
         )
         if is_pool_team and not has_pool_purchase:
             await litellm_service.update_key_budget(

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -398,7 +398,11 @@ async def _create_private_ai_key(
             if db_info and region:
                 # Delete vector database
                 postgres_manager = PostgresManager(region=region)
-                await postgres_manager.delete_database(db_info.database_name)
+                # Drop the role too — a leftover role keeps valid, unowned
+                # credentials on the shared cluster.
+                await postgres_manager.delete_database(
+                    db_info.database_name, db_info.database_username
+                )
                 logger.info("Cleaned up vector database after failure")
         except Exception as cleanup_error:
             logger.error(

--- a/app/core/team_service.py
+++ b/app/core/team_service.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from datetime import UTC, datetime
 from typing import Dict, List, Optional
 
+from app.core.config import settings
 from app.core.limit_service import DEFAULT_KEY_DURATION
 from app.db.models import (
     DBAuditLog,
@@ -21,6 +22,21 @@ from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
+
+
+def is_ai_trial_team(team: Optional[DBTeam]) -> bool:
+    """True for the single team that pools all anonymous trial users.
+
+    Unlike a customer team, its members are unrelated to each other, so keys
+    minted in it must stay private from the rest of the team.
+
+    Compared case-insensitively but WITHOUT plus-tag stripping, matching how
+    the trial team is looked up and created in `generate_trial_access` — a
+    plus-tagged address is a different team, not the trial team.
+    """
+    if team is None or not team.admin_email:
+        return False
+    return team.admin_email.lower() == settings.AI_TRIAL_TEAM_EMAIL.lower()
 
 
 def get_team_region_litellm_keys(

--- a/app/db/postgres.py
+++ b/app/db/postgres.py
@@ -59,6 +59,13 @@ class PostgresManager:
             await conn.execute(
                 f"GRANT ALL PRIVILEGES ON DATABASE {db_name} TO {db_user}"
             )
+            # PostgreSQL grants CONNECT to PUBLIC on every new database, and
+            # every tenant role is a member of PUBLIC — so on a shared cluster
+            # that default lets any tenant role open a session against any
+            # other tenant's database. The GRANT ALL above already gave db_user
+            # its own CONNECT, so revoking PUBLIC leaves exactly one role able
+            # to connect.
+            await conn.execute(f"REVOKE CONNECT ON DATABASE {db_name} FROM PUBLIC")
             logger.info("Database and user created successfully")
 
             # Close the initial connection
@@ -87,6 +94,11 @@ class PostgresManager:
                     f"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {db_user}"
                 )
                 await conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
+                # On PostgreSQL < 15 PUBLIC also holds CREATE on the public
+                # schema. db_user owns it (above) and is the only role that
+                # should touch it. No app path connects to a tenant database as
+                # the admin user, so this cannot lock our own tooling out.
+                await conn.execute("REVOKE ALL ON SCHEMA public FROM PUBLIC")
                 logger.info("Schema permissions granted successfully")
             finally:
                 await conn.close()
@@ -100,6 +112,57 @@ class PostgresManager:
         except Exception as e:
             logger.error(f"Error creating database: {str(e)}")
             raise
+        finally:
+            await conn.close()
+
+    async def restrict_connect_to_owner(
+        self, database_name: str, database_username: str
+    ) -> None:
+        """Make *database_name* connectable only by *database_username*.
+
+        Databases provisioned before create_database started revoking it still
+        carry PostgreSQL's default ``CONNECT`` grant to PUBLIC. Grant first,
+        revoke second, so the owning tenant is never locked out even if the run
+        is interrupted.
+        """
+        _validate_identifier(database_name, "database name")
+        _validate_identifier(database_username, "database username")
+
+        conn = await asyncpg.connect(
+            host=self.host,
+            port=self.port,
+            user=self.admin_user,
+            password=self.admin_password,
+        )
+        try:
+            await conn.execute(
+                f"GRANT CONNECT ON DATABASE {database_name} TO {database_username}"
+            )
+            await conn.execute(
+                f"REVOKE CONNECT ON DATABASE {database_name} FROM PUBLIC"
+            )
+        finally:
+            await conn.close()
+
+    async def list_tenant_databases(self) -> list[str]:
+        """Return every ``db_*`` database on the cluster.
+
+        Used by the connect-privilege backfill to spot tenant databases the
+        platform no longer tracks (failed deletes) — those keep PUBLIC
+        connectivity and need an operator decision, so they are reported rather
+        than modified.
+        """
+        conn = await asyncpg.connect(
+            host=self.host,
+            port=self.port,
+            user=self.admin_user,
+            password=self.admin_password,
+        )
+        try:
+            rows = await conn.fetch(
+                "SELECT datname FROM pg_database WHERE datname LIKE 'db\\_%'"
+            )
+            return [row["datname"] for row in rows]
         finally:
             await conn.close()
 

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -14,6 +14,15 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+# LiteLLM treats a key's team_id as team membership, so any team key can read
+# the whole team via management routes (/team/info returns every sibling key's
+# owner, spend and budget). `llm_api_routes` is LiteLLM's route
+# group for inference only — /chat/completions, /embeddings, /responses,
+# /v1/messages, /models, pass-through providers — and excludes /team/*, /key/*,
+# /user/* and /spend/*. Used for keys that must stay private from their own
+# team, i.e. the shared anonymous-trial team.
+INFERENCE_ONLY_ROUTES = ["llm_api_routes"]
+
 
 class LiteLLMService:
     def __init__(self, api_url: str, api_key: str):
@@ -124,8 +133,15 @@ class LiteLLMService:
         rpm_limit: Optional[int] = DEFAULT_RPM_PER_KEY,
         apply_limits: bool = True,
         blocked: Optional[bool] = None,
+        allowed_routes: Optional[list[str]] = None,
     ) -> str:
-        """Create a new API key for LiteLLM"""
+        """Create a new API key for LiteLLM
+
+        Args:
+            allowed_routes: Restrict the key to these LiteLLM routes (exact
+                paths, wildcards or route-group names such as
+                ``llm_api_routes``). None means no route restriction.
+        """
         try:
             logger.info(
                 f"Creating new LiteLLM API key for email: {email}, name: {name}, user_id: {user_id}, team_id: {team_id}"
@@ -161,6 +177,8 @@ class LiteLLMService:
             request_data["team_id"] = team_id
             if blocked is not None:
                 request_data["blocked"] = blocked
+            if allowed_routes:
+                request_data["allowed_routes"] = allowed_routes
 
             request_data["duration"] = "365d"  # Sets the key expiry date
             if settings.ENABLE_LIMITS and apply_limits:
@@ -607,6 +625,25 @@ class LiteLLMService:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Failed to set LiteLLM key restrictions: {error_msg}",
+            )
+
+    async def set_key_allowed_routes(
+        self, litellm_token: str, allowed_routes: list[str]
+    ) -> None:
+        """Scope an existing key to *allowed_routes* (used by the backfill)."""
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    f"{self.api_url}/key/update",
+                    headers={"Authorization": f"Bearer {self.master_key}"},
+                    json={"key": litellm_token, "allowed_routes": allowed_routes},
+                )
+                response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            _, error_msg, _ = self._parse_http_error(e)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to set LiteLLM key allowed_routes: {error_msg}",
             )
 
     async def update_key_team_association(self, litellm_token: str, new_team_id: str):

--- a/scripts/lock_vector_db_connect.py
+++ b/scripts/lock_vector_db_connect.py
@@ -62,7 +62,9 @@ def get_vector_dbs_grouped_by_region(session, region_name: str | None):
     for region_id, database_name, database_username in rows:
         keys_by_region[region_id].append((database_name, database_username))
 
-    return [(regions[rid], dbs) for rid, dbs in keys_by_region.items()]
+    # every region, not just ones with tracked keys — a region whose keys were all
+    # deleted without dropping their databases still needs its orphans reported
+    return [(region, keys_by_region.get(rid, [])) for rid, region in regions.items()]
 
 
 async def run(dry_run: bool, region_name: str | None) -> int:

--- a/scripts/lock_vector_db_connect.py
+++ b/scripts/lock_vector_db_connect.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+One-time backfill: revoke PUBLIC CONNECT on existing tenant vector databases.
+
+PostgreSQL grants CONNECT to PUBLIC on every new database, and every tenant role
+is a member of PUBLIC — so on a shared vectordb cluster that default lets any
+tenant role open a session against any other tenant's database.
+`PostgresManager.create_database` now revokes it at provisioning time; this
+script applies the same change to databases created before that.
+
+For each tracked vector DB it runs (in this order, so an interrupted run never
+locks a tenant out of its own database):
+
+    GRANT CONNECT ON DATABASE db_x TO user_x;
+    REVOKE CONNECT ON DATABASE db_x FROM PUBLIC;
+
+Tenant databases present on the cluster but not tracked by the platform (failed
+deletes) are reported, not modified — dropping or locking them is an operator
+decision.
+
+Usage:
+    python scripts/lock_vector_db_connect.py --dry-run
+    python scripts/lock_vector_db_connect.py
+    python scripts/lock_vector_db_connect.py --region eu-central-1
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+from collections import defaultdict
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.db.database import SessionLocal
+from app.db.models import DBPrivateAIKey, DBRegion
+from app.db.postgres import PostgresManager
+
+
+def get_vector_dbs_grouped_by_region(session, region_name: str | None):
+    """Return (region, [(database_name, database_username), ...]) pairs."""
+    regions = {
+        r.id: r
+        for r in session.query(DBRegion)
+        .filter(DBRegion.postgres_host.isnot(None))
+        .all()
+        if region_name is None or r.name == region_name
+    }
+
+    keys_by_region = defaultdict(list)
+    rows = (
+        session.query(
+            DBPrivateAIKey.region_id,
+            DBPrivateAIKey.database_name,
+            DBPrivateAIKey.database_username,
+        )
+        .filter(DBPrivateAIKey.database_name.isnot(None))
+        .filter(DBPrivateAIKey.database_username.isnot(None))
+        .filter(DBPrivateAIKey.region_id.in_(regions.keys()))
+        .all()
+    )
+    for region_id, database_name, database_username in rows:
+        keys_by_region[region_id].append((database_name, database_username))
+
+    return [(regions[rid], dbs) for rid, dbs in keys_by_region.items()]
+
+
+async def run(dry_run: bool, region_name: str | None) -> int:
+    session = SessionLocal()
+    try:
+        work = get_vector_dbs_grouped_by_region(session, region_name)
+    finally:
+        session.close()
+
+    total_locked = 0
+    total_failed = 0
+    total_untracked = 0
+
+    for region, databases in work:
+        manager = PostgresManager(region=region)
+        tracked = {name for name, _ in databases}
+
+        try:
+            on_cluster = set(await manager.list_tenant_databases())
+        except Exception as e:
+            print(f"[FAIL] region={region.name} could not list databases: {e}")
+            total_failed += 1
+            continue
+
+        untracked = sorted(on_cluster - tracked)
+        if untracked:
+            total_untracked += len(untracked)
+            print(
+                f"[WARN] region={region.name} {len(untracked)} untracked tenant "
+                f"database(s) still allow PUBLIC CONNECT (not modified): "
+                f"{', '.join(untracked)}"
+            )
+
+        for database_name, database_username in sorted(databases):
+            if database_name not in on_cluster:
+                print(f"[SKIP] region={region.name} db={database_name} not on cluster")
+                continue
+            if dry_run:
+                print(
+                    f"[DRY-RUN] region={region.name} db={database_name} -> "
+                    f"CONNECT only for {database_username}"
+                )
+                continue
+            try:
+                await manager.restrict_connect_to_owner(
+                    database_name, database_username
+                )
+                total_locked += 1
+                print(f"[OK] region={region.name} db={database_name}")
+            except Exception as e:
+                total_failed += 1
+                print(f"[FAIL] region={region.name} db={database_name} error={e}")
+
+    print(
+        f"Done. locked={total_locked} failed={total_failed} "
+        f"untracked={total_untracked} dry_run={dry_run}"
+    )
+    return 0 if total_failed == 0 else 1
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Revoke PUBLIC CONNECT on existing tenant vector databases"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print planned changes without applying them",
+    )
+    parser.add_argument(
+        "--region",
+        default=None,
+        help="Only process this region name (default: all regions)",
+    )
+    args = parser.parse_args()
+    raise SystemExit(asyncio.run(run(args.dry_run, args.region)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/restrict_trial_key_routes.py
+++ b/scripts/restrict_trial_key_routes.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+One-time backfill: scope existing anonymous-trial keys to inference routes.
+
+All anonymous trials share one team so their keys stay trackable, but LiteLLM
+treats a key's team_id as team membership: a trial key can call
+`/team/info?team_id=<shared team>` and read every sibling trial's owner, spend
+and budget metadata. New keys are created with `allowed_routes` (see
+`create_llm_token`); this script applies the same scoping to keys minted before
+that.
+
+Usage:
+    python scripts/restrict_trial_key_routes.py --dry-run
+    python scripts/restrict_trial_key_routes.py
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+from collections import defaultdict
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.api.private_ai_keys import is_ai_trial_team
+from app.db.database import SessionLocal
+from app.db.models import DBPrivateAIKey, DBRegion, DBTeam, DBUser
+from app.services.litellm import INFERENCE_ONLY_ROUTES, LiteLLMService
+
+
+def get_trial_keys_grouped_by_region(session):
+    """Return trial-team LiteLLM keys grouped by region_id."""
+    trial_team_ids = [
+        team.id for team in session.query(DBTeam).all() if is_ai_trial_team(team)
+    ]
+    if not trial_team_ids:
+        return defaultdict(list)
+
+    keys = (
+        session.query(DBPrivateAIKey)
+        .outerjoin(DBUser, DBUser.id == DBPrivateAIKey.owner_id)
+        .filter(DBPrivateAIKey.litellm_token.isnot(None))
+        .filter(DBPrivateAIKey.region_id.isnot(None))
+        .filter(
+            (DBPrivateAIKey.team_id.in_(trial_team_ids))
+            | (DBUser.team_id.in_(trial_team_ids))
+        )
+        .all()
+    )
+
+    keys_by_region = defaultdict(list)
+    for key in keys:
+        keys_by_region[key.region_id].append(key)
+    return keys_by_region
+
+
+async def run(dry_run: bool) -> int:
+    session = SessionLocal()
+    try:
+        regions = {r.id: r for r in session.query(DBRegion).all()}
+        keys_by_region = get_trial_keys_grouped_by_region(session)
+
+        total_updated = 0
+        total_failed = 0
+
+        for region_id, keys in keys_by_region.items():
+            region = regions.get(region_id)
+            if region is None:
+                continue
+
+            service = LiteLLMService(
+                api_url=region.litellm_api_url,
+                api_key=region.litellm_api_key,
+            )
+            for key in keys:
+                if dry_run:
+                    print(
+                        f"[DRY-RUN] key_id={key.id} region={region.name} -> "
+                        f"allowed_routes={INFERENCE_ONLY_ROUTES}"
+                    )
+                    continue
+                try:
+                    await service.set_key_allowed_routes(
+                        litellm_token=key.litellm_token,
+                        allowed_routes=INFERENCE_ONLY_ROUTES,
+                    )
+                    total_updated += 1
+                    print(f"[OK] key_id={key.id} region={region.name}")
+                except Exception as e:
+                    total_failed += 1
+                    print(f"[FAIL] key_id={key.id} region={region.name} error={e}")
+
+        print(f"Done. updated={total_updated} failed={total_failed} dry_run={dry_run}")
+        return 0 if total_failed == 0 else 1
+    finally:
+        session.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Restrict existing anonymous-trial LiteLLM keys to inference routes"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print planned updates without applying them",
+    )
+    args = parser.parse_args()
+    raise SystemExit(asyncio.run(run(args.dry_run)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/restrict_trial_key_routes.py
+++ b/scripts/restrict_trial_key_routes.py
@@ -22,7 +22,7 @@ from collections import defaultdict
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from app.api.private_ai_keys import is_ai_trial_team
+from app.core.team_service import is_ai_trial_team
 from app.db.database import SessionLocal
 from app.db.models import DBPrivateAIKey, DBRegion, DBTeam, DBUser
 from app.services.litellm import INFERENCE_ONLY_ROUTES, LiteLLMService

--- a/tests/test_postgres_manager.py
+++ b/tests/test_postgres_manager.py
@@ -1,5 +1,8 @@
 """Tenant isolation guarantees of vector-DB provisioning."""
 
+import os
+import sys
+
 import pytest
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -74,3 +77,23 @@ async def test_restrict_connect_to_owner_rejects_bad_identifiers(
                 database_name, database_username
             )
     mock_connect.assert_not_called()
+
+
+def test_backfill_includes_regions_with_no_tracked_keys():
+    """A region whose key rows were deleted without dropping their databases
+    must still be visited, or its orphans are never reported."""
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+    from scripts.lock_vector_db_connect import get_vector_dbs_grouped_by_region
+
+    tracked, orphan_only = Mock(spec=DBRegion), Mock(spec=DBRegion)
+    tracked.id, orphan_only.id = 1, 2
+    session = Mock()
+    query = session.query.return_value
+    query.filter.return_value.all.return_value = [tracked, orphan_only]
+    query.filter.return_value.filter.return_value.filter.return_value.all.return_value = [
+        (1, "db_abc123", "user_abc123")
+    ]
+
+    work = dict(get_vector_dbs_grouped_by_region(session, None))
+    assert work[tracked] == [("db_abc123", "user_abc123")]
+    assert work[orphan_only] == []

--- a/tests/test_postgres_manager.py
+++ b/tests/test_postgres_manager.py
@@ -1,0 +1,76 @@
+"""Tenant isolation guarantees of vector-DB provisioning."""
+
+import pytest
+from unittest.mock import AsyncMock, Mock, patch
+
+from app.db.models import DBRegion
+from app.db.postgres import PostgresManager
+
+
+@pytest.fixture
+def region():
+    region = Mock(spec=DBRegion)
+    region.postgres_host = "vectordb1.test"
+    region.postgres_port = 5432
+    region.postgres_admin_user = "admin"
+    region.postgres_admin_password = "adminpw"
+    return region
+
+
+@pytest.mark.asyncio
+async def test_create_database_revokes_public_connect(region):
+    """A new tenant database must be connectable only by its own role.
+
+    Without the REVOKE, PostgreSQL's default PUBLIC CONNECT grant lets any
+    tenant role on the shared cluster open a session against any other tenant's
+    database using only its own password.
+    """
+    conn = AsyncMock()
+    with patch("asyncpg.connect", AsyncMock(return_value=conn)):
+        result = await PostgresManager(region=region).create_database()
+
+    statements = [call.args[0] for call in conn.execute.call_args_list]
+    db_name = result["database_name"]
+    db_user = result["database_username"]
+
+    assert f"REVOKE CONNECT ON DATABASE {db_name} FROM PUBLIC" in statements
+    assert "REVOKE ALL ON SCHEMA public FROM PUBLIC" in statements
+    # The owning role keeps its own CONNECT (granted with ALL PRIVILEGES), and
+    # gets it before PUBLIC loses it.
+    grant = statements.index(f"GRANT ALL PRIVILEGES ON DATABASE {db_name} TO {db_user}")
+    revoke = statements.index(f"REVOKE CONNECT ON DATABASE {db_name} FROM PUBLIC")
+    assert grant < revoke
+
+
+@pytest.mark.asyncio
+async def test_restrict_connect_to_owner_grants_before_revoking(region):
+    """Backfill order matters: an interrupted run must not lock the tenant out."""
+    conn = AsyncMock()
+    with patch("asyncpg.connect", AsyncMock(return_value=conn)):
+        await PostgresManager(region=region).restrict_connect_to_owner(
+            "db_abc123", "user_abc123"
+        )
+
+    assert [call.args[0] for call in conn.execute.call_args_list] == [
+        "GRANT CONNECT ON DATABASE db_abc123 TO user_abc123",
+        "REVOKE CONNECT ON DATABASE db_abc123 FROM PUBLIC",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "database_name,database_username",
+    [
+        ("db_ok; DROP DATABASE db_other", "user_ok"),
+        ("db_ok", 'user_ok"; DROP ROLE x'),
+    ],
+)
+async def test_restrict_connect_to_owner_rejects_bad_identifiers(
+    region, database_name, database_username
+):
+    with patch("asyncpg.connect", AsyncMock()) as mock_connect:
+        with pytest.raises(ValueError):
+            await PostgresManager(region=region).restrict_connect_to_owner(
+                database_name, database_username
+            )
+    mock_connect.assert_not_called()

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -1,4 +1,7 @@
 from unittest.mock import patch, Mock, AsyncMock
+
+import pytest
+
 from app.db.models import (
     DBPrivateAIKey,
     DBPeriodicBudgetLedgerEntry,
@@ -1769,17 +1772,31 @@ def test_create_llm_token_for_trial_team_is_inference_only(
     assert payload["allowed_routes"] == ["llm_api_routes"]
 
 
+@pytest.mark.parametrize(
+    "admin_email",
+    [
+        "customer-team-admin@example.com",
+        # A plus-tag of the trial address is a DIFFERENT team (that's how the
+        # trial team is looked up), so it must not inherit the restriction.
+        settings.AI_TRIAL_TEAM_EMAIL.replace("@", "+customer@"),
+    ],
+)
 @patch("httpx.AsyncClient")
 def test_create_llm_token_for_customer_team_is_unrestricted(
     mock_client_class,
+    admin_email,
     client,
     admin_token,
     test_region,
+    db,
     test_team,
     mock_httpx_post_client,
 ):
     """Members of a real team are colleagues — the trial restriction must not
     leak into normal team keys."""
+    test_team.admin_email = admin_email
+    db.commit()
+
     mock_client_class.return_value = mock_httpx_post_client
 
     response = client.post(

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -13,6 +13,7 @@ from datetime import datetime, UTC
 from app.core.security import get_password_hash
 from httpx import HTTPStatusError
 from fastapi import status, HTTPException
+from app.core.config import settings
 from app.core.limit_service import (
     DEFAULT_MAX_SPEND,
     DEFAULT_RPM_PER_KEY,
@@ -1719,6 +1720,81 @@ def test_create_llm_token_for_non_gated_pool_team_is_never_blocked(
     ]
     assert len(key_generate_calls) == 1
     assert "blocked" not in key_generate_calls[0].kwargs["json"]
+
+
+def _key_generate_payload(mock_client, key_name):
+    calls = [
+        call
+        for call in mock_client.post.call_args_list
+        if str(call.args[0]).endswith("/key/generate")
+        and call.kwargs.get("json", {})
+        .get("metadata", {})
+        .get("amazeeai_private_ai_key_name")
+        == key_name
+    ]
+    assert len(calls) == 1
+    return calls[0].kwargs["json"]
+
+
+@patch("httpx.AsyncClient")
+def test_create_llm_token_for_trial_team_is_inference_only(
+    mock_client_class,
+    client,
+    admin_token,
+    test_region,
+    db,
+    test_team,
+    mock_httpx_post_client,
+):
+    """All anonymous trials share one team, and LiteLLM lets any key in a team
+    read that team (/team/info exposes every sibling key's owner, spend and
+    budget). Trial keys must therefore be scoped to inference routes."""
+    test_team.admin_email = settings.AI_TRIAL_TEAM_EMAIL
+    db.commit()
+
+    mock_client_class.return_value = mock_httpx_post_client
+
+    response = client.post(
+        "/private-ai-keys/token",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "region_id": test_region.id,
+            "name": "Trial Key",
+            "team_id": test_team.id,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = _key_generate_payload(mock_httpx_post_client, "Trial Key")
+    assert payload["allowed_routes"] == ["llm_api_routes"]
+
+
+@patch("httpx.AsyncClient")
+def test_create_llm_token_for_customer_team_is_unrestricted(
+    mock_client_class,
+    client,
+    admin_token,
+    test_region,
+    test_team,
+    mock_httpx_post_client,
+):
+    """Members of a real team are colleagues — the trial restriction must not
+    leak into normal team keys."""
+    mock_client_class.return_value = mock_httpx_post_client
+
+    response = client.post(
+        "/private-ai-keys/token",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "region_id": test_region.id,
+            "name": "Customer Key",
+            "team_id": test_team.id,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = _key_generate_payload(mock_httpx_post_client, "Customer Key")
+    assert "allowed_routes" not in payload
 
 
 def test_create_vector_db_as_system_admin(client, admin_token, test_region):

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -2738,8 +2738,9 @@ def test_create_private_ai_key_cleanup_on_db_storage_failure(
     assert cleanup_call[0][0] == f"{test_region.litellm_api_url}/key/delete"
     assert cleanup_call[1]["json"]["keys"] == ["test-private-key-123"]
 
-    # Verify vector database was cleaned up
-    mock_delete_db.assert_called_once_with("test_db_123")
+    # Verify vector database AND its role were cleaned up — a leftover role
+    # keeps valid credentials on the shared cluster.
+    mock_delete_db.assert_called_once_with("test_db_123", "test_user")
 
     # Verify no key was stored in the database
     stored_keys = client.get(

--- a/tests/test_trial_access.py
+++ b/tests/test_trial_access.py
@@ -226,3 +226,46 @@ async def test_generate_trial_access_cleanup_on_key_creation_failure(
     assert exc_info.value.status_code == expected_status
 
     assert mock_db.delete.call_count >= 1
+
+
+@patch("app.db.postgres.PostgresManager.create_database")
+@patch("httpx.AsyncClient")
+def test_trial_key_cannot_read_its_own_litellm_team(
+    mock_client_class, mock_create_db, client, db, test_region
+):
+    """Full provisioning path.
+
+    Every anonymous trial shares one team, and LiteLLM treats a key's team_id as
+    team membership — so an unscoped trial key can GET /team/info and read every
+    other trial's owner, spend and budget. The trial key must therefore be minted
+    with LiteLLM's inference-only route group.
+    """
+    mock_create_db.return_value = {
+        "database_name": "db_trial",
+        "database_host": "pghost",
+        "database_username": "user_trial",
+        "database_password": "pw",
+    }
+
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"key": "sk-trial-test-key"}
+    mock_response.raise_for_status.return_value = None
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+    mock_client_class.return_value = mock_client
+
+    with patch("app.core.config.settings.AI_TRIAL_REGION", test_region.name):
+        response = client.post("/auth/generate-trial-access", json={})
+
+    assert response.status_code == 200, response.text
+
+    key_generate_calls = [
+        call
+        for call in mock_client.post.call_args_list
+        if str(call.args[0]).endswith("/key/generate")
+    ]
+    assert len(key_generate_calls) == 1
+    assert key_generate_calls[0].kwargs["json"]["allowed_routes"] == ["llm_api_routes"]


### PR DESCRIPTION
Hotfix straight to `main`: cherry-picks of #650 and #651 only, so the two tenant-isolation fixes can ship without releasing the rest of `dev`.

Cherry-picked (`-x`, original commits stay in `dev`):

- `9371db4` fix(vector-db): restrict tenant database connectivity to its owning role (#650)
- `cd0bc1b` fix(vector-db): backfill regions with no tracked keys (#650)
- `6660574` fix(trial): scope anonymous-trial LiteLLM keys to inference routes (#651)
- `7eb6f68` fix(trial): match trial team on exact email, move helper out of API module (#651)

All four applied without conflicts; the resulting `app/` files are byte-identical to `dev`.

## What this fixes

**#650 — cross-tenant vector DB connectivity (region-wide, all teams).** `CREATE DATABASE` grants `CONNECT` to `PUBLIC` and every tenant role is a member of `PUBLIC`, so any private-AI-key credential could open a session against any other tenant's database on the same regional cluster — across users and across customer teams. Table contents stayed protected (no `PUBLIC` table grants), so the exposure was catalog/metadata disclosure plus a DoS surface, not row-level data theft. Provisioning now revokes the default grant, and the create-failure path drops the leaked tenant role.

**#651 — trial keys could read the shared trial team (trial pool only).** All anonymous trials share one team, and LiteLLM treats `team_id` as membership, so any trial key could `GET /team/info` and read every sibling trial's owner id, service_account_id, spend, budget and expiry. Trial keys are now minted with the `llm_api_routes` group. Customer teams are unaffected.

## Post-merge deploy steps (required)

The code change only covers newly provisioned resources. Existing ones need the backfills:

1. `python scripts/lock_vector_db_connect.py --dry-run` then without the flag — per region. Untracked `db_*` databases from failed deletes are reported, not modified, and keep `PUBLIC CONNECT` until an operator acts on them.
2. `python scripts/restrict_trial_key_routes.py` for trial keys minted before this change.

## Notes

- `/model/info` is not part of `llm_api_routes`. If a trial client needs it, add the exact path alongside the group.
- Tests were not run locally; CI on this PR covers them.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This hotfix closes two tenant-isolation gaps and adds operational backfills.
- Revokes default PostgreSQL privileges from newly provisioned tenant vector databases and removes leaked roles during compensated cleanup.
- Restricts anonymous-trial LiteLLM keys to inference routes while leaving customer-team keys unrestricted.
- Adds backfill scripts for existing vector databases and trial keys, including dry-run and partial-failure reporting.
- Adds coverage for provisioning privileges, cleanup, trial-team classification, and full trial key creation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the required operational backfills still necessary to protect resources created before deployment.

The changed provisioning paths preserve each database owner’s access while removing PUBLIC privileges, validate persisted identifiers before issuing privilege statements, and consistently scope keys created through the anonymous-trial flow to inference routes.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/private_ai_keys.py | Applies inference-only routes to the shared anonymous-trial team and includes the tenant role in failed vector-database cleanup. |
| app/core/team_service.py | Adds exact, case-insensitive identification of the configured anonymous-trial team without plus-tag normalization. |
| app/db/postgres.py | Revokes default cross-tenant database and schema privileges and adds validated helpers for backfilling existing clusters. |
| app/services/litellm.py | Adds optional allowed-route payload support for key creation and an update method for existing keys. |
| scripts/lock_vector_db_connect.py | Backfills tracked tenant databases per region while reporting rather than mutating untracked databases. |
| scripts/restrict_trial_key_routes.py | Finds trial-team keys through direct or owner-based team association and applies inference-only routes per regional LiteLLM instance. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as amazee.ai API
    participant LLM as LiteLLM
    participant PG as Regional PostgreSQL
    participant Ops as Backfill operator

    Client->>API: Create anonymous trial key
    API->>LLM: "Generate key with allowed_routes=[llm_api_routes]"
    LLM-->>API: Inference-only key

    Client->>API: Create vector-backed key
    API->>PG: CREATE DATABASE and role
    API->>PG: GRANT owner privileges
    API->>PG: REVOKE CONNECT FROM PUBLIC
    API->>PG: REVOKE schema privileges FROM PUBLIC
    PG-->>API: Tenant-isolated database credentials

    Ops->>PG: Backfill tracked databases
    Ops->>PG: GRANT CONNECT to recorded owner
    Ops->>PG: REVOKE CONNECT FROM PUBLIC
    Ops->>LLM: Restrict existing trial keys
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trial): match trial team on exact em..."](https://github.com/amazeeio/amazee.ai/commit/829b1d3d8b471d940f77f5c5ded13b90c5c87ed8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49076210)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Private AI Keys and LiteLLM Integration](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/private-ai-keys-litellm.md)
- Knowledge Base — [Teams and Users](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/teams-users.md)
- Knowledge Base — [Database models, session, and migrations](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/database-models.md)
</details>

<!-- /greptile_comment -->