### PR TITLE
fix(trial): allow /model/info on inference-only trial keys

### DIFF
--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -23,11 +23,13 @@ logger = logging.getLogger(__name__)
 # team, i.e. the shared anonymous-trial team.
 #
 # /model/info is added explicitly: it is an info route, NOT part of
-# `llm_api_routes`, but the Drupal module (`ai_provider_amazeeio`) calls it with
-# the trial key to list models — both from `AmazeeClient::models()` and from the
-# provider config form, which needs the human-readable description that the
-# OpenAI-style /models list does not carry. Without it, trial sites get 403 on
-# model discovery. It exposes the region's model catalogue only, not other keys.
+# `llm_api_routes`. The Drupal module (`ai_provider_amazeeio`) lists models
+# through it with whatever key it holds — trial keys and self-service keys
+# alike — from `AmazeeClient::models()` and from the provider config form, which
+# needs the human-readable description that the OpenAI-style /models list does
+# not carry. Unrestricted keys reach it anyway, so only the route-restricted
+# trial keys need it named here; without it those sites 403 on model discovery.
+# It exposes the region's model catalogue only, not other keys.
 INFERENCE_ONLY_ROUTES = ["llm_api_routes", "/model/info"]
 
 

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -21,7 +21,14 @@ logger = logging.getLogger(__name__)
 # /v1/messages, /models, pass-through providers — and excludes /team/*, /key/*,
 # /user/* and /spend/*. Used for keys that must stay private from their own
 # team, i.e. the shared anonymous-trial team.
-INFERENCE_ONLY_ROUTES = ["llm_api_routes"]
+#
+# /model/info is added explicitly: it is an info route, NOT part of
+# `llm_api_routes`, but the Drupal module (`ai_provider_amazeeio`) calls it with
+# the trial key to list models — both from `AmazeeClient::models()` and from the
+# provider config form, which needs the human-readable description that the
+# OpenAI-style /models list does not carry. Without it, trial sites get 403 on
+# model discovery. It exposes the region's model catalogue only, not other keys.
+INFERENCE_ONLY_ROUTES = ["llm_api_routes", "/model/info"]
 
 
 class LiteLLMService:

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -21,6 +21,7 @@ from app.core.limit_service import (
     DEFAULT_MAX_SPEND,
     DEFAULT_RPM_PER_KEY,
 )
+from app.services.litellm import INFERENCE_ONLY_ROUTES
 
 
 @patch("app.api.private_ai_keys.settings")
@@ -1769,7 +1770,7 @@ def test_create_llm_token_for_trial_team_is_inference_only(
 
     assert response.status_code == 200
     payload = _key_generate_payload(mock_httpx_post_client, "Trial Key")
-    assert payload["allowed_routes"] == ["llm_api_routes"]
+    assert payload["allowed_routes"] == INFERENCE_ONLY_ROUTES
 
 
 @pytest.mark.parametrize(

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -21,7 +21,6 @@ from app.core.limit_service import (
     DEFAULT_MAX_SPEND,
     DEFAULT_RPM_PER_KEY,
 )
-from app.services.litellm import INFERENCE_ONLY_ROUTES
 
 
 @patch("app.api.private_ai_keys.settings")
@@ -1770,7 +1769,9 @@ def test_create_llm_token_for_trial_team_is_inference_only(
 
     assert response.status_code == 200
     payload = _key_generate_payload(mock_httpx_post_client, "Trial Key")
-    assert payload["allowed_routes"] == INFERENCE_ONLY_ROUTES
+    # Literal list, not INFERENCE_ONLY_ROUTES: the constant builds the request,
+    # so comparing to it would silently accept any route added to it later.
+    assert payload["allowed_routes"] == ["llm_api_routes", "/model/info"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_trial_access.py
+++ b/tests/test_trial_access.py
@@ -6,7 +6,6 @@ from app.api.auth import generate_trial_access
 from app.core.limit_service import LimitService
 from app.db.models import DBUser, DBTeam, DBPrivateAIKey, DBRegion
 from app.schemas.models import Token
-from app.services.litellm import INFERENCE_ONLY_ROUTES
 from fastapi import Response
 
 
@@ -269,8 +268,12 @@ def test_trial_key_cannot_read_its_own_litellm_team(
         if str(call.args[0]).endswith("/key/generate")
     ]
     assert len(key_generate_calls) == 1
-    allowed_routes = key_generate_calls[0].kwargs["json"]["allowed_routes"]
-    assert allowed_routes == INFERENCE_ONLY_ROUTES
-    # The Drupal module lists models via /model/info, which is an info route and
-    # not covered by llm_api_routes; without it trial sites 403 on discovery.
-    assert "/model/info" in allowed_routes
+    # Spelled out rather than compared against INFERENCE_ONLY_ROUTES: the
+    # constant builds the request, so comparing to it would accept any route
+    # added to it later, including a management route. /model/info is required
+    # because the Drupal module lists models through it and llm_api_routes does
+    # not cover it; anything beyond these two must fail this test.
+    assert key_generate_calls[0].kwargs["json"]["allowed_routes"] == [
+        "llm_api_routes",
+        "/model/info",
+    ]

--- a/tests/test_trial_access.py
+++ b/tests/test_trial_access.py
@@ -6,6 +6,7 @@ from app.api.auth import generate_trial_access
 from app.core.limit_service import LimitService
 from app.db.models import DBUser, DBTeam, DBPrivateAIKey, DBRegion
 from app.schemas.models import Token
+from app.services.litellm import INFERENCE_ONLY_ROUTES
 from fastapi import Response
 
 
@@ -268,4 +269,8 @@ def test_trial_key_cannot_read_its_own_litellm_team(
         if str(call.args[0]).endswith("/key/generate")
     ]
     assert len(key_generate_calls) == 1
-    assert key_generate_calls[0].kwargs["json"]["allowed_routes"] == ["llm_api_routes"]
+    allowed_routes = key_generate_calls[0].kwargs["json"]["allowed_routes"]
+    assert allowed_routes == INFERENCE_ONLY_ROUTES
+    # The Drupal module lists models via /model/info, which is an info route and
+    # not covered by llm_api_routes; without it trial sites 403 on discovery.
+    assert "/model/info" in allowed_routes


### PR DESCRIPTION
## Problem

`64f9872b` (on `dev` via #651, on `main` via #653) scopes anonymous-trial LiteLLM keys to the route group `llm_api_routes`, so a trial key can no longer read its shared team via `/team/info`. Good fix, but the group does **not** include `/model/info` — that is a LiteLLM *info* route.

The Drupal contributed module needs `/model/info` and calls it with the trial key:

- `src/AmazeeIoApi/AmazeeClient.php:275` — `models()`, used by `AmazeeioAiProvider::getModels()`
- `src/Form/AmazeeioAiConfigForm.php:322` — `getLlmHostModels()`, with an explicit comment that it uses `/model/info` instead of `/models` because only `/model/info` returns the human-readable description

After trial provisioning the module points its own client at the LiteLLM host (`TrialAccountProvisioner.php:71` sets config `host` = `litellm_api_url`), so both calls go to LiteLLM authenticated with the trial key.

Deploying the scoping as-is would return 403 on model discovery for every drupalforge trial site. The module is a contributed project we cannot patch for this.

Verified against the latest module: `ai_provider_amazeeio` at `origin/1.3.x`, commit `0e4905c`.

## Change

`INFERENCE_ONLY_ROUTES = ["llm_api_routes", "/model/info"]` — the exact path alongside the group, which is what `64f9872b`'s own commit message says to do if a trial client needs it.

`/model/info` returns the region's model catalogue only. No sibling key, owner, spend or budget data, so the disclosure the scoping closes stays closed.

`scripts/restrict_trial_key_routes.py` already reads this constant, so the backfill for keys minted before the scoping picks it up with no further change.

## Tests

Updated the two assertions that hardcoded `["llm_api_routes"]` to compare against the constant, plus an explicit check that `/model/info` is present:

- `tests/test_trial_access.py::test_trial_key_cannot_read_its_own_litellm_team`
- `tests/test_private_ai.py::test_create_llm_token_for_trial_team_is_inference_only`

Not run locally — leaving this to CI.

## Deploy notes

- PROD is currently on the 2026-07-29 build, so the route scoping is **not live yet**. This PR must land before that deploy, otherwise trial sites break.
- The scoping applies at key creation only, so after deploying, run `scripts/restrict_trial_key_routes.py` to backfill existing trial keys (~1,130 in `amazeeai-de-eu101_719` as of 2026-08-03).
- Needs to reach `main` too, not just `dev`, since the PROD deploy of `64f9872b` comes from `main`.

## Still to verify

Not yet confirmed on a live LiteLLM that mixing a route group and an exact path in `allowed_routes` behaves as expected, i.e. `/model/info` 200 and `/team/info` 403 with the same key. Worth one DEV check before the PROD deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR permits inference-only anonymous-trial keys to access LiteLLM model metadata while retaining restrictions on management routes.
- Adds `/model/info` alongside `llm_api_routes` in the trial-key allowlist.
- Updates both provisioning-path tests to assert the complete literal allowlist, preventing the production constant from masking unintended route additions.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/services/litellm.py | Extends the restricted trial-key route allowlist with `/model/info` and documents why model discovery requires it. |
| tests/test_private_ai.py | Verifies direct trial-token creation sends exactly the intended two allowed routes. |
| tests/test_trial_access.py | Verifies full trial provisioning sends the exact allowlist without deriving expectations from the production constant. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(trial): clarify who calls /model/in..."](https://github.com/amazeeio/amazee.ai/commit/c0913bc9103734da8351c0e74269643efa042c7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49635686)</sub>

**Context used:**

- Knowledge Base — [Private AI Keys and LiteLLM Integration](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/private-ai-keys-litellm.md)

<!-- /greptile_comment -->