### PR TITLE
fix(trial): exempt the anonymous-trial team from team lifecycle rules

### DIFF
--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -46,7 +46,7 @@ from app.core.limit_service import (
     DEFAULT_RPM_PER_KEY,
 )
 from app.core.pool_budget_service import pool_team_has_ever_purchased
-from app.core.team_service import is_ai_trial_team
+from app.core.team_service import is_anonymous_trial_team
 
 router = APIRouter(tags=["private-ai-keys"])
 
@@ -533,7 +533,7 @@ async def create_llm_token(
     # Trial keys therefore get LiteLLM's inference-only route group: LLM calls
     # work, every management route returns 403. Members of a real (customer)
     # team are colleagues, so this scoping is deliberately trial-only.
-    allowed_routes = INFERENCE_ONLY_ROUTES if is_ai_trial_team(effective_team) else None
+    allowed_routes = INFERENCE_ONLY_ROUTES if is_anonymous_trial_team(effective_team) else None
 
     if (owner is not None and owner.team_id) or team_id:
         if settings.ENABLE_LIMITS and not is_pool_team:

--- a/app/core/team_service.py
+++ b/app/core/team_service.py
@@ -24,7 +24,7 @@ from sqlalchemy.orm import Session
 logger = logging.getLogger(__name__)
 
 
-def is_ai_trial_team(team: Optional[DBTeam]) -> bool:
+def is_anonymous_trial_team(team: Optional[DBTeam]) -> bool:
     """True for the single team that pools all anonymous trial users.
 
     Unlike a customer team, its members are unrelated to each other, so keys

--- a/app/core/trial_cleanup.py
+++ b/app/core/trial_cleanup.py
@@ -29,7 +29,7 @@ from sqlalchemy import exists, or_
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
-from app.core.team_service import is_ai_trial_team
+from app.core.team_service import is_anonymous_trial_team
 from app.db.models import (
     DBAuditLog,
     DBBudgetAlertState,
@@ -150,10 +150,10 @@ def assert_safe_for_region(
 def get_trial_team_ids(db: Session) -> list[int]:
     """Ids of every team that pools anonymous trial users.
 
-    Normally exactly one. Returns a list because ``is_ai_trial_team`` matches on
+    Normally exactly one. Returns a list because ``is_anonymous_trial_team`` matches on
     ``admin_email`` and a manually created duplicate would otherwise be missed.
     """
-    return [team.id for team in db.query(DBTeam).all() if is_ai_trial_team(team)]
+    return [team.id for team in db.query(DBTeam).all() if is_anonymous_trial_team(team)]
 
 
 def select_trial_keys(
@@ -471,7 +471,7 @@ def _delete_trial_user(db: Session, user_id: int) -> tuple[bool, Optional[str]]:
     user = db.query(DBUser).filter(DBUser.id == user_id).first()
     if user is None:
         return False, "user row already gone"
-    if not is_ai_trial_team(user.team):
+    if not is_anonymous_trial_team(user.team):
         # Defensive: a non-trial owner means the selection query is wrong.
         return False, "owner is not in a trial team"
 

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -35,7 +35,7 @@ from app.services.ses import SESService
 from app.core.team_service import (
     get_team_keys_by_region,
     get_team_region_litellm_keys,
-    is_ai_trial_team,
+    is_anonymous_trial_team,
     soft_delete_team,
 )
 from app.db.database import get_db
@@ -2096,12 +2096,10 @@ async def _check_team_retention_policy(
     if team.budget_type == BudgetType.POOL:
         return
 
-    # So is the anonymous-trial team. Activity is measured from its newest user
-    # or key, so a lull in trial signups long enough to cross the inactivity
-    # threshold would soft-delete the team that owns every trial key — and the
-    # hard-delete job then removes those keys, their users and the team across
-    # every region. It cannot be allowed to depend on signup volume.
-    if is_ai_trial_team(team):
+    # So is the anonymous-trial team. Activity is measured from its newest key,
+    # so a long enough lull in signups would soft-delete the team that owns
+    # every trial key, and the hard-delete job would then remove them all.
+    if is_anonymous_trial_team(team):
         return
 
     # Check team retention policy (only for non-deleted teams)
@@ -2414,14 +2412,6 @@ async def monitor_teams(db: Session):
 
                 # Now handle trial expiry notifications and key expiry (after retention checks)
                 is_pool_team = team.budget_type == BudgetType.POOL
-                # NB two different "trials" meet here. TRIAL_OVER_DAYS /
-                # days_remaining above are the 30-day free trial of a real,
-                # signed-up member. This flag is the *anonymous* trial team
-                # (AI_TRIAL_TEAM_EMAIL) — a permanent container for unrelated
-                # trial users, not a customer working through a trial period.
-                # Its freshness therefore runs out and never renews, so every
-                # lifecycle rule keyed on that fires against it forever.
-                is_anonymous_trial_team = is_ai_trial_team(team)
 
                 # Check if team was monitored within 24 hours
                 should_send_notifications = settings.ENABLE_LIMITS
@@ -2435,7 +2425,7 @@ async def monitor_teams(db: Session):
                 # POOL teams have their own lifecycle and are excluded from trial notifications.
                 team_freshness = _monitor_team_freshness(team, db)
                 days_remaining = TRIAL_OVER_DAYS - team_freshness
-                if not is_pool_team and not is_anonymous_trial_team:
+                if not is_pool_team and not is_anonymous_trial_team(team):
                     _send_expiry_notification(
                         db,
                         team,
@@ -2452,18 +2442,17 @@ async def monitor_teams(db: Session):
                 # Expire if team trial has expired (if team has a product, expiry will be handled by Stripe)
                 # POOL teams are always exempt from trial expiration.
                 #
-                # So is the anonymous-trial team, and it MUST be. Its keys belong
-                # to thousands of unrelated users, and this branch expires every
-                # key in every region the team holds one in. Because the team's
-                # own freshness expired long ago and never renews, leaving it in
-                # scope re-expires every trial key — including ones minted
-                # minutes earlier — on each run that passes the 24h notification
-                # gate. Per-user budget enforcement is a separate mechanism
-                # (monitor_trial_users) and is unaffected by this exemption.
+                # The anonymous-trial team is exempt too. Its freshness ran
+                # out long ago and never renews, so leaving it in scope expires
+                # every trial key in every region on each run. Per-user budget
+                # limits are enforced separately by monitor_trial_users.
+                #
+                # Note the two unrelated meanings of "trial" here:
+                # days_remaining is a real member's 30-day trial.
                 if (
                     not has_products
                     and not is_pool_team
-                    and not is_anonymous_trial_team
+                    and not is_anonymous_trial_team(team)
                     and days_remaining <= 0
                     and should_send_notifications
                 ):

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -2414,11 +2414,14 @@ async def monitor_teams(db: Session):
 
                 # Now handle trial expiry notifications and key expiry (after retention checks)
                 is_pool_team = team.budget_type == BudgetType.POOL
-                # The anonymous-trial team is a permanent container for trial
-                # users, not a customer working through a trial period. Its
-                # freshness therefore runs out and never renews, and every
-                # lifecycle rule keyed on that would fire against it forever.
-                is_trial_team = is_ai_trial_team(team)
+                # NB two different "trials" meet here. TRIAL_OVER_DAYS /
+                # days_remaining above are the 30-day free trial of a real,
+                # signed-up member. This flag is the *anonymous* trial team
+                # (AI_TRIAL_TEAM_EMAIL) — a permanent container for unrelated
+                # trial users, not a customer working through a trial period.
+                # Its freshness therefore runs out and never renews, so every
+                # lifecycle rule keyed on that fires against it forever.
+                is_anonymous_trial_team = is_ai_trial_team(team)
 
                 # Check if team was monitored within 24 hours
                 should_send_notifications = settings.ENABLE_LIMITS
@@ -2432,7 +2435,7 @@ async def monitor_teams(db: Session):
                 # POOL teams have their own lifecycle and are excluded from trial notifications.
                 team_freshness = _monitor_team_freshness(team, db)
                 days_remaining = TRIAL_OVER_DAYS - team_freshness
-                if not is_pool_team and not is_trial_team:
+                if not is_pool_team and not is_anonymous_trial_team:
                     _send_expiry_notification(
                         db,
                         team,
@@ -2460,7 +2463,7 @@ async def monitor_teams(db: Session):
                 if (
                     not has_products
                     and not is_pool_team
-                    and not is_trial_team
+                    and not is_anonymous_trial_team
                     and days_remaining <= 0
                     and should_send_notifications
                 ):

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -35,6 +35,7 @@ from app.services.ses import SESService
 from app.core.team_service import (
     get_team_keys_by_region,
     get_team_region_litellm_keys,
+    is_ai_trial_team,
     soft_delete_team,
 )
 from app.db.database import get_db
@@ -2095,6 +2096,14 @@ async def _check_team_retention_policy(
     if team.budget_type == BudgetType.POOL:
         return
 
+    # So is the anonymous-trial team. Activity is measured from its newest user
+    # or key, so a lull in trial signups long enough to cross the inactivity
+    # threshold would soft-delete the team that owns every trial key — and the
+    # hard-delete job then removes those keys, their users and the team across
+    # every region. It cannot be allowed to depend on signup volume.
+    if is_ai_trial_team(team):
+        return
+
     # Check team retention policy (only for non-deleted teams)
     if team.deleted_at:
         return  # Team already soft-deleted, skip retention check
@@ -2405,6 +2414,11 @@ async def monitor_teams(db: Session):
 
                 # Now handle trial expiry notifications and key expiry (after retention checks)
                 is_pool_team = team.budget_type == BudgetType.POOL
+                # The anonymous-trial team is a permanent container for trial
+                # users, not a customer working through a trial period. Its
+                # freshness therefore runs out and never renews, and every
+                # lifecycle rule keyed on that would fire against it forever.
+                is_trial_team = is_ai_trial_team(team)
 
                 # Check if team was monitored within 24 hours
                 should_send_notifications = settings.ENABLE_LIMITS
@@ -2418,7 +2432,7 @@ async def monitor_teams(db: Session):
                 # POOL teams have their own lifecycle and are excluded from trial notifications.
                 team_freshness = _monitor_team_freshness(team, db)
                 days_remaining = TRIAL_OVER_DAYS - team_freshness
-                if not is_pool_team:
+                if not is_pool_team and not is_trial_team:
                     _send_expiry_notification(
                         db,
                         team,
@@ -2434,9 +2448,19 @@ async def monitor_teams(db: Session):
 
                 # Expire if team trial has expired (if team has a product, expiry will be handled by Stripe)
                 # POOL teams are always exempt from trial expiration.
+                #
+                # So is the anonymous-trial team, and it MUST be. Its keys belong
+                # to thousands of unrelated users, and this branch expires every
+                # key in every region the team holds one in. Because the team's
+                # own freshness expired long ago and never renews, leaving it in
+                # scope re-expires every trial key — including ones minted
+                # minutes earlier — on each run that passes the 24h notification
+                # gate. Per-user budget enforcement is a separate mechanism
+                # (monitor_trial_users) and is unaffected by this exemption.
                 if (
                     not has_products
                     and not is_pool_team
+                    and not is_trial_team
                     and days_remaining <= 0
                     and should_send_notifications
                 ):

--- a/scripts/restrict_trial_key_routes.py
+++ b/scripts/restrict_trial_key_routes.py
@@ -22,7 +22,7 @@ from collections import defaultdict
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from app.core.team_service import is_ai_trial_team
+from app.core.team_service import is_anonymous_trial_team
 from app.db.database import SessionLocal
 from app.db.models import DBPrivateAIKey, DBRegion, DBTeam, DBUser
 from app.services.litellm import INFERENCE_ONLY_ROUTES, LiteLLMService
@@ -31,7 +31,7 @@ from app.services.litellm import INFERENCE_ONLY_ROUTES, LiteLLMService
 def get_trial_keys_grouped_by_region(session):
     """Return trial-team LiteLLM keys grouped by region_id."""
     trial_team_ids = [
-        team.id for team in session.query(DBTeam).all() if is_ai_trial_team(team)
+        team.id for team in session.query(DBTeam).all() if is_anonymous_trial_team(team)
     ]
     if not trial_team_ids:
         return defaultdict(list)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3631,3 +3631,115 @@ async def test_invoice_ledger_duplicate_invoice_id_is_idempotent(
         f"Double-allocation detected: consumed_cents={topup_entry.consumed_cents}, "
         "expected at most 100¢ from a single FIFO run"
     )
+
+
+@pytest.mark.asyncio
+@patch("app.core.worker.LimitService")
+@patch("app.core.worker.SESService")
+@patch("app.core.worker.LiteLLMService")
+@patch("app.core.config.settings.ENABLE_LIMITS", True)
+async def test_monitor_teams_does_not_expire_anonymous_trial_team_keys(
+    mock_litellm,
+    mock_ses,
+    mock_limit_service,
+    db,
+    test_region,
+):
+    """The anonymous-trial team must never have its keys expired wholesale.
+
+    Its keys belong to thousands of unrelated users, and this branch expires
+    every key in every region the team holds one in. The team's own freshness
+    expired long ago and never renews, so without an exemption every trial key
+    is re-expired on each run that passes the 24h notification gate — including
+    keys minted minutes earlier.
+    """
+    from app.core.config import settings
+    from app.db.models import DBUser  # noqa: F811
+    trial_team = DBTeam(
+        name="AI Trial Team",
+        admin_email=settings.AI_TRIAL_TEAM_EMAIL,
+        is_active=True,
+        created_at=datetime.now(UTC) - timedelta(days=200),
+    )
+    db.add(trial_team)
+    db.commit()
+    db.refresh(trial_team)
+
+    trial_user = DBUser(
+        email="trial-1-abc@example.com",
+        team_id=trial_team.id,
+        is_active=True,
+        role="user",
+    )
+    db.add(trial_user)
+    db.commit()
+    db.refresh(trial_user)
+
+    # Minted moments ago — exactly the key the old behaviour destroyed.
+    fresh_key = DBPrivateAIKey(
+        name="Trial Key for trial-1-abc@example.com",
+        database_name="db_trial_1",
+        database_username="u_trial_1",
+        database_password="pw",
+        owner_id=trial_user.id,
+        team_id=trial_team.id,
+        region_id=test_region.id,
+        litellm_token="trial_token_1",
+        created_at=datetime.now(UTC),
+    )
+    db.add(fresh_key)
+    db.commit()
+
+    mock_litellm_instance = mock_litellm.return_value
+    mock_litellm_instance.get_key_info = AsyncMock(
+        return_value={
+            "info": {"spend": 0.0, "max_budget": 2.0, "key_alias": "trial-key"}
+        }
+    )
+    mock_litellm_instance.update_key_duration = AsyncMock()
+
+    mock_limit_instance = mock_limit_service.return_value
+    mock_limit_instance.set_team_limits = Mock()
+
+    await monitor_teams(db)
+
+    mock_litellm_instance.update_key_duration.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("app.core.worker.LimitService")
+@patch("app.core.worker.SESService")
+@patch("app.core.worker.LiteLLMService")
+@patch("app.core.config.settings.ENABLE_LIMITS", True)
+async def test_monitor_teams_does_not_retire_anonymous_trial_team(
+    mock_litellm,
+    mock_ses,
+    mock_limit_service,
+    db,
+    test_region,
+):
+    """Inactivity must never soft-delete the team that owns every trial key.
+
+    Activity is measured from the newest trial user or key, so a long enough
+    lull in signups would otherwise start the retention clock — and the
+    hard-delete job then removes the keys, users and team across every region.
+    """
+    from app.core.config import settings
+    trial_team = DBTeam(
+        name="AI Trial Team",
+        admin_email=settings.AI_TRIAL_TEAM_EMAIL,
+        is_active=True,
+        created_at=datetime.now(UTC) - timedelta(days=400),
+    )
+    db.add(trial_team)
+    db.commit()
+    db.refresh(trial_team)
+
+    mock_limit_instance = mock_limit_service.return_value
+    mock_limit_instance.set_team_limits = Mock()
+
+    await monitor_teams(db)
+
+    db.refresh(trial_team)
+    assert trial_team.retention_warning_sent_at is None
+    assert trial_team.deleted_at is None

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3645,13 +3645,10 @@ async def test_monitor_teams_does_not_expire_anonymous_trial_team_keys(
     db,
     test_region,
 ):
-    """The anonymous-trial team must never have its keys expired wholesale.
+    """A trial key minted moments ago must survive monitor_teams.
 
-    Its keys belong to thousands of unrelated users, and this branch expires
-    every key in every region the team holds one in. The team's own freshness
-    expired long ago and never renews, so without an exemption every trial key
-    is re-expired on each run that passes the 24h notification gate — including
-    keys minted minutes earlier.
+    The trial team's freshness ran out long ago, so without an exemption every
+    trial key is expired on each run.
     """
     from app.core.config import settings
     from app.db.models import DBUser  # noqa: F811
@@ -3718,11 +3715,9 @@ async def test_monitor_teams_does_not_retire_anonymous_trial_team(
     db,
     test_region,
 ):
-    """Inactivity must never soft-delete the team that owns every trial key.
+    """A quiet trial team must not be retired for inactivity.
 
-    Activity is measured from the newest trial user or key, so a long enough
-    lull in signups would otherwise start the retention clock — and the
-    hard-delete job then removes the keys, users and team across every region.
+    Retiring it would soft-delete the team that owns every trial key.
     """
     from app.core.config import settings
     trial_team = DBTeam(


### PR DESCRIPTION
## Why

`monitor_teams` treats a team whose freshness has run out as an expired trial and calls `reconcile_team_keys(expire_keys=True)` (`worker.py:2483`). That function loops `for region, keys in keys_by_region.items()` and sets `duration: "0d"` on **every key in every region the team holds one in** (`worker.py:1817`).

The anonymous-trial team is caught by this, and always will be:

| Condition (`worker.py:2436-2447`) | Trial team | Met |
|---|---|---|
| `not has_products` | no product rows | yes |
| `not is_pool_team` | `budget_type = periodic` | yes |
| `days_remaining <= 0` | freshness measured from its own creation date, long past, never renews | yes |
| `should_send_notifications` | true whenever `last_monitored` is over 24h old | yes |

So on every run that clears the 24-hour notification gate, every trial key the team owns is expired — including keys minted minutes earlier. **A trial key stops authenticating within a day of being issued.** That is why essentially none of them ever record spend: for the most part they could not be used.

Verified on production: a set of trial keys was restored to correct expiries and confirmed working with live inference calls; within the hour the next sweep had expired all of them again.

The trial team is a permanent container for thousands of unrelated users, not a customer working through a trial period, so team-level trial expiry is meaningless for it. This exempts it, exactly as POOL teams already are on the same condition.

## Also exempted

Two adjacent rules keyed on the same freshness:

- **The expiry notification email.** Its recipient is the team's synthetic `admin_email`, so it goes nowhere useful.
- **Inactivity retention.** Activity is measured from the newest trial user or key, so a long enough lull in signups would cross the threshold and soft-delete the team that owns every trial key — after which `hard_delete_expired_teams` removes those keys, their users and the team across every region. Currently latent, because constant signups keep it looking active. It should not depend on signup volume.

## What is deliberately unchanged

- **Per-user budget enforcement.** `monitor_trial_users` still deactivates a trial user who spends their allowance and expires their key. That is the mechanism that *should* expire a trial key.
- **Spend monitoring.** `reconcile_team_keys` still runs for the trial team, just with `expire_keys=False`, so spend is still read from LiteLLM and per-user totals still accumulate.
- **Every other team.** See below.

## Scope

The whole change is six lines:

```
+    is_ai_trial_team,                                   # import
+    if is_ai_trial_team(team):  return                  # retention guard
+                is_trial_team = is_ai_trial_team(team)  # the flag
-                if not is_pool_team:
+                if not is_pool_team and not is_trial_team:
+                    and not is_trial_team
```

Every gate is `is_ai_trial_team(team)`, which matches on `admin_email == AI_TRIAL_TEAM_EMAIL`, case-insensitive, no plus-tag stripping. That is one team. For any other team `is_trial_team` is `False`, all three conditions evaluate as before, and the retention guard returns without acting. No behaviour change for paying teams, POOL teams, or Drupal-provisioned keys.

## Testing

`make backend-test-regex regex="anonymous_trial_team or monitor_teams or reconcile_team_keys"` — 47 passed. Ruff clean.

Two new regression tests:

- a trial key minted moments ago survives `monitor_teams` on a 200-day-old trial team
- a 400-day-old trial team gets no retention warning and no soft delete

The existing `reconcile_team_keys_expired_key` and `monitor_teams_pool_team_*` tests still pass, so expiry still works for the teams it is meant to work for.

## Note on remediation

Restoring already-expired trial keys is pointless until this ships — the next sweep undoes it. Once merged and deployed, existing expired keys stay expired; whether to restore them is a separate operational decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR exempts the permanent anonymous-trial team from team-level retention, expiry notifications, and wholesale key expiration while preserving per-key spend reconciliation and per-user trial enforcement.
- Adds anonymous-trial guards to retention and expired-team key handling.
- Keeps `reconcile_team_keys` active with key expiration disabled.
- Adds regression tests covering fresh-key preservation and retention exemption.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable changed-code failures identified.

The anonymous-trial guards prevent inappropriate team-level expiration and retention while subsequent spend reconciliation and separate per-user trial enforcement remain reachable.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/core/worker.py | Correctly scopes all three team-lifecycle exemptions to `is_ai_trial_team` without bypassing reconciliation or independent per-user enforcement. |
| tests/test_worker.py | Adds focused regression coverage for wholesale key expiration and inactivity-based retirement of the anonymous-trial team. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trial): exempt the anonymous-trial t..."](https://github.com/amazeeio/amazee.ai/commit/271c6c20fdc733eb747dbfa5789934fa91788b43) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49676246)</sub>

**Context used:**

- Knowledge Base — [Background/Periodic Jobs (worker + internal trigger API)](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/worker-background-jobs.md)

<!-- /greptile_comment -->