### PR TITLE
fix(spend): canonicalise word-form budget durations and unblock budget-row deletes

### DIFF
--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -46,6 +46,7 @@ from app.core.limit_service import (
     DEFAULT_RPM_PER_KEY,
 )
 from app.core.pool_budget_service import pool_team_has_ever_purchased
+from app.core.spend_period_service import canonical_budget_duration
 from app.core.team_service import is_anonymous_trial_team
 
 router = APIRouter(tags=["private-ai-keys"])
@@ -1140,7 +1141,9 @@ async def update_budget_period(
     3. Return the updated spend information
 
     Required parameters:
-    - **budget_duration**: The new budget period (e.g. "monthly", "weekly", "daily")
+    - **budget_duration**: The new budget period. Accepts canonical forms such
+      as "30d", "7d" or "24h", and the word forms "monthly", "weekly", "daily"
+      and "hourly", which are stored in their canonical equivalent.
 
     Note: You must be authenticated to use this endpoint.
     Only the owner of the key or an admin can update it.
@@ -1159,10 +1162,12 @@ async def update_budget_period(
     )
 
     try:
-        # Update budget period in LiteLLM
+        # Canonicalise before writing. A word form stored on the key leaves it
+        # with no computable period start, so period spend and budget alerts go
+        # blank for that key.
         await litellm_service.update_budget(
             litellm_token=private_ai_key.litellm_token,
-            budget_duration=budget_update.budget_duration,
+            budget_duration=canonical_budget_duration(budget_update.budget_duration),
         )
 
         # Get updated spend information

--- a/app/api/teams.py
+++ b/app/api/teams.py
@@ -25,6 +25,7 @@ from app.core.litellm_user_sync import sync_add_user_to_team, sync_remove_user_f
 from app.core.worker import generate_pricing_url, get_team_admin_email
 from app.db.database import get_db
 from app.db.models import (
+    DBBudgetAlertState,
     DBPrivateAIKey,
     DBProduct,
     DBRegion,
@@ -434,6 +435,17 @@ async def delete_team(team_id: int, db: Session = Depends(get_db)):
 
     # Remove all product associations
     db.query(DBTeamProduct).filter(DBTeamProduct.team_id == team_id).delete()
+
+    # Budget rows reference the team without a cascade, so a team that ever had a
+    # team or member budget, or fired a budget alert, cannot be deleted until
+    # they are cleared. Both only describe spend limits, so they die with the
+    # team. Deleting by team_id also covers team_member-scoped caps.
+    db.query(DBSpendCap).filter(DBSpendCap.team_id == team_id).delete(
+        synchronize_session=False
+    )
+    db.query(DBBudgetAlertState).filter(DBBudgetAlertState.team_id == team_id).delete(
+        synchronize_session=False
+    )
 
     # Delete the team
     db.delete(db_team)

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -32,6 +32,7 @@ from app.schemas.models import (
     UserMarketingUpdatesByEmailUpdate,
 )
 from app.db.models import (
+    DBBudgetAlertState,
     DBPrivateAIKey,
     DBRegion,
     DBSpendCap,
@@ -1213,6 +1214,17 @@ async def delete_user(
         )
 
     team_id = db_user.team_id
+
+    # Budget rows reference the user without a cascade, so a user who ever had a
+    # member budget or fired a budget alert cannot be deleted until they are
+    # cleared. Both only describe spend limits, so they die with the user.
+    db.query(DBSpendCap).filter(DBSpendCap.user_id == user_id).delete(
+        synchronize_session=False
+    )
+    db.query(DBBudgetAlertState).filter(DBBudgetAlertState.user_id == user_id).delete(
+        synchronize_session=False
+    )
+
     db.delete(db_user)
     try:
         db.commit()

--- a/app/core/spend_period_service.py
+++ b/app/core/spend_period_service.py
@@ -20,6 +20,30 @@ from app.schemas.models import BudgetType
 from app.services.litellm import LiteLLMService
 
 
+# Word-form budget durations accepted at our API boundary, mapped to the
+# canonical forms LiteLLM and our period maths both understand. Storing a word
+# form leaves the key with no computable period start, because the parsers below
+# only match "1mo" and "<int><unit>".
+_WORD_FORM_DURATIONS = {
+    "hourly": "1h",
+    "daily": "24h",
+    "weekly": "7d",
+    "monthly": "30d",
+}
+
+
+def canonical_budget_duration(budget_duration: str | None) -> str | None:
+    """Map a word-form budget duration to its canonical form.
+
+    Anything already canonical, or unrecognised, is passed through unchanged so
+    LiteLLM stays the authority on what is valid.
+    """
+    if not budget_duration:
+        return budget_duration
+    key = str(budget_duration).strip().lower()
+    return _WORD_FORM_DURATIONS.get(key, budget_duration)
+
+
 def _to_int_or_none(value: Any) -> int | None:
     if value is None:
         return None
@@ -67,6 +91,10 @@ def current_cycle_start(
     if not budget_duration:
         return None
 
+    # Keys written before durations were canonicalised on write may still carry
+    # a word form, which would otherwise fall through as unparseable.
+    budget_duration = canonical_budget_duration(budget_duration)
+
     if budget_duration in ("1mo", "30d"):
         return now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
 
@@ -101,6 +129,10 @@ def compute_period_start(
     """
     if budget_reset_at is None or not budget_duration:
         return None
+
+    # Keys written before durations were canonicalised on write may still carry
+    # a word form, which would otherwise fall through as unparseable.
+    budget_duration = canonical_budget_duration(budget_duration)
 
     # Handle "1mo" / "30d" — both snap to 1st of next calendar month
     # so the period start is always the 1st of the current month.

--- a/tests/test_budget_alerts.py
+++ b/tests/test_budget_alerts.py
@@ -1567,10 +1567,19 @@ def test_current_cycle_start_rolls_forward_to_contain_now():
 
     # 1mo snaps to the calendar month, matching LiteLLM's own boundary.
     assert current_cycle_start("1mo", anchor, now) == datetime(2026, 7, 1, tzinfo=UTC)
-    # An anchor in the future is left alone, and junk yields nothing.
+    # An anchor in the future is left alone.
     future = now + timedelta(days=5)
     assert current_cycle_start("31d", future, now) == future
-    assert current_cycle_start("weekly", anchor, now) is None
+
+    # A stored word form canonicalises, so it resolves to a real cycle instead
+    # of silently yielding no window.
+    weekly = current_cycle_start("weekly", anchor, now)
+    assert weekly == current_cycle_start("7d", anchor, now)
+    assert weekly is not None
+    assert weekly <= now < weekly + timedelta(days=7)
+
+    # Genuine junk still yields nothing.
+    assert current_cycle_start("nonsense", anchor, now) is None
     assert current_cycle_start(None, anchor, now) is None
 
 

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -1378,13 +1378,14 @@ def test_update_budget_duration_as_team_admin(
     data = response.json()
     assert data["budget_duration"] == "monthly"
 
-    # Verify that the LiteLLM API was called with the correct parameters
+    # The word form is canonicalised before it reaches LiteLLM, so the key does
+    # not end up carrying a duration our period maths cannot parse.
     mock_httpx_combined_client.post.assert_called_with(
         f"{test_region.litellm_api_url}/key/update",
         headers={"Authorization": f"Bearer {test_region.litellm_api_key}"},
         json={
             "key": test_key.litellm_token,
-            "budget_duration": "monthly",
+            "budget_duration": "30d",
             "duration": "365d",
         },
     )

--- a/tests/test_spend_period_service.py
+++ b/tests/test_spend_period_service.py
@@ -2,6 +2,8 @@ from datetime import UTC, datetime, timedelta
 
 from app.core.config import settings
 from app.core.spend_period_service import (
+    canonical_budget_duration,
+    compute_period_start,
     resolve_team_period_window,
     upsert_team_spend_period,
 )
@@ -226,3 +228,51 @@ def test_pool_window_ignores_topups_when_a_subscription_is_active(
     assert window.source == "subscription_ledger"
     assert 10 <= (now - window.period_start).days <= 12
     assert window.budget_duration == "31d"
+
+
+def test_canonical_budget_duration_maps_word_forms():
+    """
+    GIVEN: A budget duration written as a word
+    WHEN: It is canonicalised
+    THEN: The canonical equivalent is returned
+    """
+    assert canonical_budget_duration("hourly") == "1h"
+    assert canonical_budget_duration("daily") == "24h"
+    assert canonical_budget_duration("weekly") == "7d"
+    assert canonical_budget_duration("monthly") == "30d"
+
+
+def test_canonical_budget_duration_is_case_and_space_insensitive():
+    assert canonical_budget_duration(" Monthly ") == "30d"
+    assert canonical_budget_duration("WEEKLY") == "7d"
+
+
+def test_canonical_budget_duration_passes_through_unrecognised():
+    """LiteLLM stays the authority on what is valid, so nothing else is rewritten."""
+    for value in ("30d", "7d", "24h", "1h", "1mo", "31d", "nonsense"):
+        assert canonical_budget_duration(value) == value
+    assert canonical_budget_duration(None) is None
+    assert canonical_budget_duration("") == ""
+
+
+def test_word_form_and_canonical_agree_on_period_start():
+    """
+    GIVEN: A word-form duration and its canonical equivalent
+    WHEN: The period start is computed for each
+    THEN: Both yield the same value, and the word form is no longer None
+    """
+    reset_at = datetime(2026, 9, 1, tzinfo=UTC)
+    for word, canonical in (
+        ("monthly", "30d"),
+        ("weekly", "7d"),
+        ("daily", "24h"),
+        ("hourly", "1h"),
+    ):
+        via_word = compute_period_start(reset_at, canonical_budget_duration(word))
+        via_canonical = compute_period_start(reset_at, canonical)
+        assert via_word == via_canonical
+        assert via_word is not None
+
+        # Read-side safety net: keys already carrying a word form resolve too,
+        # so no data migration is needed.
+        assert compute_period_start(reset_at, word) == via_canonical

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -5,9 +5,11 @@ from app.core.config import settings
 from app.core.limit_service import LimitService, setup_default_limits
 from app.core.security import get_password_hash
 from app.db.models import (
+    DBBudgetAlertState,
     DBPrivateAIKey,
     DBProduct,
     DBRegion,
+    DBSpendCap,
     DBTeam,
     DBTeamProduct,
     DBTeamRegion,
@@ -2368,3 +2370,64 @@ def test_restored_team_keys_are_accessible(
     keys = response.json()
     key_names = [k.get("name") for k in keys]
     assert "restored-key" in key_names
+
+
+def test_delete_team_with_budget_rows(client, admin_token, db, test_team, test_region):
+    """
+    GIVEN: A team with a team spend cap, a member spend cap and a budget alert state row
+    WHEN: The team is deleted
+    THEN: A 200 is returned and every budget row for the team is gone
+
+    Both tables reference teams.id without a cascade, so before this was fixed
+    the delete raised a foreign key violation and surfaced as a 500.
+    """
+    member = DBUser(email="team-budget-member@example.com", team_id=test_team.id)
+    db.add(member)
+    db.commit()
+    db.refresh(member)
+
+    db.add_all(
+        [
+            DBSpendCap(
+                scope="team",
+                region_id=test_region.id,
+                team_id=test_team.id,
+                max_budget=20.0,
+                budget_duration="31d",
+            ),
+            DBSpendCap(
+                scope="team_member",
+                region_id=test_region.id,
+                team_id=test_team.id,
+                user_id=member.id,
+                max_budget=3.0,
+                budget_duration="1mo",
+            ),
+            DBBudgetAlertState(
+                subject_key=f"team:{test_team.id}",
+                subject_type="team",
+                region_id=test_region.id,
+                team_id=test_team.id,
+                period_key="2026-08",
+            ),
+        ]
+    )
+    db.commit()
+    team_id = test_team.id
+
+    with patch(
+        "app.api.teams.LiteLLMService.update_team_budget", new_callable=AsyncMock
+    ):
+        response = client.delete(
+            f"/teams/{team_id}", headers={"Authorization": f"Bearer {admin_token}"}
+        )
+    assert response.status_code == 200
+
+    assert db.query(DBTeam).filter(DBTeam.id == team_id).first() is None
+    assert db.query(DBSpendCap).filter(DBSpendCap.team_id == team_id).count() == 0
+    assert (
+        db.query(DBBudgetAlertState)
+        .filter(DBBudgetAlertState.team_id == team_id)
+        .count()
+        == 0
+    )

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,4 +1,5 @@
 from app.db.models import (
+    DBBudgetAlertState,
     DBRegion,
     DBSpendCap,
     DBUser,
@@ -1489,3 +1490,57 @@ def test_sign_in_creates_user_with_default_limits(client, db):
     )
     assert budget_limit is None  # Should be inherited from team, not user-specific
     assert rpm_limit is None  # Should be inherited from team, not user-specific
+
+
+def test_delete_user_with_member_budget_and_alert_state(
+    client, admin_token, db, test_team, test_region
+):
+    """
+    GIVEN: A user who has a team member spend cap and a budget alert state row
+    WHEN: The user is deleted
+    THEN: A 200 is returned and both budget rows are gone
+
+    Both tables reference users.id without a cascade, so before this was fixed
+    the delete raised a foreign key violation and surfaced as a 500.
+    """
+    user = DBUser(email="member-budget@example.com", team_id=test_team.id)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    db.add(
+        DBSpendCap(
+            scope="team_member",
+            region_id=test_region.id,
+            team_id=test_team.id,
+            user_id=user.id,
+            max_budget=3.0,
+            budget_duration="1mo",
+        )
+    )
+    db.add(
+        DBBudgetAlertState(
+            subject_key=f"team_member:{test_team.id}:{user.id}",
+            subject_type="team_member",
+            region_id=test_region.id,
+            team_id=test_team.id,
+            user_id=user.id,
+            period_key="2026-08",
+        )
+    )
+    db.commit()
+    user_id = user.id
+
+    response = client.delete(
+        f"/users/{user_id}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert response.status_code == 200
+
+    assert db.query(DBUser).filter(DBUser.id == user_id).first() is None
+    assert db.query(DBSpendCap).filter(DBSpendCap.user_id == user_id).count() == 0
+    assert (
+        db.query(DBBudgetAlertState)
+        .filter(DBBudgetAlertState.user_id == user_id)
+        .count()
+        == 0
+    )


### PR DESCRIPTION
Fixes the two bugs in amazeeio/moad#671. Both are pre-existing — each was reproduced on LiteLLM 1.94.0 as well as 1.95.0 — and neither is caused by the upgrade they were found during.

## 1. Word-form `budget_duration` left keys with no period start

`PUT /private-ai-keys/{id}/budget-period` documented its input as `"monthly"` / `"weekly"` / `"daily"` and passed the string straight to LiteLLM. But `compute_period_start` and `current_cycle_start` only match `1mo` and `<int><unit>`, so a word form returned `None` and period spend plus budget alerts went blank for that key.

New `canonical_budget_duration()` maps `hourly→1h`, `daily→24h`, `weekly→7d`, `monthly→30d`, and passes anything else through so LiteLLM stays the authority on validity.

Applied in two places:

- **On write**, in the endpoint — the key never ends up storing a duration we cannot parse.
- **On read**, in both period parsers — keys already carrying a word form resolve too, so no data migration is needed.

`monthly→30d` keeps the reset boundary identical: verified on DEV that both `monthly` and `30d` yield `budget_reset_at = 2026-09-01`.

## 2. Budget rows blocked user and team deletion with a 500

`spend_caps.user_id`, `spend_caps.team_id`, `budget_alert_state.user_id` and `budget_alert_state.team_id` are foreign keys with **no cascade**, and neither delete path cleared them. Any user or team that had ever had a member budget set, or fired a budget alert, hit a foreign key violation that surfaced as a 500.

`delete_user` and `delete_team` now clear both tables first. Deleting the caps by `team_id` also covers `team_member`-scoped rows.

Scope note: the ticket only proved the `spend_caps` path. `budget_alert_state` has the identical missing cascade on the same two columns and would re-open the same ticket the first time an alert fired, so it is fixed here too.

## Verification

- Full backend suite: **1298 passed, 2 skipped**. `make lint` clean.
- Root cause of bug 2 isolated on DEV by elimination — a plain team+user deletes fine, adding a periodic purchase still deletes fine, adding a member budget produces the 500 on both LiteLLM versions.

Two existing tests asserted the old behaviour and were updated, which is the point worth reviewing:

- `test_update_budget_duration_as_team_admin` asserted we send `"monthly"` to `/key/update`; now `"30d"`.
- `test_current_cycle_start_rolls_forward_to_contain_now` asserted `current_cycle_start("weekly", ...) is None` as "junk yields nothing"; now `weekly` resolves, and a genuine junk case was added in its place.

The shared conftest mocks that return `budget_duration: "monthly"` from `/key/info` were deliberately left alone — a pre-existing key can still legitimately carry a word form, since this changes what we write, not what is already stored.

New tests: canonicalisation mapping, case and whitespace handling, pass-through, word form and canonical agreeing on `period_start`, and the two deletion regressions.

## Not included

Purging the three leftover DEV users from moad#671 (12937, 12973, 12974) — they are deactivated and unblocked by this change, but deleting them is an environment action, not a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkVUaCBfHCyw64XrZa3FVc

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR repairs period calculations for legacy word-form budget durations and removes budget-related foreign-key blockers from user and team deletion.
- Canonicalizes supported duration aliases before writing them to LiteLLM and when parsing existing values.
- Deletes spend-cap and budget-alert state rows before deleting their referenced user or team.
- Adds regression coverage for canonicalization, period calculations, and deletion with dependent budget rows.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The canonicalization is applied consistently on writes and legacy reads, while the new parent-deletion cleanup matches the foreign-key fields populated by current spend-cap and alert-state creation paths.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/core/spend_period_service.py | Adds duration-alias canonicalization on both legacy read paths while preserving pass-through validation by LiteLLM. |
| app/api/private_ai_keys.py | Canonicalizes budget-period aliases before updating the key in LiteLLM. |
| app/api/teams.py | Removes team-referencing spend-cap and alert-state rows before hard deletion. |
| app/api/users.py | Removes user-referencing spend-cap and alert-state rows before hard deletion. |
| tests/test_spend_period_service.py | Covers alias mapping, normalization, pass-through behavior, and equivalent period calculations. |
| tests/test_teams.py | Adds regression coverage for deleting teams with dependent budget records. |
| tests/test_users.py | Adds regression coverage for deleting users with member-budget and alert-state records. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Budget duration input] --> B[Canonicalize word form]
    B --> C[Write canonical duration to LiteLLM]
    C --> D[Read key budget state]
    D --> E[Canonicalize legacy value]
    E --> F[Compute current spend period]

    G[Delete user or team] --> H[Delete spend-cap rows]
    H --> I[Delete budget-alert state]
    I --> J[Delete parent row]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(spend): canonicalise word-form budge..."](https://github.com/amazeeio/amazee.ai/commit/d018b12ae0385f3f5b26b5513afe3bff79f39e38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49743837)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Budgets and Spend Limits](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/budgets-spend.md)
- Knowledge Base — [Private AI Keys and LiteLLM Integration](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/private-ai-keys-litellm.md)
- Knowledge Base — [Teams and Users](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/teams-users.md)
</details>

<!-- /greptile_comment -->