### PR TITLE
fix(regions): restore multi-region visibility for team members

### DIFF
--- a/app/api/regions.py
+++ b/app/api/regions.py
@@ -178,22 +178,61 @@ async def list_regions(
 
     # Regular users can only see non-dedicated regions
     if not current_user.team_id:
-        return (
-            db.query(DBRegion)
-            .filter(DBRegion.is_active.is_(True), DBRegion.is_dedicated.is_(False))
-            .all()
-        )
+        return _active_public_regions(db)
 
-    # Team members can only see their team's single assigned region.
     team = db.query(DBTeam).filter(DBTeam.id == current_user.team_id).first()
-    if not team or not team.region_id:
-        return []
-    region = (
+    if not team:
+        return _active_public_regions(db)
+
+    # The team's own regions: its explicit allowlist plus its primary region.
+    # Both are read because they model different things — the allowlist is the
+    # set a team may use, while the scalar records which one it currently sits
+    # in. Reading only the scalar would strand a team on a single region even
+    # when more are assigned, and return nothing at all once that region goes
+    # inactive.
+    assigned = (
         db.query(DBRegion)
-        .filter(DBRegion.id == team.region_id, DBRegion.is_active.is_(True))
-        .first()
+        .outerjoin(DBTeamRegion, DBTeamRegion.region_id == DBRegion.id)
+        .filter(
+            DBRegion.is_active.is_(True),
+            (DBTeamRegion.team_id == team.id) | (DBRegion.id == team.region_id),
+        )
+        .distinct()
+        .all()
     )
-    return [region] if region else []
+
+    # A team holding any dedicated region is served by dedicated infrastructure
+    # and must not be offered the public pool. Teams that only hold public
+    # regions can use any public region.
+    #
+    # Inactive dedicated regions count here, unlike above: retiring a dedicated
+    # region must not quietly hand that team the whole public pool.
+    holds_dedicated_region = (
+        db.query(DBRegion.id)
+        .outerjoin(DBTeamRegion, DBTeamRegion.region_id == DBRegion.id)
+        .filter(
+            DBRegion.is_dedicated.is_(True),
+            (DBTeamRegion.team_id == team.id) | (DBRegion.id == team.region_id),
+        )
+        .first()
+        is not None
+    )
+    if team.hide_public_regions or holds_dedicated_region:
+        return assigned
+
+    by_id = {region.id: region for region in assigned}
+    for region in _active_public_regions(db):
+        by_id.setdefault(region.id, region)
+    return list(by_id.values())
+
+
+def _active_public_regions(db: Session) -> List[DBRegion]:
+    """Active regions in the shared public pool."""
+    return (
+        db.query(DBRegion)
+        .filter(DBRegion.is_active.is_(True), DBRegion.is_dedicated.is_(False))
+        .all()
+    )
 
 
 @router.get(

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -758,8 +758,9 @@ def test_list_regions_team_member_sees_team_dedicated_regions(
 ):
     """
     Given a team member whose team has a dedicated region as its primary region
+      and a public region in its allowlist
     When the team member lists regions
-    Then they should see exactly that dedicated region
+    Then they should see both, and no other public region
     """
     # Create a dedicated region and assign it as the team's primary region
     dedicated_region = (
@@ -792,18 +793,28 @@ def test_list_regions_team_member_sees_team_dedicated_regions(
 
     assert response.status_code == 200
     regions = response.json()
-    assert len(regions) == 1
-    assert regions[0]["name"] == "team-dedicated-region"
+    region_names = {r["name"] for r in regions}
+    assert region_names == {test_region.name, "team-dedicated-region"}
 
 
 def test_list_regions_team_member_with_only_dedicated_assignment(
     client, team_admin_token, db, test_region, test_team
 ):
     """
-    Given a team whose primary region is a dedicated region
+    Given a team whose only assigned region is a dedicated region
     When a team member lists regions
     Then they should only see that dedicated region
     """
+    from app.db.models import DBTeamRegion
+
+    # Remove the default public association so the dedicated region is the
+    # team's only assignment.
+    db.query(DBTeamRegion).filter(
+        DBTeamRegion.team_id == test_team.id,
+        DBTeamRegion.region_id == test_region.id,
+    ).delete()
+    db.commit()
+
     # Create a dedicated region and set it as the team's primary region
     dedicated_region = (
         db.query(DBRegion)
@@ -898,6 +909,138 @@ def test_list_regions_team_member_does_not_see_other_team_dedicated_regions(
     assert regions[0]["name"] == test_region.name
     assert regions[0]["label"] == test_region.label
     assert "other-team-dedicated-region" not in [r["name"] for r in regions]
+
+
+def _make_public_region(db, name):
+    """Create an extra active public region for visibility tests."""
+    region = db.query(DBRegion).filter(DBRegion.name == name).first()
+    if region:
+        return region
+    region = DBRegion(
+        name=name,
+        label=name,
+        postgres_host=f"{name}-host",
+        postgres_port=5432,
+        postgres_admin_user=f"{name}-admin",
+        postgres_admin_password=f"{name}-password",
+        litellm_api_url=f"https://{name}-litellm.com",
+        litellm_api_key=f"{name}-litellm-key",
+        is_active=True,
+        is_dedicated=False,
+    )
+    db.add(region)
+    db.commit()
+    db.refresh(region)
+    return region
+
+
+def test_list_regions_team_member_sees_all_public_regions(
+    client, team_admin_token, db, test_region, test_team
+):
+    """
+    Given a public team pinned to one region and another public region exists
+    When a team member lists regions
+    Then they should see both, so they are free to pick either
+    """
+    other_public = _make_public_region(db, "second-public-region")
+    test_team.region_id = test_region.id
+    db.commit()
+
+    response = client.get(
+        "/regions/", headers={"Authorization": f"Bearer {team_admin_token}"}
+    )
+
+    assert response.status_code == 200
+    region_names = {r["name"] for r in response.json()}
+    assert region_names == {test_region.name, other_public.name}
+
+
+def test_list_regions_team_member_with_inactive_primary_region(
+    client, team_admin_token, db, test_region, test_team
+):
+    """
+    Given a public team pinned to a region that has been deactivated
+    When a team member lists regions
+    Then they should still see the remaining active public regions
+    """
+    retired = _make_public_region(db, "retired-region")
+    retired.is_active = False
+    test_team.region_id = retired.id
+    db.commit()
+
+    response = client.get(
+        "/regions/", headers={"Authorization": f"Bearer {team_admin_token}"}
+    )
+
+    assert response.status_code == 200
+    region_names = {r["name"] for r in response.json()}
+    assert region_names == {test_region.name}
+
+
+def test_list_regions_team_with_retired_dedicated_region_stays_restricted(
+    client, team_admin_token, db, test_region, test_team
+):
+    """
+    Given a team whose only dedicated region has been deactivated
+    When a team member lists regions
+    Then they should not be handed the public pool
+    """
+    from app.db.models import DBTeamRegion
+
+    db.query(DBTeamRegion).filter(
+        DBTeamRegion.team_id == test_team.id,
+        DBTeamRegion.region_id == test_region.id,
+    ).delete()
+    _make_public_region(db, "pool-region")
+
+    retired_dedicated = DBRegion(
+        name="retired-dedicated-region",
+        label="Retired Dedicated Region",
+        postgres_host="retired-dedicated-host",
+        postgres_port=5432,
+        postgres_admin_user="retired-dedicated-admin",
+        postgres_admin_password="retired-dedicated-password",
+        litellm_api_url="https://retired-dedicated-litellm.com",
+        litellm_api_key="retired-dedicated-litellm-key",
+        is_active=False,
+        is_dedicated=True,
+    )
+    db.add(retired_dedicated)
+    db.commit()
+    db.refresh(retired_dedicated)
+
+    test_team.region_id = retired_dedicated.id
+    db.commit()
+
+    response = client.get(
+        "/regions/", headers={"Authorization": f"Bearer {team_admin_token}"}
+    )
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_list_regions_flagged_team_does_not_get_the_public_pool(
+    client, team_admin_token, db, test_region, test_team
+):
+    """
+    Given a team flagged to hide public regions, assigned one public region
+      while a second public region exists
+    When a team member lists regions
+    Then they should see only their assigned region, not the whole public pool
+    """
+    _make_public_region(db, "unassigned-public-region")
+    test_team.hide_public_regions = True
+    test_team.region_id = test_region.id
+    db.commit()
+
+    response = client.get(
+        "/regions/", headers={"Authorization": f"Bearer {team_admin_token}"}
+    )
+
+    assert response.status_code == 200
+    region_names = {r["name"] for r in response.json()}
+    assert region_names == {test_region.name}
 
 
 @patch("app.api.regions.validate_litellm_endpoint")


### PR DESCRIPTION
Fixes amazeeio/moad#672.

## Problem

`GET /regions` returned exactly one region for any user belonging to a team — the scalar `teams.region_id` — and an empty list when that region was inactive. The Drupal `ai_provider_amazeeio` provider feeds this response straight into its region dropdown, so users were locked to a single region after their first key, or could not provision at all.

Commit `43a70a80` introduced this while implementing the moad workspace region lock (moad#381). That lock is right for moad workspaces, but it was applied to the shared `GET /regions` endpoint that Drupal also consumes, and it stopped reading the `team_regions` allowlist that moad#372 had backfilled.

## Change

`list_regions` now resolves a team's regions from both sources and only then decides whether to add the public pool:

- **Assigned** = active regions in `team_regions` ∪ `teams.region_id`. The allowlist is the set a team may use; the scalar records which one it currently sits in. Reading only the scalar stranded teams on one region and returned nothing once it went inactive.
- **Restricted teams** (`hide_public_regions`, or holding any dedicated region) get only their assigned regions. Inactive dedicated regions still count as dedicated, so retiring one cannot quietly hand that team the public pool.
- **Public teams** get their assigned regions plus every active public region.

Nothing else changes. Key creation never validated the region against the caller's team — `create_llm_token` only checks that the region is active — and `_delegate_to_moad` already re-pins the user on a region switch. So no Drupal change is needed.

## Effect on PROD data

| Group | Before | After |
|---|---|---|
| 1108 teams with `team_regions` rows not matching `region_id` | 1 region | their assigned regions + public pool |
| 119 teams pinned to inactive `amazeeai-de103` | `[]` — could not provision | remaining active public regions |
| 19 teams holding a dedicated region | their one region | unchanged |
| 3 teams with `hide_public_regions` | their one region | unchanged |

moad is unaffected: it calls amazee.ai with the admin token (`amazeeai.live.ts:131-132`), so it takes the `is_admin` branch.

## Tests

Two existing tests asserted the narrow behavior and are restored to what they checked before `43a70a80`:

- `test_list_regions_team_member_sees_team_dedicated_regions` — back to "non-dedicated regions plus their team's dedicated regions".
- `test_list_regions_team_member_with_only_dedicated_assignment` — back to deleting the public association first, so the dedicated region really is the only assignment.

Four new tests:

- a public team sees every active public region, not just its pinned one;
- a team pinned to a deactivated region still gets the remaining active ones instead of `[]`;
- a team holding a retired dedicated region stays restricted;
- a `hide_public_regions` team is not given the public pool.

## Follow-up

moad#672 carries an AC to resolve the conflict with moad#372, which is still open and specifies `list_regions` as a pure `team_regions` allowlist. This change keeps a read-time public-region fallback instead, so it needs no migration and self-heals for teams created since #381. If #372's allowlist-only model is still wanted, the writers (`register_team`) and a backfill have to come with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR restores multi-region visibility for team members while preserving restrictions for dedicated and explicitly restricted teams.
- Resolves assigned regions from both `team_regions` and the team's primary `region_id`.
- Adds the active public pool for unrestricted public teams.
- Keeps teams with dedicated assignments or `hide_public_regions` restricted to their active assigned regions.
- Adds regression coverage for public, inactive-primary, retired-dedicated, and hidden-public-region cases.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security failures identified.

The revised query consistently filters returned regions by active status, deduplicates assigned and public regions, and preserves public-pool suppression for dedicated or explicitly restricted teams.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/regions.py | Expands team-member region visibility by combining explicit and primary assignments, with dedicated and hidden-public restrictions preserved. |
| tests/test_region.py | Updates prior expectations and adds focused regression tests for public-pool fallback and restricted-team behavior. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[GET /regions by non-admin] --> B{User has team_id?}
  B -- No --> P[Return active public regions]
  B -- Yes --> C{Team exists?}
  C -- No --> P
  C -- Yes --> D[Load active team_regions union primary region]
  D --> E{hide_public_regions or any dedicated assignment?}
  E -- Yes --> F[Return active assigned regions]
  E -- No --> G[Return assigned regions union active public pool]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(regions): restore multi-region visib..."](https://github.com/amazeeio/amazee.ai/commit/50679409c1ae8f2420cd71b64c499334078c4863) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50020672)</sub>

**Context used:**

- Knowledge Base — [Public Models API, Regions, and Pricing Tables](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/regions-public-pricing.md)

<!-- /greptile_comment -->