### PR TITLE
fix(models): keep vendor casing in public model display names

### DIFF
--- a/app/api/public.py
+++ b/app/api/public.py
@@ -98,11 +98,29 @@ def _apply_profit_margin(price: float | None, margin: float) -> float | None:
     return price * (1 + margin)
 
 
+# Words that must not be title-cased, because the vendor writes them
+# differently (acronyms, lowercase model families).
+_DISPLAY_WORD_OVERRIDES = {
+    "gpt": "GPT",
+    "deepseek": "DeepSeek",
+    "o1": "o1",
+    "o3": "o3",
+    "o4": "o4",
+}
+
+
+def _display_word(word: str) -> str:
+    override = _DISPLAY_WORD_OVERRIDES.get(word.lower())
+    if override:
+        return override
+    return word if word.isupper() else word.capitalize()
+
+
 def _to_display_name(model_id: str, aliases: list[str] | None = None) -> str:
     """Convert a model_id to a human-friendly display name.
 
-    If aliases contain a dotted version number (e.g. "claude-4.7"), use that
-    to produce "Claude 4.7" instead of "Claude 4 7".
+    If aliases contain a dotted version number (for example "claude-4.7"), use
+    that to produce "Claude 4.7" instead of "Claude 4 7".
     """
     # Build a mapping of hyphenated number sequences to dotted equivalents
     # by inspecting aliases for dotted versions.
@@ -129,9 +147,7 @@ def _to_display_name(model_id: str, aliases: list[str] | None = None) -> str:
         )
 
     words = re.split(r"[-_]+", modified_id)
-    return " ".join(
-        word.upper() if word.isupper() else word.capitalize() for word in words if word
-    )
+    return " ".join(_display_word(word) for word in words if word)
 
 
 def _normalize_alias(alias: str) -> str:

--- a/tests/test_public_models.py
+++ b/tests/test_public_models.py
@@ -1374,3 +1374,19 @@ async def test_bedrock_eol_index_is_derived_once_per_fetch():
     assert mock_client.get.await_count == 1
     expected = {"anthropic.claude-3-haiku-20240307-v1:0": "2026-09-10"}
     assert all(index == expected for index in indexes)
+
+
+@pytest.mark.parametrize(
+    "model_id,aliases,expected",
+    [
+        ("gpt-4-1", ["gpt-4.1"], "GPT 4.1"),
+        ("gpt-4-1-mini", ["gpt-4.1-mini"], "GPT 4.1 Mini"),
+        ("gpt-4o-transcribe", None, "GPT 4o Transcribe"),
+        ("gpt-o4-mini", None, "GPT o4 Mini"),
+        ("deepseek-v3-2", ["deepseek-v3.2"], "DeepSeek V3.2"),
+        ("claude-4-5-sonnet", ["claude-4.5"], "Claude 4.5 Sonnet"),
+        ("mistral-large-latest", None, "Mistral Large Latest"),
+    ],
+)
+def test_to_display_name_keeps_vendor_casing(model_id, aliases, expected):
+    assert public_api._to_display_name(model_id, aliases) == expected


### PR DESCRIPTION
## Problem

`/public/models` returned `Gpt 4.1` instead of `GPT 4.1`. The display name is
built in our backend (`_to_display_name` in `app/api/public.py`) by splitting the
model id on `-`/`_` and calling `.capitalize()` on each word, so `gpt` became
`Gpt`. Nothing on the website side needs to change.

## Change

Add `_DISPLAY_WORD_OVERRIDES` for words the vendor writes differently, and route
each word through a small `_display_word()` helper.

| Before | After |
|---|---|
| Gpt 4.1 | GPT 4.1 |
| Gpt 4.1 Mini | GPT 4.1 Mini |
| Gpt 4o Transcribe | GPT 4o Transcribe |
| Gpt O4 Mini | GPT o4 Mini |
| Deepseek V3.2 | DeepSeek V3.2 |

All other names are unchanged.

## Tests

New parametrised test `test_to_display_name_keeps_vendor_casing` in
`tests/test_public_models.py`. Ran `make backend-test-regex regex="display_name or public_models"` — 54 passed.

## Note for deploy

`/public/models` is cached for `_CACHE_TTL` (1 hour), so prod will show the new
names only after the cache expires following the deploy.

## Still open

Other names are debatable and left alone: `Gemma 3 12b`, `Qwen3 235b`,
`Titan Embed Text V2:0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR preserves vendor-specific casing when generating human-readable names for the public model catalog.
- Adds centralized casing overrides for GPT, DeepSeek, and lowercase OpenAI reasoning-model families.
- Routes display-name tokens through the new casing helper while retaining existing capitalization behavior for other words.
- Adds parametrized coverage for corrected and unchanged display names.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The helper changes only presentation casing, preserves the prior fallback behavior for all unrecognized words, and is covered by representative tests for both overridden and ordinary model names.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/public.py | Adds narrowly scoped vendor-casing overrides to public model display-name generation without changing model identity, aliasing, pricing, or catalog visibility. |
| tests/test_public_models.py | Adds representative parametrized tests covering each new casing rule and unchanged fallback behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(models): keep vendor casing in publi..."](https://github.com/amazeeio/amazee.ai/commit/96d7bfff6da3f9ce0d4e0bfda0937ee20f01664b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50087234)</sub>

**Context used:**

- Knowledge Base — [Public Models API, Regions, and Pricing Tables](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/regions-public-pricing.md)

<!-- /greptile_comment -->