### PR TITLE
fix(pool): gate unpurchased keys with a zero budget, not the blocked flag

### DIFF
--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -595,10 +595,14 @@ async def create_llm_token(
             max_budget=max_max_spend,
             rpm_limit=max_rpm_limit,
             apply_limits=not is_pool_team,
-            blocked=(True if is_pool_team and not has_pool_purchase else None),
             allowed_routes=allowed_routes,
         )
         if is_pool_team and not has_pool_purchase:
+            # Gate the key with a zero budget instead of LiteLLM's `blocked`
+            # flag. A blocked key fails with an auth error telling the caller to
+            # ask an admin for an unblock, which the user cannot act on. A zero
+            # max_budget makes LiteLLM reject inference with a budget error,
+            # which says the real reason: the team has not purchased yet.
             await litellm_service.update_key_budget(
                 litellm_token=litellm_token,
                 budget_duration=f"{settings.POOL_PURCHASE_EXPIRY_DAYS}d",

--- a/tests/test_private_ai.py
+++ b/tests/test_private_ai.py
@@ -1726,6 +1726,65 @@ def test_create_llm_token_for_non_gated_pool_team_is_never_blocked(
     assert "blocked" not in key_generate_calls[0].kwargs["json"]
 
 
+@patch("httpx.AsyncClient")
+@patch("app.core.config.settings.ENABLE_LIMITS", True)
+def test_create_llm_token_for_gated_pool_team_without_purchase_uses_zero_budget(
+    mock_client_class,
+    client,
+    admin_token,
+    test_region,
+    db,
+    test_team,
+    mock_httpx_post_client,
+):
+    """A gated POOL team with no purchase gets a zero-budget key, not a blocked
+    one. LiteLLM then rejects inference with a budget error the user can act on,
+    instead of an auth error pointing at an admin-only unblock.
+    """
+    test_team.budget_type = "pool"
+    test_team.require_purchase_for_requests = True
+    db.commit()
+
+    mock_client_class.return_value = mock_httpx_post_client
+
+    response = client.post(
+        "/private-ai-keys/token",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "region_id": test_region.id,
+            "name": "Gated Pool Key",
+            "team_id": test_team.id,
+        },
+    )
+
+    assert response.status_code == 200
+
+    key_generate_calls = [
+        call
+        for call in mock_httpx_post_client.post.call_args_list
+        if str(call.args[0]).endswith("/key/generate")
+        and call.kwargs.get("json", {})
+        .get("metadata", {})
+        .get("amazeeai_private_ai_key_name")
+        == "Gated Pool Key"
+    ]
+    assert len(key_generate_calls) == 1
+    assert "blocked" not in key_generate_calls[0].kwargs["json"]
+
+    key_update_calls = [
+        call
+        for call in mock_httpx_post_client.post.call_args_list
+        if str(call.args[0]).endswith("/key/update")
+    ]
+    assert len(key_update_calls) == 1
+    update_payload = key_update_calls[0].kwargs["json"]
+    assert update_payload["max_budget"] == 0.0
+    assert update_payload["budget_duration"] == (
+        f"{settings.POOL_PURCHASE_EXPIRY_DAYS}d"
+    )
+    assert "blocked" not in update_payload
+
+
 def _key_generate_payload(mock_client, key_name):
     calls = [
         call


### PR DESCRIPTION
Closes amazeeio/moad#674

## What

Pool-gated keys with no purchase are no longer created with LiteLLM's `blocked` flag. They keep `max_budget=0.0`, which was already being set right after creation.

## Why

LiteLLM checks `blocked` before any budget check, so the caller got:

```
401 auth_error — "Key is blocked. Update via /key/unblock if you're an admin."
```

That is the wrong reason and points at an action the user cannot take. With `blocked` dropped, the zero budget produces:

```
429 budget_exceeded — "Budget has been exceeded! Current cost: 0.0, Max budget: 0.0"
```

Both verified live on DEV `amazeeai-us1` with throwaway keys.

## Known gaps (not addressed here — see the issue)

1. The key budget check only runs on LLM API routes (`RouteChecks.is_llm_api_route`). A zero-budget key still gets `200` on non-LLM routes such as `/key/info`; a blocked key got `401` everywhere. `allowed_routes` is inference-only for the AI trial team only.
2. LiteLLM skips all budget checks for a model group whose input **and** output cost are explicitly `0` (`_is_model_cost_zero`). No such model on DEV `amazeeai-us1`. PROD regions are not yet checked.

## Tests

`make backend-test` — full suite. New test: `test_create_llm_token_for_gated_pool_team_without_purchase_uses_zero_budget` asserts the key is created without `blocked` and that `/key/update` sets `max_budget=0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR changes unpurchased pool-team key gating from LiteLLM's `blocked` flag to a zero maximum budget so inference failures report the applicable budget condition.
- Omits `blocked` when generating gated pool-team keys.
- Retains the post-creation update that sets `max_budget=0.0`.
- Adds coverage for the generated and updated LiteLLM payloads.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge within the scope of the available follow-up review.

No blocking failure remains in the eligible review findings.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/private_ai_keys.py | Removes the blocked flag from unpurchased pool-team key generation while preserving the zero-budget update. |
| tests/test_private_ai.py | Adds payload assertions confirming that gated pool-team keys are unblocked and subsequently assigned a zero budget. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(pool): gate unpurchased keys with a ..."](https://github.com/amazeeio/amazee.ai/commit/12bce65f59f76f10f9cfabc12220e882ff33085a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50173127)</sub>

**Context used:**

- Knowledge Base — [Private AI Keys and LiteLLM Integration](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/private-ai-keys-litellm.md)

<!-- /greptile_comment -->