### PR TITLE
fix(pool): keep the zero-budget gate when a key budget is cleared

### DIFF
--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -404,6 +404,24 @@ def _get_region_or_404(db: Session, region_id: int) -> DBRegion:
     return region
 
 
+def _lock_region_or_404(db: Session, region_id: int) -> DBRegion:
+    """Load an active region and hold a row lock on it for this transaction.
+
+    The purchase path takes the same lock and clears key gates in LiteLLM before
+    it commits its purchase row, so a reader that does not contend on this row
+    can observe "never purchased" for a team that is already funded.
+    """
+    region = (
+        db.query(DBRegion)
+        .filter(DBRegion.id == region_id, DBRegion.is_active.is_(True))
+        .with_for_update()
+        .first()
+    )
+    if not region:
+        raise HTTPException(status_code=404, detail="Region not found")
+    return region
+
+
 def _assert_team_access(current_user: DBUser, role: str, team_id: int) -> None:
     if current_user.is_admin:
         return
@@ -2318,15 +2336,23 @@ async def clear_key_budget(
         gate_team_id = (
             db.query(DBUser.team_id).filter(DBUser.id == key.owner_id).scalar()
         )
+    gate_team = (
+        db.query(DBTeam).filter(DBTeam.id == gate_team_id).first()
+        if gate_team_id is not None
+        else None
+    )
 
     gate_key = False
-    if gate_team_id is not None:
-        team = db.query(DBTeam).filter(DBTeam.id == gate_team_id).first()
-        gate_key = (
-            team is not None
-            and team.requires_pool_purchase_gate
-            and not pool_team_has_ever_purchased(db, gate_team_id, region_id)
-        )
+    if gate_team is not None and gate_team.requires_pool_purchase_gate:
+        # Serialise against a concurrent first purchase. That path clears key
+        # gates in LiteLLM before committing its purchase row, so an unlocked
+        # check can still read "never purchased" and re-gate a key the purchase
+        # just funded, leaving it unable to serve requests. Taking the same
+        # region lock means whichever runs first wins: a purchase in flight
+        # blocks this until it commits, and a clear in flight makes the purchase
+        # wait and then clear the gate itself.
+        _lock_region_or_404(db, region_id)
+        gate_key = not pool_team_has_ever_purchased(db, gate_team_id, region_id)
 
     if gate_key:
         await service.update_key_budget(

--- a/app/api/spend.py
+++ b/app/api/spend.py
@@ -16,6 +16,7 @@ from app.core.periodic_budget_ledger_service import compute_active_topup_remaini
 from app.core.pool_budget_service import (
     pool_available_budget_for_team_region as shared_pool_available_budget_for_team_region,
     pool_team_budget_duration_for_enforcement as shared_pool_team_budget_duration_for_enforcement,
+    pool_team_has_ever_purchased,
 )
 from app.core.security import (
     get_current_user_from_auth,
@@ -2246,7 +2247,10 @@ async def update_key_budget(
     summary="Clear key budget override",
     description=(
         "Clears key max_budget and budget_duration by setting both to null "
-        "in LiteLLM. Removes the spend cap and budget reset window from the key."
+        "in LiteLLM. Removes the spend cap and budget reset window from the key. "
+        "Exception: for a purchase-gated pool team with no purchase yet, the key "
+        "keeps a zero max_budget so it still cannot serve requests; the first "
+        "purchase clears it."
     ),
     response_description="Key budget clear result with max_budget=null and budget_duration=null.",
     openapi_extra={
@@ -2299,13 +2303,49 @@ async def clear_key_budget(
     service = LiteLLMService(
         api_url=region.litellm_api_url, api_key=region.litellm_api_key
     )
-    await service.update_key_budget(
-        litellm_token=key.litellm_token,
-        budget_duration=None,
-        max_budget=None,
-        clear_max_budget=True,
-        clear_budget_duration=True,
-    )
+
+    # A gated pool team that has never purchased keeps its keys at a zero
+    # max_budget, which is the only thing stopping inference: LiteLLM denies a
+    # key at spend >= max_budget but a team only at spend > max_budget, so a
+    # cleared key would pass its first request against the team's $0 budget.
+    # Re-apply the gate instead of clearing. The first purchase clears it, and
+    # from then on this endpoint behaves normally.
+    # Resolve the team the same way key creation does: the key's own team, or
+    # the owner's team for a user-scoped key. Reading only key.team_id would
+    # miss a user key whose owner sits in a gated team.
+    gate_team_id = key.team_id
+    if gate_team_id is None and key.owner_id is not None:
+        gate_team_id = (
+            db.query(DBUser.team_id).filter(DBUser.id == key.owner_id).scalar()
+        )
+
+    gate_key = False
+    if gate_team_id is not None:
+        team = db.query(DBTeam).filter(DBTeam.id == gate_team_id).first()
+        gate_key = (
+            team is not None
+            and team.requires_pool_purchase_gate
+            and not pool_team_has_ever_purchased(db, gate_team_id, region_id)
+        )
+
+    if gate_key:
+        await service.update_key_budget(
+            litellm_token=key.litellm_token,
+            budget_duration=f"{settings.POOL_PURCHASE_EXPIRY_DAYS}d",
+            max_budget=0.0,
+            clear_max_budget=False,
+        )
+    else:
+        await service.update_key_budget(
+            litellm_token=key.litellm_token,
+            budget_duration=None,
+            max_budget=None,
+            clear_max_budget=True,
+            clear_budget_duration=True,
+        )
+
+    # The cap row is dropped either way, so the first purchase resolves the key
+    # to the team budget rather than resurrecting a cap the caller removed.
     _delete_spend_cap(
         db,
         scope="key",
@@ -2328,5 +2368,10 @@ async def clear_key_budget(
         key_id=key_id,
         max_budget=info.get("max_budget"),
         budget_duration=info.get("budget_duration"),
-        note="Cleared key max_budget and budget_duration overrides.",
+        note=(
+            "Team has not purchased yet: key kept at a zero max_budget so it "
+            "cannot serve requests. The first purchase clears it."
+            if gate_key
+            else "Cleared key max_budget and budget_duration overrides."
+        ),
     )

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -5,6 +5,7 @@ from app.core.roles import UserRole
 from datetime import UTC, datetime, timedelta
 from sqlalchemy.exc import IntegrityError
 
+from app.api.spend import _lock_region_or_404
 from app.core.config import settings
 from app.core.security import get_password_hash
 from app.db.models import (
@@ -2180,6 +2181,51 @@ def test_clear_key_budget_keeps_gate_for_unpurchased_pool_team(
         .first()
         is None
     )
+
+
+@patch("app.api.spend._lock_region_or_404", wraps=_lock_region_or_404)
+@patch("app.api.spend.LiteLLMService.get_key_info", new_callable=AsyncMock)
+@patch("app.api.spend.LiteLLMService.update_key_budget", new_callable=AsyncMock)
+def test_clear_key_budget_takes_region_lock_before_gate_decision(
+    mock_update_key_budget,
+    mock_get_key_info,
+    spy_lock_region,
+    client,
+    admin_token,
+    test_team,
+    test_team_user,
+    test_region,
+    db,
+):
+    """The purchase check must run behind the region lock.
+
+    A first purchase clears key gates in LiteLLM before committing its purchase
+    row, so an unlocked check can re-gate a key that purchase just funded.
+    """
+    test_team.budget_type = BudgetType.POOL
+    test_team.require_purchase_for_requests = True
+    db.add(test_team)
+    key = DBPrivateAIKey(
+        name="pool-lock-key",
+        litellm_token="pool-lock-token",
+        region_id=test_region.id,
+        owner_id=test_team_user.id,
+        team_id=test_team.id,
+    )
+    db.add(key)
+    db.commit()
+    mock_get_key_info.return_value = {
+        "info": {"max_budget": 0.0, "budget_duration": "30d"}
+    }
+
+    response = client.post(
+        f"/spend/{test_region.id}/key/{key.id}/budget/clear",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+
+    assert response.status_code == 200
+    spy_lock_region.assert_called_once()
+    assert spy_lock_region.call_args.args[1] == test_region.id
 
 
 @patch("app.api.spend.LiteLLMService.get_key_info", new_callable=AsyncMock)

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -5,6 +5,7 @@ from app.core.roles import UserRole
 from datetime import UTC, datetime, timedelta
 from sqlalchemy.exc import IntegrityError
 
+from app.core.config import settings
 from app.core.security import get_password_hash
 from app.db.models import (
     BudgetType,
@@ -2109,6 +2110,135 @@ def test_clear_key_budget_endpoint(
         .first()
     )
     assert cap is None
+
+
+@patch("app.api.spend.LiteLLMService.get_key_info", new_callable=AsyncMock)
+@patch("app.api.spend.LiteLLMService.update_key_budget", new_callable=AsyncMock)
+def test_clear_key_budget_keeps_gate_for_unpurchased_pool_team(
+    mock_update_key_budget,
+    mock_get_key_info,
+    client,
+    admin_token,
+    test_team,
+    test_team_user,
+    test_region,
+    db,
+):
+    """A gated pool team with no purchase must not have its key gate cleared.
+
+    LiteLLM denies a key at spend >= max_budget but a team only at
+    spend > max_budget, so a cleared key would serve its first request against
+    the team's $0 budget.
+    """
+    test_team.budget_type = BudgetType.POOL
+    test_team.require_purchase_for_requests = True
+    db.add(test_team)
+    key = DBPrivateAIKey(
+        name="pool-gated-key",
+        litellm_token="pool-gated-token",
+        region_id=test_region.id,
+        owner_id=test_team_user.id,
+        team_id=test_team.id,
+    )
+    db.add(key)
+    db.commit()
+    db.add(
+        DBSpendCap(
+            scope="key",
+            region_id=test_region.id,
+            team_id=test_team.id,
+            user_id=test_team_user.id,
+            key_id=key.id,
+            max_budget=10.0,
+            budget_duration="1mo",
+        )
+    )
+    db.commit()
+    mock_get_key_info.return_value = {
+        "info": {"max_budget": 0.0, "budget_duration": "30d"}
+    }
+
+    response = client.post(
+        f"/spend/{test_region.id}/key/{key.id}/budget/clear",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+
+    assert response.status_code == 200
+    mock_update_key_budget.assert_awaited_once_with(
+        litellm_token=key.litellm_token,
+        budget_duration=f"{settings.POOL_PURCHASE_EXPIRY_DAYS}d",
+        max_budget=0.0,
+        clear_max_budget=False,
+    )
+    assert response.json()["max_budget"] == 0.0
+    assert "has not purchased" in response.json()["note"]
+    # The cap row still goes, so the first purchase resolves the key to the
+    # team budget instead of resurrecting a cap the caller removed.
+    assert (
+        db.query(DBSpendCap)
+        .filter(DBSpendCap.scope == "key", DBSpendCap.key_id == key.id)
+        .first()
+        is None
+    )
+
+
+@patch("app.api.spend.LiteLLMService.get_key_info", new_callable=AsyncMock)
+@patch("app.api.spend.LiteLLMService.update_key_budget", new_callable=AsyncMock)
+def test_clear_key_budget_clears_once_pool_team_has_purchased(
+    mock_update_key_budget,
+    mock_get_key_info,
+    client,
+    admin_token,
+    test_team,
+    test_team_user,
+    test_region,
+    db,
+):
+    """One purchase is enough to restore the normal clear behaviour."""
+    test_team.budget_type = BudgetType.POOL
+    test_team.require_purchase_for_requests = True
+    db.add(test_team)
+    key = DBPrivateAIKey(
+        name="pool-purchased-key",
+        litellm_token="pool-purchased-token",
+        region_id=test_region.id,
+        owner_id=test_team_user.id,
+        team_id=test_team.id,
+    )
+    db.add(key)
+    db.add(
+        DBPoolPurchase(
+            team_id=test_team.id,
+            region_id=test_region.id,
+            amount_cents=500,
+            currency="USD",
+            purchased_at=datetime.now(UTC),
+            stripe_payment_id=f"pool-clear-{test_team.id}-{test_region.id}",
+            created_at=datetime.now(UTC),
+        )
+    )
+    db.commit()
+    mock_get_key_info.return_value = {
+        "info": {"max_budget": None, "budget_duration": None}
+    }
+
+    response = client.post(
+        f"/spend/{test_region.id}/key/{key.id}/budget/clear",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+
+    assert response.status_code == 200
+    mock_update_key_budget.assert_awaited_once_with(
+        litellm_token=key.litellm_token,
+        budget_duration=None,
+        max_budget=None,
+        clear_max_budget=True,
+        clear_budget_duration=True,
+    )
+    assert response.json()["max_budget"] is None
+    assert response.json()["note"] == (
+        "Cleared key max_budget and budget_duration overrides."
+    )
 
 
 @patch("app.api.spend.LiteLLMService.update_team_member", new_callable=AsyncMock)


### PR DESCRIPTION
Follow-up to #666 / amazeeio/moad#674.

## Problem

#666 replaced the pool gate's `blocked=True` with `max_budget=0.0`. MOAD's key creation makes two calls in sequence (`moad/src/server/graphql/resolvers/keys.ts:89` and `:424`):

1. `POST /private-ai-keys/token`
2. `POST /spend/{region_id}/key/{key_id}/budget/clear`

Step 2 clears the field that is now the gate. `blocked=True` used to survive that call — `update_key_budget` only sends `blocked` when the argument is not `None` — so on `main` the key stays denied. On `dev` the gate is gone.

## Why the team budget does not cover it

LiteLLM's checks are not symmetric (`litellm/proxy/auth/auth_checks.py`):

- key, line 3669: `spend >= valid_token.max_budget`
- team, line 4034: `spend > team_object.max_budget`

So a $0 team budget lets the first request through and denies from the second. Measured on DEV: request 1 → `200` (real completion, $0.0000436 spent), requests 2-5 → `429 budget_exceeded` naming the team.

Neither side of the team inequality can be moved: `/team/update` silently drops a `spend` field (not in `UpdateTeamRequest`), and a negative `max_budget` is rejected with `400 max_budget must be a non-negative finite number`. Both verified live on DEV. Only the key-level budget can deny the first request.

## Change

`clear_key_budget` keeps the gate when the key's team `requires_pool_purchase_gate` and `pool_team_has_ever_purchased(db, team_id, region_id)` is false: it writes `max_budget=0.0` with the pool expiry duration instead of clearing. Every other case is untouched. The spend-cap row is deleted either way, so the first purchase resolves the key to the team budget rather than resurrecting a cap the caller removed.

## Post-purchase behaviour is unchanged

Verified live on DEV against the endpoint MOAD's `grantTeamBudget` calls:

```
PURCHASES 1
KEY_AFTER_PURCHASE   max_budget=None  budget_duration=None  blocked=False
TEAM_AFTER_PURCHASE  max_budget=5.0   budget_duration=31d
budget/clear after purchase -> {"max_budget": null, "budget_duration": null}
inference -> HTTP 200, 200, 200
```

Two reasons it stays that way: the purchase itself clears the key gate via `_sync_pool_key_effective_budgets`, and `pool_team_has_ever_purchased` stays true for any historical purchase "regardless of remaining balance" (`app/core/pool_budget_service.py:67`), so the guard never fires again — including after the budget is consumed or expires.

## Not affected

The Drupal path (`ai_provider_amazeeio`) calls `POST /private-ai-keys` and never calls `budget/clear`, so its keys already kept the gate.

## Tests

- `test_clear_key_budget_keeps_gate_for_unpurchased_pool_team`
- `test_clear_key_budget_clears_once_pool_team_has_purchased`
- existing `test_clear_key_budget_endpoint` and `test_clear_key_budget_wrong_team_id_is_404` unchanged and passing

## Verification still to do after this lands on DEV

Re-run the MOAD sequence end to end (create workspace → create key → no purchase → inference) and confirm the first request is denied with `budget_exceeded`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR preserves the zero-budget key gate when an unpurchased pool team clears a key budget and resolves the previously reported concurrent-purchase race.
- Resolves user-scoped keys to their owner’s team before evaluating the purchase gate.
- Serializes the gate decision against pool purchases using the shared region-row lock.
- Deletes the manual spend-cap row while retaining the temporary LiteLLM gate until the first purchase.
- Adds coverage for unpurchased, purchased, and lock-taking behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The previously reported purchase-versus-clear race is resolved because both paths lock the same active region row and retain that lock through their LiteLLM updates until the transaction commits, ensuring the later operation observes the committed purchase state.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/spend.py | Preserves the pre-purchase zero-budget gate and serializes its decision with first-purchase processing on the region row lock. |
| tests/test_spend.py | Adds focused coverage for gated clears, post-purchase clears, spend-cap deletion, and acquisition of the region lock. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Clear as Clear key budget
    participant DB as PostgreSQL
    participant Purchase as First pool purchase
    participant LLM as LiteLLM
    Clear->>DB: SELECT region FOR UPDATE
    alt Clear acquires lock first
        Clear->>DB: Check purchase history
        Clear->>LLM: Keep key max_budget at 0
        Clear->>DB: Delete spend cap and commit
        Purchase->>DB: Acquire region lock
        Purchase->>LLM: Apply purchased budget and clear key gate
        Purchase->>DB: Commit purchase
    else Purchase acquires lock first
        Purchase->>LLM: Apply purchased budget and clear key gate
        Purchase->>DB: Commit purchase
        Clear->>DB: Acquire region lock and observe purchase
        Clear->>LLM: Clear key budget normally
        Clear->>DB: Delete spend cap and commit
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(pool): decide the key gate behind th..."](https://github.com/amazeeio/amazee.ai/commit/1f9ef55c5c6e1865df12291ddbcf39c3ffcd4614) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50361888)</sub>

**Context used:**

- Knowledge Base — [Budgets and Spend Limits](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/budgets-spend.md)

<!-- /greptile_comment -->