### PR TITLE
Add GLM and MiniMax to model display name and manufacturer rules

### DIFF
--- a/app/api/public.py
+++ b/app/api/public.py
@@ -103,6 +103,8 @@ def _apply_profit_margin(price: float | None, margin: float) -> float | None:
 _DISPLAY_WORD_OVERRIDES = {
     "gpt": "GPT",
     "deepseek": "DeepSeek",
+    "glm": "GLM",
+    "minimax": "MiniMax",
     "o1": "o1",
     "o3": "o3",
     "o4": "o4",
@@ -211,6 +213,8 @@ _MANUFACTURER_RULES: list[dict[str, str | None]] = [
     {"keyword": "deepseek", "name": "DeepSeek", "website": "https://www.deepseek.com"},
     {"keyword": "llama", "name": "Meta", "website": "https://ai.meta.com/llama"},
     {"keyword": "kimi", "name": "Moonshot", "website": "https://www.moonshot.cn"},
+    {"keyword": "glm", "name": "Z.ai", "website": "https://z.ai"},
+    {"keyword": "minimax", "name": "MiniMax", "website": "https://www.minimax.io"},
     {
         "keyword": "qwen",
         "name": "Alibaba",

--- a/tests/test_public_models.py
+++ b/tests/test_public_models.py
@@ -1386,7 +1386,31 @@ async def test_bedrock_eol_index_is_derived_once_per_fetch():
         ("deepseek-v3-2", ["deepseek-v3.2"], "DeepSeek V3.2"),
         ("claude-4-5-sonnet", ["claude-4.5"], "Claude 4.5 Sonnet"),
         ("mistral-large-latest", None, "Mistral Large Latest"),
+        ("glm-5.2", None, "GLM 5.2"),
+        ("glm-4-6", ["glm-4.6"], "GLM 4.6"),
+        ("minimax-m3", None, "MiniMax M3"),
     ],
 )
 def test_to_display_name_keeps_vendor_casing(model_id, aliases, expected):
     assert public_api._to_display_name(model_id, aliases) == expected
+
+
+@pytest.mark.parametrize(
+    "model_id,litellm_provider,expected_name,expected_website",
+    [
+        ("glm-5.2", "deepinfra", "Z.ai", "https://z.ai"),
+        ("glm-4-6", "openai", "Z.ai", "https://z.ai"),
+        ("minimax-m3", "deepinfra", "MiniMax", "https://www.minimax.io"),
+        # Existing vendors must keep resolving as before.
+        ("deepseek-v4-flash", "deepinfra", "DeepSeek", "https://www.deepseek.com"),
+        ("claude-4-5-sonnet", "bedrock", "Anthropic", "https://www.anthropic.com"),
+    ],
+)
+def test_infer_manufacturer_covers_open_weight_vendors(
+    model_id, litellm_provider, expected_name, expected_website
+):
+    item = {"model_info": {"litellm_provider": litellm_provider}}
+    manufacturer = public_api._infer_manufacturer(model_id, item)
+    assert manufacturer is not None, f"no manufacturer inferred for {model_id}"
+    assert manufacturer.name == expected_name
+    assert manufacturer.website == expected_website


### PR DESCRIPTION
## What

`/public/models` derives `display_name` and `manufacturer` by matching the model id against keyword tables in `app/api/public.py`. Neither Z.ai's GLM family nor MiniMax appears in either table, so those models are served with the wrong casing and no manufacturer:

| model_id | before | after |
|---|---|---|
| `glm-5.2` | `"Glm 5.2"`, manufacturer `null` | `"GLM 5.2"`, Z.ai |
| `glm-5.1` | `"Glm 5.1"`, manufacturer `null` | `"GLM 5.1"`, Z.ai |
| `minimax-m3` | `"Minimax M3"`, manufacturer `null` | `"MiniMax M3"`, MiniMax |

## Changes

- `_DISPLAY_WORD_OVERRIDES`: add `glm → GLM` and `minimax → MiniMax`, matching the existing `gpt → GPT` / `deepseek → DeepSeek` entries.
- `_MANUFACTURER_RULES`: add rules for both vendors, positioned with the other model-keyword rules so they resolve before the provider-based fallbacks at the end of the list.

## Tests

- New display-name cases in the existing `test_to_display_name_keeps_vendor_casing` parametrisation, including a dotted-alias case (`glm-4-6` + `glm-4.6` → `GLM 4.6`) to confirm the version-dot handling still applies.
- New `test_infer_manufacturer_covers_open_weight_vendors`, covering both new vendors plus DeepSeek and Anthropic as regression cases.

`pytest tests/test_public_models.py` passes; `ruff check` and `ruff format --check` are clean. The DB-backed tests in `tests/test_public_models_missing.py` were not run locally — they need the Postgres test container.

## Notes

Only affects presentation of the public model catalogue. No routing, pricing, or margin behaviour changes.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR extends public model-catalog presentation rules for the GLM and MiniMax model families.
- Preserves vendor-specific capitalization in generated display names.
- Infers Z.ai and MiniMax manufacturer metadata before provider fallbacks.
- Adds focused regression coverage for display names, dotted aliases, and manufacturer inference.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the new presentation mappings covered by focused regression tests.

The changes extend existing lookup tables consistently, and the tests cover vendor casing, alias-based dotted versions, manufacturer inference, and representative existing vendors.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/public.py | Adds GLM and MiniMax display-name overrides and manufacturer mappings without changing routing, pricing, or catalog visibility. |
| tests/test_public_models.py | Adds focused coverage for both new model families and verifies representative existing manufacturer rules remain unchanged. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Add GLM and MiniMax to model display nam..."](https://github.com/amazeeio/amazee.ai/commit/9ad900e122f67015d03a24638b9eb9acfc89ac27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50501655)</sub>

**Context used:**

- Knowledge Base — [Public Models API, Regions, and Pricing Tables](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/regions-public-pricing.md)

<!-- /greptile_comment -->