### PR TITLE
fix: apply skip unmanaged regions

### DIFF
--- a/app/api/admin_model_apply.py
+++ b/app/api/admin_model_apply.py
@@ -15,6 +15,10 @@ Semantics:
   and are soft-deactivated (never hard-deleted).
 - Access groups are never pruned automatically: deleting a group cascades to
   team attachments, which is runtime state this endpoint does not own.
+- CATALOG_MANAGED_REGIONS bounds every write. Region references outside it —
+  unknown here, inactive, or not opted in — are skipped and returned in
+  `skipped_regions`, never a 400: one catalog is posted to every environment,
+  so a region only prod knows about must not fail the whole dev apply.
 """
 
 import logging
@@ -43,6 +47,7 @@ from app.schemas.models import (
     ApplyConfigRequest,
     ApplyConfigResponse,
     ApplyModelSpec,
+    SkippedRegion,
 )
 from app.services.model_sync import sync_model_to_region_task
 
@@ -101,38 +106,53 @@ def _validate_specs(req: ApplyConfigRequest) -> None:
             )
 
 
-def _resolve_regions(db: Session, req: ApplyConfigRequest) -> Dict[str, DBRegion]:
+def _resolve_regions(
+    db: Session, req: ApplyConfigRequest
+) -> Tuple[Dict[str, DBRegion], Set[int], List[SkippedRegion]]:
+    """Split the payload's region references into what this environment acts on
+    and what it leaves alone.
+
+    CATALOG_MANAGED_REGIONS is the blast radius. The config repo POSTs the same
+    catalog to dev/main/prod, so a region this environment has never heard of —
+    or has retired, or has not opted in — is skipped and reported, never a 400:
+    one stale row must not sink the other forty deployments.
+
+    Returns (resolvable payload regions, managed region ids, skipped). The
+    managed-id set is every managed region in the DB, not just the ones this
+    payload names — it is the scope for deactivation, so a region dropped from
+    the CSVs still gets its deployments turned off, while a region outside the
+    scope is never written to at all.
+    """
     names: Set[str] = set()
     for g in req.access_groups:
         names.update(g.regions)
     for m in req.models:
         names.update(d.region for d in m.deployments)
         names.update(t.region for t in m.alias_targets)
-    if not names:
-        return {}
-    rows = db.query(DBRegion).filter(DBRegion.name.in_(names)).all()
-    found = {r.name: r for r in rows}
-    missing = sorted(names - set(found))
-    if missing:
-        raise _bad_request(f"Unknown regions in payload: {missing}")
-    inactive = sorted(name for name, r in found.items() if not r.is_active)
-    if inactive:
-        raise _bad_request(f"Inactive regions in payload: {inactive}")
-    # Fail the config-repo PR loudly rather than writing DB rows whose sync the
-    # choke point in sync_model_to_region_task would then refuse.
-    unmanaged = sorted(name for name in found if not catalog_manages(name))
-    if unmanaged:
-        raise _bad_request(
-            f"Regions not managed by the model catalog: {unmanaged}. "
-            "Add them to CATALOG_MANAGED_REGIONS to opt them in."
-        )
-    return found
+
+    by_name = {r.name: r for r in db.query(DBRegion).all()}
+    managed_ids = {r.id for r in by_name.values() if r.is_active and catalog_manages(r.name)}
+
+    regions: Dict[str, DBRegion] = {}
+    skipped: List[SkippedRegion] = []
+    for name in sorted(names):
+        row = by_name.get(name)
+        if row is None:
+            skipped.append(SkippedRegion(region=name, reason="unknown"))
+        elif not row.is_active:
+            skipped.append(SkippedRegion(region=name, reason="inactive"))
+        elif not catalog_manages(name):
+            skipped.append(SkippedRegion(region=name, reason="not_catalog_managed"))
+        else:
+            regions[name] = row
+    return regions, managed_ids, skipped
 
 
 def _apply_access_groups(
     db: Session,
     req: ApplyConfigRequest,
     regions: Dict[str, DBRegion],
+    managed_ids: Set[int],
     changes: List[ApplyChange],
 ) -> Tuple[Dict[str, DBModelAccessGroup], Dict[int, Set[int]]]:
     """Upsert groups and their region deployments. Returns (slug -> group,
@@ -154,10 +174,11 @@ def _apply_access_groups(
             changes.append(
                 ApplyChange(entity="access_group", key=spec.slug, action="update", detail="label/description")
             )
-        desired_regions = {regions[name].id for name in spec.regions}
+        desired_regions = {regions[name].id for name in spec.regions if name in regions}
         existing_regions = {
             row.region_id
             for row in db.query(DBModelAccessGroupRegion).filter_by(group_id=group.id).all()
+            if row.region_id in managed_ids
         }
         if desired_regions != existing_regions:
             for rid in existing_regions - desired_regions:
@@ -258,6 +279,7 @@ def _apply_deployments(
     spec_key: str,
     desired: Dict[int, Optional[dict]],
     region_names: Dict[int, str],
+    managed_ids: Set[int],
     changes: List[ApplyChange],
 ) -> Set[int]:
     """Reconcile DBModelRegion rows to `desired` (region_id -> override).
@@ -312,8 +334,10 @@ def _apply_deployments(
                 )
             )
             to_sync.add(region_id)
+    # Only managed regions are ours to turn off; a deployment in a skipped
+    # region is someone else's row and stays exactly as it is.
     for region_id, assoc in existing.items():
-        if region_id not in desired and assoc.is_active:
+        if region_id in managed_ids and region_id not in desired and assoc.is_active:
             assoc.is_active = False
             assoc.sync_status = "pending"
             assoc.sync_error = None
@@ -356,7 +380,7 @@ async def apply_model_config(
 ):
     """Apply a full desired-state model config (see module docstring)."""
     _validate_specs(req)
-    regions = _resolve_regions(db, req)
+    regions, managed_ids, skipped_regions = _resolve_regions(db, req)
     region_names = {r.id: r.name for r in regions.values()}
     # Deactivations can hit regions not referenced in the payload at all.
     for r in db.query(DBRegion.id, DBRegion.name).all():
@@ -365,7 +389,7 @@ async def apply_model_config(
     changes: List[ApplyChange] = []
     syncs: Set[Tuple[int, int]] = set()  # (model_pk, region_id)
 
-    groups, changed_group_regions = _apply_access_groups(db, req, regions, changes)
+    groups, changed_group_regions = _apply_access_groups(db, req, regions, managed_ids, changes)
 
     # Non-alias models first so alias targets can resolve against the DB.
     ordered = [m for m in req.models if not m.is_alias] + [m for m in req.models if m.is_alias]
@@ -380,6 +404,8 @@ async def apply_model_config(
         if spec.is_alias:
             desired_targets = set()
             for t in spec.alias_targets:
+                if t.region not in regions:
+                    continue
                 target = models_by_id.get(t.target) or (
                     db.query(DBModel)
                     .filter(DBModel.model_id == t.target, DBModel.deleted_at.is_(None))
@@ -395,9 +421,15 @@ async def apply_model_config(
             existing_targets = {
                 (row.region_id, row.target_model_id)
                 for row in db.query(DBModelAliasTarget).filter_by(alias_model_id=model.id).all()
+                if row.region_id in managed_ids
             }
             if desired_targets != existing_targets:
-                db.query(DBModelAliasTarget).filter_by(alias_model_id=model.id).delete()
+                # Scoped delete: rewriting the alias must not drop targets that
+                # point at regions this environment does not manage.
+                db.query(DBModelAliasTarget).filter(
+                    DBModelAliasTarget.alias_model_id == model.id,
+                    DBModelAliasTarget.region_id.in_(managed_ids),
+                ).delete(synchronize_session=False)
                 for region_id, target_pk in desired_targets:
                     db.add(
                         DBModelAliasTarget(
@@ -415,11 +447,13 @@ async def apply_model_config(
             }
         else:
             desired_deployments = {
-                regions[d.region].id: d.litellm_params_override for d in spec.deployments
+                regions[d.region].id: d.litellm_params_override
+                for d in spec.deployments
+                if d.region in regions
             }
 
         to_sync = _apply_deployments(
-            db, model, spec.model_id, desired_deployments, region_names, changes
+            db, model, spec.model_id, desired_deployments, region_names, managed_ids, changes
         )
         group_pks = {groups[slug].id for slug in spec.access_groups}
         if _replace_group_memberships(db, model, group_pks, changes):
@@ -433,7 +467,7 @@ async def apply_model_config(
         model = models_by_id[spec.model_id]
         if model.id in catalog_changed:
             for assoc in db.query(DBModelRegion).filter_by(model_id=model.id).all():
-                if assoc.is_active:
+                if assoc.is_active and assoc.region_id in managed_ids:
                     syncs.add((model.id, assoc.region_id))
 
     # A group's region set changing re-tags member models in the affected regions.
@@ -488,7 +522,7 @@ async def apply_model_config(
                 model.is_active_globally = False
                 changes.append(ApplyChange(entity="model", key=model.model_id, action="prune"))
             for assoc in db.query(DBModelRegion).filter_by(model_id=model.id).all():
-                if assoc.is_active:
+                if assoc.is_active and assoc.region_id in managed_ids:
                     assoc.is_active = False
                     assoc.sync_status = "pending"
                     assoc.updated_at = datetime.now(UTC)
@@ -518,6 +552,7 @@ async def apply_model_config(
             changes=changes,
             unmanaged_models=sorted(unmanaged_models),
             unmanaged_access_groups=unmanaged_access_groups,
+            skipped_regions=skipped_regions,
             syncs_scheduled=len(syncs),
         )
 
@@ -532,5 +567,6 @@ async def apply_model_config(
         changes=changes,
         unmanaged_models=sorted(unmanaged_models),
         unmanaged_access_groups=unmanaged_access_groups,
+        skipped_regions=skipped_regions,
         syncs_scheduled=len(syncs),
     )

--- a/app/api/public.py
+++ b/app/api/public.py
@@ -8,7 +8,7 @@ import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy.orm import Session
 
-from app.core.config import settings
+from app.core.config import catalog_manages, settings
 from app.core.security import get_current_user_from_auth
 from app.db.database import get_db
 from app.db.models import (
@@ -676,6 +676,12 @@ def _filter_region_groups_by_access(
     to everyone" default set. Regions without a default are unfiltered
     (legacy all-models). Admins always see everything.
 
+    A region the catalog does not manage is unfiltered too, even if a default
+    group was set on it by hand: `effective_team_group_slugs` refuses to
+    restrict those teams on LiteLLM, so filtering the listing would hide models
+    the caller can actually call — and would make the listing move whenever an
+    apply rewrites the (global, region-less) model->group memberships.
+
     Query cost is fixed per request (at most three queries) regardless of how
     many regions are enforced — this is a high-traffic endpoint.
     """
@@ -687,6 +693,7 @@ def _filter_region_groups_by_access(
         for r in db.query(DBRegion)
         .filter(DBRegion.default_access_group_id.isnot(None))
         .all()
+        if catalog_manages(r.name)
     }
     if not enforced:
         return region_groups

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -1438,6 +1438,11 @@ class ApplyChange(BaseModel):
     detail: Optional[str] = None
 
 
+class SkippedRegion(BaseModel):
+    region: str
+    reason: str  # unknown | inactive | not_catalog_managed
+
+
 class ApplyConfigResponse(BaseModel):
     dry_run: bool
     changes: List[ApplyChange] = Field(default_factory=list)
@@ -1445,6 +1450,10 @@ class ApplyConfigResponse(BaseModel):
     unmanaged_models: List[str] = Field(default_factory=list)
     # group slugs present in the DB but not in the payload (never auto-pruned)
     unmanaged_access_groups: List[str] = Field(default_factory=list)
+    # Regions the payload named that this environment left untouched. Not an
+    # error — one catalog is posted to every environment. Callers surface these
+    # (PR comment, Slack) so a typo'd or retired region stays visible.
+    skipped_regions: List[SkippedRegion] = Field(default_factory=list)
     syncs_scheduled: int = 0
 
 

--- a/tests/test_access_groups.py
+++ b/tests/test_access_groups.py
@@ -410,6 +410,49 @@ def test_model_access_group_slugs(db, test_region, test_team):
     assert model_access_group_slugs(db, model.id, test_region.id) == ["in-region"]
 
 
+def test_public_listing_does_not_enforce_on_unmanaged_regions(db, test_region, monkeypatch):
+    """Model->group membership is global (no region column), so a catalog apply
+    rewrites it for every region at once. A region the catalog does not manage
+    must therefore not filter its listing on it — its teams are unrestricted on
+    LiteLLM anyway (see effective_team_group_slugs)."""
+    from app.api.public import _filter_region_groups_by_access
+    from app.core.config import settings
+    from app.schemas.models import (
+        PublicModelCapabilities,
+        PublicModelPricing,
+        PublicModelSummary,
+        PublicRegionModels,
+    )
+
+    group = _make_group(db, slug="default-zdr", region_ids=[test_region.id])
+    test_region.default_access_group_id = group.id
+    db.commit()
+    groups = [
+        PublicRegionModels(
+            region=test_region.name,
+            status="available",
+            models=[
+                PublicModelSummary(
+                    model_id="openai/not-in-any-group",
+                    display_name="Not In Any Group",
+                    provider="openai",
+                    type="chat",
+                    description="",
+                    capabilities=PublicModelCapabilities(),
+                    pricing=PublicModelPricing(),
+                )
+            ],
+        )
+    ]
+
+    monkeypatch.setattr(settings, "ENV_SUFFIX", "production")
+    monkeypatch.setattr(settings, "CATALOG_MANAGED_REGIONS", test_region.name)
+    assert _filter_region_groups_by_access(db, groups, None)[0].models == []
+
+    monkeypatch.setattr(settings, "CATALOG_MANAGED_REGIONS", "")
+    assert _filter_region_groups_by_access(db, groups, None)[0].models == groups[0].models
+
+
 @patch("app.services.model_sync.LiteLLMService")
 def test_model_sync_pushes_access_groups(mock_service_cls, client, db, test_region):
     from app.services.model_sync import sync_model_to_region_task

--- a/tests/test_model_config_apply.py
+++ b/tests/test_model_config_apply.py
@@ -193,11 +193,32 @@ def test_apply_without_prune_reports_unmanaged(mock_svc, client, admin_token, db
     assert alias.is_active_globally is True
 
 
-def test_apply_unknown_region_rejected(client, admin_token, test_region):
-    payload = _payload("no-such-region")
-    res = _apply(client, admin_token, payload)
-    assert res.status_code == 400
-    assert "Unknown regions" in res.json()["detail"]
+def test_apply_unknown_region_is_skipped_not_rejected(client, admin_token, test_region):
+    """A region this environment has never heard of is reported, not fatal —
+    the config repo posts one catalog to dev/main/prod."""
+    res = _apply(client, admin_token, _payload("no-such-region"))
+    assert res.status_code == 200
+    assert res.json()["skipped_regions"] == [
+        {"region": "no-such-region", "reason": "unknown"}
+    ]
+
+
+def test_apply_skips_bad_region_but_still_applies_the_good_ones(
+    client, admin_token, db, test_region
+):
+    """The bug this fixes: one stale region must not sink the rest of the apply."""
+    payload = _payload(test_region.name)
+    payload["models"][0]["deployments"].append({"region": "no-such-region"})
+    with patch("app.services.model_sync.LiteLLMService"):
+        res = _apply(client, admin_token, payload)
+    assert res.status_code == 200
+    data = res.json()
+    assert [s["region"] for s in data["skipped_regions"]] == ["no-such-region"]
+    assert {c["key"] for c in data["changes"] if c["entity"] == "deployment"} == {
+        f"claude-sonnet@{test_region.name}",
+        f"chat@{test_region.name}",
+    }
+    assert db.query(DBModelRegion).count() == 2
 
 
 def test_apply_prune_with_empty_models_rejected(client, admin_token):
@@ -285,24 +306,51 @@ def test_apply_override_change_resyncs_only_that_region(mock_svc, client, admin_
     assert keys == {f"claude-sonnet@{test_region.name}"}
 
 
-def test_apply_refuses_regions_the_catalog_does_not_manage(
+def test_apply_leaves_regions_the_catalog_does_not_manage_alone(
     client, admin_token, db, test_region, monkeypatch
 ):
-    """The prod gate: outside local, a region absent from CATALOG_MANAGED_REGIONS
-    is rejected before anything is written — this is what keeps the catalog off
-    private regions like ren2."""
+    """The prod gate: outside local, CATALOG_MANAGED_REGIONS bounds every write.
+    A region absent from it is reported and untouched — no deployment row, no
+    sync — which is what keeps the catalog off private regions like ren2."""
     from app.core.config import settings
 
     monkeypatch.setattr(settings, "ENV_SUFFIX", "production")
     monkeypatch.setattr(settings, "CATALOG_MANAGED_REGIONS", "")
     res = _apply(client, admin_token, _payload(test_region.name))
-    assert res.status_code == 400
-    assert "not managed by the model catalog" in res.json()["detail"]
-    assert db.query(DBModel).count() == 0
+    assert res.status_code == 200
+    assert res.json()["skipped_regions"] == [
+        {"region": test_region.name, "reason": "not_catalog_managed"}
+    ]
+    assert res.json()["syncs_scheduled"] == 0
+    assert db.query(DBModelRegion).count() == 0
 
     monkeypatch.setattr(settings, "CATALOG_MANAGED_REGIONS", f"other, {test_region.name}")
     with patch("app.services.model_sync.LiteLLMService"):
+        res = _apply(client, admin_token, _payload(test_region.name))
+    assert res.status_code == 200
+    assert res.json()["skipped_regions"] == []
+    assert db.query(DBModelRegion).count() == 2
+
+
+def test_apply_does_not_deactivate_deployments_in_unmanaged_regions(
+    client, admin_token, db, test_region, monkeypatch
+):
+    """The destructive case skipping opens up: once a region drops out of
+    CATALOG_MANAGED_REGIONS its deployment is no longer in the payload's desired
+    set, and the 'file is authoritative' rule would otherwise switch it off."""
+    from app.core.config import settings
+
+    with patch("app.services.model_sync.LiteLLMService"):
         assert _apply(client, admin_token, _payload(test_region.name)).status_code == 200
+    assocs = db.query(DBModelRegion).all()
+    assert len(assocs) == 2 and all(a.is_active for a in assocs)
+
+    monkeypatch.setattr(settings, "ENV_SUFFIX", "production")
+    monkeypatch.setattr(settings, "CATALOG_MANAGED_REGIONS", "")
+    assert _apply(client, admin_token, _payload(test_region.name)).status_code == 200
+    for a in assocs:
+        db.refresh(a)
+    assert all(a.is_active for a in assocs)
 
 
 def test_apply_requires_admin(client, test_token, test_region):


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR scopes catalog reconciliation to configured managed regions and reports skipped region references instead of rejecting the entire apply.
- Preserves deployments, alias targets, access-group regions, and synchronization state outside the catalog-managed region set.
- Aligns public model listing filters with the access-group restrictions actually synchronized to LiteLLM.
- Adds response metadata and tests for unknown, inactive, and unmanaged region handling.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/admin_model_apply.py | Scopes reconciliation, deactivation, alias replacement, pruning, and synchronization to managed regions while reporting skipped references. |
| app/api/public.py | Applies access-group listing restrictions only where the catalog also manages LiteLLM access restrictions, completing the prior-thread fix. |
| app/schemas/models.py | Adds structured skipped-region details to apply responses. |
| tests/test_access_groups.py | Verifies public listing behavior for managed and unmanaged regions. |
| tests/test_model_config_apply.py | Covers partial applies and preservation of deployments outside the managed-region boundary. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Catalog apply references region] --> B{Active and catalog-managed?}
  B -->|Yes| C[Reconcile catalog-owned state]
  C --> D[Schedule LiteLLM synchronization]
  B -->|No| E[Preserve existing regional state]
  E --> F[Return skipped_regions entry]
  G[Public models request] --> H{Catalog manages region?}
  H -->|Yes| I[Filter by default and team access groups]
  H -->|No| J[Return unrestricted regional listing]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: don&#39;t enforce access groups on cata..."](https://github.com/amazeeio/amazee.ai/commit/1b2f14cb413de7de8e18aaff3dbb5b3ca2f5382a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51192205)</sub>

**Context used:**

- Knowledge Base — [Public Models API, Regions, and Pricing Tables](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/regions-public-pricing.md)

<!-- /greptile_comment -->