### PR TITLE
fix: plumb CATALOG_MANAGED_REGIONS through the helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Stripe Processing**: Harden event handling and idempotency for budget and subscription flows (#562)
 - **Budget Enforcement**: Block requests from zero-budget pool teams/keys and tighten budget validation (#562)
 - **Billing Sync Recovery**: Recover from LiteLLM sync failures in top-up and `/cycle` flows (#617)
+- **Catalog Apply**: Skip and report unknown/inactive/unmanaged regions instead of rejecting the whole apply (#672)
+- **Access Groups**: Stop enforcing access-group visibility on regions the catalog does not manage (#672)
+- **Helm**: Set `CATALOG_MANAGED_REGIONS` on the backend pod — the allow-list was read but never plumbed through, so no deployed environment could push the catalog to any region (#672)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Billing Sync Recovery**: Recover from LiteLLM sync failures in top-up and `/cycle` flows (#617)
 - **Catalog Apply**: Skip and report unknown/inactive/unmanaged regions instead of rejecting the whole apply (#672)
 - **Access Groups**: Stop enforcing access-group visibility on regions the catalog does not manage (#672)
-- **Helm**: Set `CATALOG_MANAGED_REGIONS` on the backend pod — the allow-list was read but never plumbed through, so no deployed environment could push the catalog to any region (#672)
+- **Helm**: Set `CATALOG_MANAGED_REGIONS` on the backend pod — the allow-list was read but never plumbed through, so no deployed environment could push the catalog to any region (#673)
 
 ### Changed
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -222,6 +222,7 @@ helm install amazee-ai . -n amazee-ai --create-namespace \
 | `backend.envSuffix` | Environment suffix. Anything other than `local` disables the docs/openapi routes and local-bearer bypass; never set `local` in a deployed env. | `"production"` |
 | `backend.forwardedAllowIps` | IPs/CIDRs uvicorn trusts `X-Forwarded-*` headers from (`FORWARDED_ALLOW_IPS`). Narrow to your ingress/Lagoon-router CIDR; never `"*"`. | RFC1918 ranges |
 | `backend.passwordlessSignIn` | Enable passwordless sign-in | `true` |
+| `backend.catalogManagedRegions` | Comma-separated amazee.ai region **names** the model catalog may write to and push at (`CATALOG_MANAGED_REGIONS`). Empty = the catalog touches nothing. Opt regions in one at a time; names must match `regions.name` in amazee.ai, not the k0rdent region name. | `""` |
 | `backend.resources.requests.memory` | Backend memory request | `256Mi` |
 | `backend.resources.requests.cpu` | Backend CPU request | `250m` |
 | `backend.resources.limits.memory` | Backend memory limit | `512Mi` |

--- a/helm/charts/backend/templates/configmap.yaml
+++ b/helm/charts/backend/templates/configmap.yaml
@@ -15,3 +15,4 @@ data:
   ENV_SUFFIX: "{{ .Values.envSuffix }}"
   FORWARDED_ALLOW_IPS: "{{ .Values.forwardedAllowIps }}"
   PASSWORDLESS_SIGN_IN: "{{ .Values.passwordlessSignIn }}"
+  CATALOG_MANAGED_REGIONS: "{{ .Values.catalogManagedRegions }}"

--- a/helm/charts/backend/templates/deployment.yaml
+++ b/helm/charts/backend/templates/deployment.yaml
@@ -15,6 +15,12 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        # Every env var below comes from the ConfigMap by reference, so a
+        # `helm upgrade` that only changes a value leaves the pod template
+        # identical and the running pods keep the old value. Hashing the
+        # rendered ConfigMap into the template makes the change roll the pods.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "backend.selectorLabels" . | nindent 8 }}
     spec:

--- a/helm/charts/backend/templates/deployment.yaml
+++ b/helm/charts/backend/templates/deployment.yaml
@@ -90,6 +90,11 @@ spec:
                 configMapKeyRef:
                   name: {{ include "backend.fullname" . }}-config
                   key: PASSWORDLESS_SIGN_IN
+            - name: CATALOG_MANAGED_REGIONS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "backend.fullname" . }}-config
+                  key: CATALOG_MANAGED_REGIONS
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/helm/charts/backend/values.yaml
+++ b/helm/charts/backend/values.yaml
@@ -30,6 +30,10 @@ enableLimits: "true"
 # local-bearer bypass. Only docker-compose should ever set "local".
 envSuffix: "production"
 passwordlessSignIn: "true"
+# Comma-separated amazee.ai region names the model catalog may write to and
+# push at. Empty = the catalog touches nothing; opt regions in one at a time.
+# Must be the region's `name` in amazee.ai, not its k0rdent name.
+catalogManagedRegions: ""
 # Client IPs/CIDRs uvicorn trusts X-Forwarded-* headers from. Defaults to the
 # RFC1918 ranges so only in-cluster peers (the ingress/Lagoon router) are
 # trusted; narrow to your router's actual CIDR if known. Never use "*".

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -49,6 +49,10 @@ backend:
   # local-bearer bypass. Only docker-compose should ever set "local".
   envSuffix: "production"
   passwordlessSignIn: "true"
+  # Comma-separated amazee.ai region names the model catalog may write to and
+  # push at. Empty = the catalog touches nothing; opt regions in one at a time.
+  # Must be the region's `name` in amazee.ai, not its k0rdent name.
+  catalogManagedRegions: ""
   # Client IPs/CIDRs uvicorn trusts X-Forwarded-* headers from. Defaults to the
   # RFC1918 ranges so only in-cluster peers (the ingress/Lagoon router) are
   # trusted; narrow to your router's actual CIDR if known. Never use "*".


### PR DESCRIPTION
Follow-up to #672, which merged before these commits landed.

`CATALOG_MANAGED_REGIONS` is read at `app/core/config.py:251` but was never set on the backend pod — not in the configmap, not in the deployment, not in either values file. Outside `ENV_SUFFIX=local` that makes `catalog_manages()` False for every region, so a catalog apply creates the global model rows and deploys nothing anywhere. That is why dev showed a full model list in `/admin/models` with no deployments pushed to any LiteLLM proxy.

Plumbs it through the same way `PASSWORDLESS_SIGN_IN` is, defaulting to `""` (unchanged behaviour). Deployments must set `backend.catalogManagedRegions` to opt regions in, using the amazee.ai `regions.name` — not the k0rdent region name.

Also carries the changelog entries for #672, which were on the same orphaned branch.

https://claude.ai/code/session_012EJcybv1VLzwtioG4SB1uu

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR exposes `CATALOG_MANAGED_REGIONS` as a Helm value and passes it through the backend ConfigMap and Deployment, while documenting its default-empty allow-list behavior and carrying changelog entries from the preceding catalog work. However, changing the value alone does not roll existing backend pods, so the effective allow-list can remain stale.

- Adds `backend.catalogManagedRegions` to the parent and backend chart values.
- Adds `CATALOG_MANAGED_REGIONS` to the backend ConfigMap and container environment.
- Documents the setting and catalog-related changelog entries.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until updates to the managed-region allow-list reliably restart backend pods and take effect.

The value is wired and parsed correctly, but existing pods retain their old environment value after a ConfigMap-only Helm upgrade, leaving catalog deployment scope stale.

**Files Needing Attention:** helm/charts/backend/templates/configmap.yaml, helm/charts/backend/templates/deployment.yaml
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| helm/charts/backend/templates/configmap.yaml | Adds the allow-list value, but ConfigMap-only changes are not connected to a backend pod rollout. |
| helm/charts/backend/templates/deployment.yaml | Exposes the ConfigMap key as an environment variable without a checksum annotation to refresh running pods. |
| helm/charts/backend/values.yaml | Adds the correctly documented default-empty child-chart value. |
| helm/values.yaml | Adds the corresponding parent-chart value under the backend subchart. |
| helm/README.md | Documents the value, accepted region-name format, and empty-value behavior. |
| CHANGELOG.md | Records the catalog behavior changes and new Helm configuration plumbing. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: changelog for #672"](https://github.com/amazeeio/amazee.ai/commit/bb4df78cd1c2565da5fb288571c133343b5343fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51204787)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->