### PR TITLE
fix: don't publish helm charts from pull requests

### DIFF
--- a/.github/workflows/helm-package-publish.yml
+++ b/.github/workflows/helm-package-publish.yml
@@ -23,6 +23,11 @@ env:
 
 jobs:
   package-and-publish:
+    # The OCI tag comes from Chart.yaml's SemVer, and nothing forces a bump per
+    # PR — so publishing on pull_request overwrites the released tag with
+    # unreviewed branch content. PRs get `test-charts` below; only push and
+    # release publish.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       packages: write  # helm push charts to GHCR (GitHub Packages)


### PR DESCRIPTION
`package-and-publish` runs on `pull_request` with no event guard, and `helm push` derives the OCI tag from `Chart.yaml`'s SemVer — which nothing forces you to bump per PR. So every PR touching `helm/**` overwrites the released chart tag in GHCR with unreviewed branch content.

This just happened for real on #673, which is still open:

```
Pushed: ghcr.io/amazeeio/amazee.ai/backend:2.1.0
Pushed: ghcr.io/amazeeio/amazee.ai/frontend:2.1.0
Pushed: ghcr.io/amazeeio/amazee.ai/amazee-ai:2.1.0
```

Anyone pulling `2.1.0` right now gets that branch. PRs already get validated by the `test-charts` job, which templates and lints every chart — publishing adds nothing on a PR.

After this merges, `2.1.0` should be re-published from `dev` (a push to `dev` does it automatically) so the tag matches something real again.

https://claude.ai/code/session_012EJcybv1VLzwtioG4SB1uu

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents Helm chart publication during pull-request workflows while preserving chart validation and publication for push and release events.
- Adds a job-level event guard to skip `package-and-publish` for pull requests.
- Leaves the independent `test-charts` job running for pull requests.
- Continues publishing charts on pushes to `main` or `dev` and on published releases.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because pull requests retain Helm validation while chart publication remains enabled for push and release events.

The new job-level condition only skips chart packaging and publication for pull-request events; the independent chart validation job remains reachable, and existing publishing events are unaffected.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/helm-package-publish.yml | Adds a correctly scoped event guard that prevents PR chart publication without disabling PR linting and template validation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: don&#39;t publish helm charts from pull..."](https://github.com/amazeeio/amazee.ai/commit/a88b75ea1f84847af88c56b0ea71a555d7af0851) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51205717)</sub>

<!-- /greptile_comment -->