### PR TITLE
fix: reschedule failed model syncs on every catalog apply

### DIFF
--- a/app/api/admin_model_apply.py
+++ b/app/api/admin_model_apply.py
@@ -15,6 +15,8 @@ Semantics:
   and are soft-deactivated (never hard-deleted).
 - Access groups are never pruned automatically: deleting a group cascades to
   team attachments, which is runtime state this endpoint does not own.
+- Deployments in managed regions whose last sync did not end in 'synced' are
+  rescheduled on every apply, even with no config diff — apply is self-healing.
 - CATALOG_MANAGED_REGIONS bounds every write. Region references outside it —
   unknown here, inactive, or not opted in — are skipped and returned in
   `skipped_regions`, never a 400: one catalog is posted to every environment,
@@ -487,6 +489,32 @@ async def apply_model_config(
                 .all()
             ):
                 syncs.add((assoc.model_id, assoc.region_id))
+
+    # A deployment whose last sync failed never diffs again, so re-running the
+    # apply with an unchanged config would leave it broken forever (e.g. syncs
+    # rejected because the proxy still had the model in its config file).
+    # Reschedule every managed row that is not cleanly synced — the sync task
+    # is an idempotent upsert/delete, so retrying is always safe.
+    for assoc, model_key in (
+        db.query(DBModelRegion, DBModel.model_id)
+        .join(DBModel, DBModel.id == DBModelRegion.model_id)
+        .filter(
+            DBModelRegion.region_id.in_(managed_ids),
+            DBModelRegion.sync_status != "synced",
+        )
+        .all()
+    ):
+        if (assoc.model_id, assoc.region_id) in syncs:
+            continue
+        changes.append(
+            ApplyChange(
+                entity="deployment",
+                key=f"{model_key}@{region_names.get(assoc.region_id, assoc.region_id)}",
+                action="resync",
+                detail=f"retrying sync_status={assoc.sync_status}",
+            )
+        )
+        syncs.add((assoc.model_id, assoc.region_id))
 
     # Models in the DB but absent from the payload.
     payload_ids = {m.model_id for m in req.models}

--- a/app/api/admin_model_apply.py
+++ b/app/api/admin_model_apply.py
@@ -490,32 +490,6 @@ async def apply_model_config(
             ):
                 syncs.add((assoc.model_id, assoc.region_id))
 
-    # A deployment whose last sync failed never diffs again, so re-running the
-    # apply with an unchanged config would leave it broken forever (e.g. syncs
-    # rejected because the proxy still had the model in its config file).
-    # Reschedule every managed row that is not cleanly synced — the sync task
-    # is an idempotent upsert/delete, so retrying is always safe.
-    for assoc, model_key in (
-        db.query(DBModelRegion, DBModel.model_id)
-        .join(DBModel, DBModel.id == DBModelRegion.model_id)
-        .filter(
-            DBModelRegion.region_id.in_(managed_ids),
-            DBModelRegion.sync_status != "synced",
-        )
-        .all()
-    ):
-        if (assoc.model_id, assoc.region_id) in syncs:
-            continue
-        changes.append(
-            ApplyChange(
-                entity="deployment",
-                key=f"{model_key}@{region_names.get(assoc.region_id, assoc.region_id)}",
-                action="resync",
-                detail=f"retrying sync_status={assoc.sync_status}",
-            )
-        )
-        syncs.add((assoc.model_id, assoc.region_id))
-
     # Models in the DB but absent from the payload.
     payload_ids = {m.model_id for m in req.models}
     unmanaged = (
@@ -564,6 +538,34 @@ async def apply_model_config(
                     syncs.add((model.id, assoc.region_id))
         else:
             unmanaged_models.append(model.model_id)
+
+    # A deployment whose last sync failed never diffs again, so re-running the
+    # apply with an unchanged config would leave it broken forever (e.g. syncs
+    # rejected because the proxy still had the model in its config file).
+    # Reschedule every managed row that is not cleanly synced — the sync task
+    # is an idempotent upsert/delete, so retrying is always safe. This runs
+    # after every diff-driven sync (including pruning) so a deployment already
+    # scheduled — e.g. one being deactivated — is not double-reported.
+    for assoc, model_key in (
+        db.query(DBModelRegion, DBModel.model_id)
+        .join(DBModel, DBModel.id == DBModelRegion.model_id)
+        .filter(
+            DBModelRegion.region_id.in_(managed_ids),
+            DBModelRegion.sync_status != "synced",
+        )
+        .all()
+    ):
+        if (assoc.model_id, assoc.region_id) in syncs:
+            continue
+        changes.append(
+            ApplyChange(
+                entity="deployment",
+                key=f"{model_key}@{region_names.get(assoc.region_id, assoc.region_id)}",
+                action="resync",
+                detail=f"retrying sync_status={assoc.sync_status}",
+            )
+        )
+        syncs.add((assoc.model_id, assoc.region_id))
 
     payload_slugs = {g.slug for g in req.access_groups}
     unmanaged_access_groups = sorted(

--- a/app/schemas/models.py
+++ b/app/schemas/models.py
@@ -1434,7 +1434,7 @@ class ApplyConfigRequest(BaseModel):
 class ApplyChange(BaseModel):
     entity: str  # access_group | model | deployment | alias_target
     key: str
-    action: str  # create | update | deactivate | prune | prune_blocked
+    action: str  # create | update | deactivate | prune | prune_blocked | resync
     detail: Optional[str] = None
 
 

--- a/tests/test_model_config_apply.py
+++ b/tests/test_model_config_apply.py
@@ -88,11 +88,37 @@ def test_apply_creates_everything(mock_svc, client, admin_token, db, test_region
 def test_apply_is_idempotent(mock_svc, client, admin_token, db, test_region):
     payload = _payload(test_region.name)
     assert _apply(client, admin_token, payload).status_code == 200
+    # Only cleanly synced rows are a no-op; anything else is retried on purpose.
+    db.query(DBModelRegion).update({"sync_status": "synced"})
+    db.commit()
     res = _apply(client, admin_token, payload)
     assert res.status_code == 200
     data = res.json()
     assert data["changes"] == []
     assert data["syncs_scheduled"] == 0
+
+
+@patch("app.services.model_sync.LiteLLMService")
+def test_apply_reschedules_failed_syncs_without_config_diff(
+    mock_svc, client, admin_token, db, test_region
+):
+    """A sync that failed (e.g. the proxy still had the model in its config
+    file) must be retried by the next apply, even when the config is unchanged."""
+    payload = _payload(test_region.name)
+    assert _apply(client, admin_token, payload).status_code == 200
+    db.query(DBModelRegion).update({"sync_status": "synced"})
+    model = db.query(DBModel).filter_by(model_id="claude-sonnet").one()
+    assoc = db.query(DBModelRegion).filter_by(model_id=model.id).one()
+    assoc.sync_status = "failed"
+    db.commit()
+
+    res = _apply(client, admin_token, payload)
+    assert res.status_code == 200
+    data = res.json()
+    assert data["syncs_scheduled"] == 1
+    assert {(c["key"], c["action"]) for c in data["changes"]} == {
+        (f"claude-sonnet@{test_region.name}", "resync")
+    }
 
 
 def test_apply_dry_run_writes_nothing(client, admin_token, db, test_region):
@@ -259,6 +285,8 @@ def test_apply_retarget_alias_triggers_resync(mock_svc, client, admin_token, db,
         }
     )
     assert _apply(client, admin_token, payload).status_code == 200
+    db.query(DBModelRegion).update({"sync_status": "synced"})
+    db.commit()
 
     # Point the alias at a different target: alias must be marked changed and resynced.
     payload["models"][1]["alias_targets"] = [{"region": test_region.name, "target": "claude-haiku"}]
@@ -293,6 +321,8 @@ def test_apply_override_change_resyncs_only_that_region(mock_svc, client, admin_
     payload["models"][1]["alias_targets"].append({"region": "second-region", "target": "claude-sonnet"})
     payload["access_groups"][0]["regions"].append("second-region")
     assert _apply(client, admin_token, payload).status_code == 200
+    db.query(DBModelRegion).update({"sync_status": "synced"})
+    db.commit()
 
     # Change only the first region's override — the second region must not resync.
     payload["models"][0]["deployments"][0]["litellm_params_override"] = {

--- a/tests/test_model_config_apply.py
+++ b/tests/test_model_config_apply.py
@@ -121,6 +121,31 @@ def test_apply_reschedules_failed_syncs_without_config_diff(
     }
 
 
+@patch("app.services.model_sync.LiteLLMService")
+def test_apply_pruned_deployment_is_deactivated_not_resynced(
+    mock_svc, client, admin_token, db, test_region
+):
+    """A failed deployment that is being pruned in the same apply must show a
+    single 'deactivate' change — never a contradictory 'resync' as well."""
+    payload = _payload(test_region.name)
+    payload["models"][1]["real_eol"] = "2020-01-01T00:00:00Z"
+    assert _apply(client, admin_token, payload).status_code == 200
+    db.query(DBModelRegion).update({"sync_status": "failed"})
+    db.commit()
+
+    pruned = _payload(test_region.name)
+    pruned["models"] = [m for m in pruned["models"] if m["model_id"] == "claude-sonnet"]
+    pruned["prune"] = True
+    res = _apply(client, admin_token, pruned)
+    assert res.status_code == 200
+    actions = [
+        (c["key"], c["action"])
+        for c in res.json()["changes"]
+        if c["key"].startswith("chat@")
+    ]
+    assert actions == [(f"chat@{test_region.name}", "deactivate")]
+
+
 def test_apply_dry_run_writes_nothing(client, admin_token, db, test_region):
     payload = _payload(test_region.name)
     payload["dry_run"] = True


### PR DESCRIPTION
## Problem

Rolling out model management to us1 stalled: the first catalog apply ran while us1's LiteLLM still had the models in its config file, so LiteLLM rejected every write (`Can't edit model. Model in config`) and ~38 deployments were left with `sync_status: failed`. Re-triggering the catalog GitHub Action could never recover them — the apply endpoint is a pure config-diff, so a row whose config didn't change is never re-synced, and every run reported `No changes — 0 syncs scheduled`.

## Fix

After the normal diff, the apply now also reschedules every deployment in a managed region whose `sync_status != "synced"`. The sync task is an idempotent upsert/delete, so retrying is always safe. Retried rows are reported as `resync` changes, so the catalog rollout report shows exactly what is being healed instead of "No changes".

This makes the apply self-healing: once us1's LiteLLM config is emptied, the next scheduled (or manually triggered) catalog apply repairs all failed deployments with no manual intervention.

## Tests

- New: `test_apply_reschedules_failed_syncs_without_config_diff`
- Updated: idempotency/resync tests now pin rows to `synced` first, since a non-synced row being retried is the new intended behavior
- All 17 tests in `tests/test_model_config_apply.py` pass

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The apply endpoint now retries managed deployments whose previous synchronization did not complete successfully, allowing unchanged catalog applications to heal failed deployments.
- Adds non-synced deployments to the existing synchronization schedule.
- Reports retry-only work as a `resync` change.
- Avoids duplicate or contradictory reporting for deployments already scheduled by configuration changes or pruning.
- Adds regression coverage for unchanged failed deployments and prune/resync overlap.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/admin_model_apply.py | Adds retry scheduling for non-synced managed deployments after all diff and pruning work, with tuple-based deduplication against previously scheduled actions. |
| app/schemas/models.py | Documents `resync` as an additional apply-change action. |
| tests/test_model_config_apply.py | Covers failed-sync retries without configuration changes and confirms pruning emits only the deactivation action. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Apply catalog] --> B[Compute configuration diff]
    B --> C[Schedule changed deployments]
    C --> D[Deactivate and schedule pruned deployments]
    D --> E[Query managed deployments not synced]
    E --> F{Already scheduled?}
    F -->|Yes| G[Keep existing change action]
    F -->|No| H[Report resync and schedule task]
    G --> I[Commit and enqueue sync tasks]
    H --> I
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: run the resync sweep after pruning ..."](https://github.com/amazeeio/amazee.ai/commit/c0bec09c1d468a6e82ffac1b60847bdf266948c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51752584)</sub>

<!-- /greptile_comment -->