### PR TITLE
feat: sync aliases as router model_group_alias, not duplicate models

### DIFF
--- a/app/services/access_groups.py
+++ b/app/services/access_groups.py
@@ -55,8 +55,18 @@ def model_access_group_slugs(db: Session, model_pk: int, region_id: int) -> list
 
 def region_access_group_members(db: Session, region_id: int) -> dict[str, list[str]]:
     """slug -> sorted member model_ids for every group deployed to the region.
-    Only real, actively deployed models count — aliases resolve to their target
-    at auth time, so they are never entity members."""
+
+    Every deployed group is included, even with no members yet (e.g. a
+    'preview' group that exists so teams can attach before any model ships).
+    Only real, actively deployed models count as members — aliases resolve to
+    their target at auth time, so they are never entity members."""
+    deployed = (
+        db.query(DBModelAccessGroup.slug)
+        .join(DBModelAccessGroupRegion, DBModelAccessGroupRegion.group_id == DBModelAccessGroup.id)
+        .filter(DBModelAccessGroupRegion.region_id == region_id)
+        .all()
+    )
+    members: dict[str, list[str]] = {slug: [] for (slug,) in deployed}
     rows = (
         db.query(DBModelAccessGroup.slug, DBModel.model_id)
         .join(DBModelAccessGroupRegion, DBModelAccessGroupRegion.group_id == DBModelAccessGroup.id)
@@ -76,7 +86,6 @@ def region_access_group_members(db: Session, region_id: int) -> dict[str, list[s
         )
         .all()
     )
-    members: dict[str, list[str]] = {}
     for slug, model_id in rows:
         members.setdefault(slug, []).append(model_id)
     return {slug: sorted(ids) for slug, ids in members.items()}

--- a/app/services/access_groups.py
+++ b/app/services/access_groups.py
@@ -16,9 +16,11 @@ from sqlalchemy.orm import Session
 from app.core.config import catalog_manages
 from app.db.database import get_db
 from app.db.models import (
+    DBModel,
     DBModelAccessGroup,
     DBModelAccessGroupModel,
     DBModelAccessGroupRegion,
+    DBModelRegion,
     DBRegion,
     DBTeam,
     DBTeamGroupSyncRun,
@@ -28,6 +30,11 @@ from app.db.models import (
 from app.services.litellm import LiteLLMService
 
 logger = logging.getLogger(__name__)
+
+# Written into every access-group entity amazee.ai creates on a proxy — the
+# reconciler only ever deletes entities carrying this marker, so groups made
+# by hand in the LiteLLM UI survive.
+ACCESS_GROUP_MANAGED_DESCRIPTION = "Managed by the amazee.ai model catalog"
 
 
 def model_access_group_slugs(db: Session, model_pk: int, region_id: int) -> list[str]:
@@ -44,6 +51,66 @@ def model_access_group_slugs(db: Session, model_pk: int, region_id: int) -> list
         .all()
     )
     return sorted(row[0] for row in rows)
+
+
+def region_access_group_members(db: Session, region_id: int) -> dict[str, list[str]]:
+    """slug -> sorted member model_ids for every group deployed to the region.
+    Only real, actively deployed models count — aliases resolve to their target
+    at auth time, so they are never entity members."""
+    rows = (
+        db.query(DBModelAccessGroup.slug, DBModel.model_id)
+        .join(DBModelAccessGroupRegion, DBModelAccessGroupRegion.group_id == DBModelAccessGroup.id)
+        .join(DBModelAccessGroupModel, DBModelAccessGroupModel.group_id == DBModelAccessGroup.id)
+        .join(DBModel, DBModel.id == DBModelAccessGroupModel.model_id)
+        .join(
+            DBModelRegion,
+            (DBModelRegion.model_id == DBModel.id)
+            & (DBModelRegion.region_id == region_id)
+            & (DBModelRegion.is_active.is_(True)),
+        )
+        .filter(
+            DBModelAccessGroupRegion.region_id == region_id,
+            DBModel.deleted_at.is_(None),
+            DBModel.is_active_globally.is_(True),
+            DBModel.is_alias.is_(False),
+        )
+        .all()
+    )
+    members: dict[str, list[str]] = {}
+    for slug, model_id in rows:
+        members.setdefault(slug, []).append(model_id)
+    return {slug: sorted(ids) for slug, ids in members.items()}
+
+
+async def sync_region_access_group_entities(
+    db: Session, region: DBRegion, service: LiteLLMService | None = None
+) -> None:
+    """Mirror the region's access groups into LiteLLM's entity store
+    (/v1/access_group — what the proxy admin UI lists).
+
+    Enforcement itself rides on the model tags and team `models` lists; the
+    entity registry is the operator-visible half. Reconciled whole each time:
+    create missing groups, fix drifted member lists, and delete groups we
+    created that are no longer deployed to the region. Entities without our
+    description marker are treated as hand-made and never deleted.
+    """
+    desired = region_access_group_members(db, region.id)
+    if service is None:
+        service = LiteLLMService(api_url=region.litellm_api_url, api_key=region.litellm_api_key)
+    existing = {g["access_group_name"]: g for g in await service.list_access_groups()}
+
+    for slug, members in desired.items():
+        row = existing.get(slug)
+        if row is None:
+            await service.create_access_group(
+                slug, members, description=ACCESS_GROUP_MANAGED_DESCRIPTION
+            )
+        elif sorted(row.get("access_model_names") or []) != members:
+            await service.update_access_group(row["access_group_id"], model_names=members)
+
+    for slug, row in existing.items():
+        if slug not in desired and row.get("description") == ACCESS_GROUP_MANAGED_DESCRIPTION:
+            await service.delete_access_group(row["access_group_id"])
 
 
 def effective_team_group_slugs(db: Session, team_id: int, region: DBRegion) -> list[str] | None:

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -981,6 +981,91 @@ class LiteLLMService:
                 detail=f"Failed to update LiteLLM model_group_alias: {error_msg}",
             )
 
+    async def list_access_groups(self) -> list[dict]:
+        """List the proxy's access-group entities (GET /v1/access_group) —
+        the registry the LiteLLM admin UI shows, distinct from the legacy
+        per-model model_info.access_groups tags."""
+        try:
+            async with httpx.AsyncClient(timeout=MODEL_HTTP_TIMEOUT) as client:
+                response = await client.get(
+                    f"{self.api_url}/v1/access_group",
+                    headers={"Authorization": f"Bearer {self.master_key}"},
+                )
+                response.raise_for_status()
+                data = response.json()
+                return data if isinstance(data, list) else []
+        except httpx.HTTPStatusError as e:
+            _, error_msg, _ = self._parse_http_error(e)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to list LiteLLM access groups: {error_msg}",
+            )
+
+    async def create_access_group(
+        self, name: str, model_names: list[str], description: Optional[str] = None
+    ) -> dict:
+        """Create an access-group entity (POST /v1/access_group)."""
+        try:
+            async with httpx.AsyncClient(timeout=MODEL_HTTP_TIMEOUT) as client:
+                response = await client.post(
+                    f"{self.api_url}/v1/access_group",
+                    headers={"Authorization": f"Bearer {self.master_key}"},
+                    json={
+                        "access_group_name": name,
+                        "access_model_names": model_names,
+                        "description": description,
+                    },
+                )
+                response.raise_for_status()
+                logger.info(f"Created access group '{name}' with {len(model_names)} models in LiteLLM")
+                return response.json()
+        except httpx.HTTPStatusError as e:
+            _, error_msg, _ = self._parse_http_error(e)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to create LiteLLM access group: {error_msg}",
+            )
+
+    async def update_access_group(
+        self, access_group_id: str, model_names: list[str]
+    ) -> dict:
+        """Update an access-group entity's member models (PUT
+        /v1/access_group/{id}). Only the model list is sent, so team/key
+        assignments made on the proxy are left untouched."""
+        try:
+            async with httpx.AsyncClient(timeout=MODEL_HTTP_TIMEOUT) as client:
+                response = await client.put(
+                    f"{self.api_url}/v1/access_group/{access_group_id}",
+                    headers={"Authorization": f"Bearer {self.master_key}"},
+                    json={"access_model_names": model_names},
+                )
+                response.raise_for_status()
+                logger.info(f"Updated access group {access_group_id} to {len(model_names)} models in LiteLLM")
+                return response.json()
+        except httpx.HTTPStatusError as e:
+            _, error_msg, _ = self._parse_http_error(e)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to update LiteLLM access group: {error_msg}",
+            )
+
+    async def delete_access_group(self, access_group_id: str) -> None:
+        """Delete an access-group entity (DELETE /v1/access_group/{id})."""
+        try:
+            async with httpx.AsyncClient(timeout=MODEL_HTTP_TIMEOUT) as client:
+                response = await client.delete(
+                    f"{self.api_url}/v1/access_group/{access_group_id}",
+                    headers={"Authorization": f"Bearer {self.master_key}"},
+                )
+                response.raise_for_status()
+                logger.info(f"Deleted access group {access_group_id} in LiteLLM")
+        except httpx.HTTPStatusError as e:
+            _, error_msg, _ = self._parse_http_error(e)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to delete LiteLLM access group: {error_msg}",
+            )
+
     async def get_cost_margin_config(self) -> dict:
         """Get LiteLLM provider margin configuration."""
         try:

--- a/app/services/litellm.py
+++ b/app/services/litellm.py
@@ -958,6 +958,29 @@ class LiteLLMService:
                 detail=f"Failed to get LiteLLM router settings: {error_msg}",
             )
 
+    async def set_model_group_aliases(self, alias_map: dict[str, str]) -> None:
+        """Replace the proxy's router-level alias map (model_group_alias).
+
+        POST /config/update persists router_settings in LiteLLM's DB config
+        row, so this survives restarts. The map is one router-wide dict —
+        callers must always send the region's FULL desired map, not a delta.
+        """
+        try:
+            async with httpx.AsyncClient(timeout=MODEL_HTTP_TIMEOUT) as client:
+                response = await client.post(
+                    f"{self.api_url}/config/update",
+                    headers={"Authorization": f"Bearer {self.master_key}"},
+                    json={"router_settings": {"model_group_alias": alias_map}},
+                )
+                response.raise_for_status()
+                logger.info(f"Updated model_group_alias to {alias_map} in LiteLLM")
+        except httpx.HTTPStatusError as e:
+            _, error_msg, _ = self._parse_http_error(e)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to update LiteLLM model_group_alias: {error_msg}",
+            )
+
     async def get_cost_margin_config(self) -> dict:
         """Get LiteLLM provider margin configuration."""
         try:

--- a/app/services/model_sync.py
+++ b/app/services/model_sync.py
@@ -5,7 +5,10 @@ from datetime import datetime, UTC
 from app.core.config import catalog_manages
 from app.db.database import get_db
 from app.db.models import DBModel, DBModelAliasTarget, DBModelRegion, DBRegion
-from app.services.access_groups import model_access_group_slugs
+from app.services.access_groups import (
+    model_access_group_slugs,
+    sync_region_access_group_entities,
+)
 from app.services.litellm import LiteLLMService
 
 logger = logging.getLogger(__name__)
@@ -209,7 +212,13 @@ async def sync_model_to_region_task(model_id: int, region_id: int) -> None:
         else:
             logger.info(f"Deregistering model '{model.model_id}' from region '{region.name}'")
             await litellm_service.delete_model(model.model_id, deployment_ids)
-            
+
+        # A model coming or going changes group membership, so mirror the
+        # region's access groups into the proxy's entity registry (the list
+        # the LiteLLM admin UI shows). Aliases are never entity members.
+        if not model.is_alias:
+            await sync_region_access_group_entities(db, region, service=litellm_service)
+
         # Success!
         assoc.sync_status = "synced"
         assoc.sync_error = None

--- a/app/services/model_sync.py
+++ b/app/services/model_sync.py
@@ -2,6 +2,8 @@ import logging
 import traceback
 from datetime import datetime, UTC
 
+from sqlalchemy import text
+
 from app.core.config import catalog_manages
 from app.db.database import get_db
 from app.db.models import DBModel, DBModelAliasTarget, DBModelRegion, DBRegion
@@ -12,6 +14,10 @@ from app.services.access_groups import (
 from app.services.litellm import LiteLLMService
 
 logger = logging.getLogger(__name__)
+
+# First key of the two-int postgres advisory lock serializing per-region
+# writes of router_settings.model_group_alias (second key: region id).
+ALIAS_MAP_LOCK_NAMESPACE = 743_291_648
 
 
 def effective_litellm_params(
@@ -165,14 +171,39 @@ async def sync_model_to_region_task(model_id: int, region_id: int) -> None:
         if model.is_alias:
             # Real aliases live in router_settings.model_group_alias, not as
             # duplicate model entries (auth resolves the alias to its target,
-            # so access-group checks apply to the target's tags). Delete any
-            # legacy alias-as-model entry, then write the region's full map —
-            # activation and deactivation are both just "recompute the map".
+            # so access-group checks apply to the target's tags). The map is
+            # one router-wide dict, so activation, retargeting and
+            # deactivation are all "recompute and rewrite the full map".
+            #
+            # Serialize map writes per region: concurrent alias syncs (e.g.
+            # overlapping catalog applies across uvicorn workers) would
+            # otherwise race on the shared dict and the last — possibly
+            # stalest — writer would win. The advisory lock is transaction-
+            # scoped, so compute-and-push always runs against DB state at
+            # least as fresh as any earlier writer's.
+            db.execute(
+                text("SELECT pg_advisory_xact_lock(:ns, :region)"),
+                {"ns": ALIAS_MAP_LOCK_NAMESPACE, "region": region_id},
+            )
+            alias_map = region_model_group_alias_map(db, region_id)
+            # A DB row saying the target is deployed is not enough — its own
+            # sync may still be pending or failed. Only route to model groups
+            # that actually exist on the proxy, or the alias would 404.
+            info = await litellm_service.get_model_info()
+            live_names = {
+                entry.get("model_name")
+                for entry in (info.get("data") or [])
+                if isinstance(entry, dict)
+            }
+            alias_map = {a: t for a, t in alias_map.items() if t in live_names}
+            # Write the map before deleting any legacy alias-as-model entry:
+            # if the delete then fails, both mechanisms briefly coexist (which
+            # still serves requests) and the retry cleans up — the reverse
+            # order would leave the alias with neither.
+            await litellm_service.set_model_group_aliases(alias_map)
             if deployment_ids:
                 logger.info(f"Removing legacy alias model entry '{model.model_id}' from region '{region.name}'")
                 await litellm_service.delete_model(model.model_id, deployment_ids)
-            alias_map = region_model_group_alias_map(db, region_id)
-            await litellm_service.set_model_group_aliases(alias_map)
             if (
                 assoc.is_active
                 and model.is_active_globally
@@ -180,7 +211,8 @@ async def sync_model_to_region_task(model_id: int, region_id: int) -> None:
             ):
                 assoc.sync_status = "failed"
                 assoc.sync_error = (
-                    f"Alias '{model.model_id}' has no active target deployment in this region."
+                    f"Alias '{model.model_id}' has no active target deployment "
+                    "in this region (or its target has not synced yet)."
                 )
                 db.commit()
                 logger.error(f"Sync failed for model_id={model_id}, region_id={region_id}: {assoc.sync_error}")

--- a/app/services/model_sync.py
+++ b/app/services/model_sync.py
@@ -45,6 +45,42 @@ def effective_litellm_params(
     return {**dict(model.litellm_params or {}), **override}, None
 
 
+def region_model_group_alias_map(db, region_id: int) -> dict[str, str]:
+    """The full desired ``model_group_alias`` map for one region's proxy:
+    every active alias with an active target deployment in that region.
+    Router-level state — always computed whole, never per-alias deltas."""
+    alias_map: dict[str, str] = {}
+    rows = (
+        db.query(DBModel, DBModelAliasTarget)
+        .join(DBModelAliasTarget, DBModelAliasTarget.alias_model_id == DBModel.id)
+        .join(
+            DBModelRegion,
+            (DBModelRegion.model_id == DBModel.id)
+            & (DBModelRegion.region_id == region_id)
+            & (DBModelRegion.is_active.is_(True)),
+        )
+        .filter(
+            DBModelAliasTarget.region_id == region_id,
+            DBModel.is_alias.is_(True),
+            DBModel.is_active_globally.is_(True),
+            DBModel.deleted_at.is_(None),
+        )
+        .all()
+    )
+    for alias, target_row in rows:
+        target = db.query(DBModel).filter_by(id=target_row.target_model_id).first()
+        if not target or target.deleted_at is not None or not target.is_active_globally:
+            continue
+        deployed = (
+            db.query(DBModelRegion)
+            .filter_by(model_id=target.id, region_id=region_id, is_active=True)
+            .first()
+        )
+        if deployed:
+            alias_map[alias.model_id] = target.model_id
+    return alias_map
+
+
 def _scrub_secrets(text: str, litellm_params) -> str:
     """Proxy error bodies can echo the request payload (e.g. a 422 quoting
     litellm_params, api_key included). sync_error is shown in admin responses,
@@ -123,7 +159,30 @@ async def sync_model_to_region_task(model_id: int, region_id: int) -> None:
         # of add-then-catch-conflict (which would silently create duplicates).
         deployment_ids = await litellm_service.get_model_deployment_ids(model.model_id)
 
-        if assoc.is_active and model.is_active_globally:
+        if model.is_alias:
+            # Real aliases live in router_settings.model_group_alias, not as
+            # duplicate model entries (auth resolves the alias to its target,
+            # so access-group checks apply to the target's tags). Delete any
+            # legacy alias-as-model entry, then write the region's full map —
+            # activation and deactivation are both just "recompute the map".
+            if deployment_ids:
+                logger.info(f"Removing legacy alias model entry '{model.model_id}' from region '{region.name}'")
+                await litellm_service.delete_model(model.model_id, deployment_ids)
+            alias_map = region_model_group_alias_map(db, region_id)
+            await litellm_service.set_model_group_aliases(alias_map)
+            if (
+                assoc.is_active
+                and model.is_active_globally
+                and model.model_id not in alias_map
+            ):
+                assoc.sync_status = "failed"
+                assoc.sync_error = (
+                    f"Alias '{model.model_id}' has no active target deployment in this region."
+                )
+                db.commit()
+                logger.error(f"Sync failed for model_id={model_id}, region_id={region_id}: {assoc.sync_error}")
+                return
+        elif assoc.is_active and model.is_active_globally:
             # Base params + per-region override, or the alias target's params.
             params, resolve_error = effective_litellm_params(db, model, region_id)
             pushed_params = params

--- a/tests/test_access_groups.py
+++ b/tests/test_access_groups.py
@@ -463,11 +463,13 @@ def test_model_sync_pushes_access_groups(mock_service_cls, client, db, test_regi
     _make_group(db, slug="grp", model_ids=[model.id], region_ids=[test_region.id])
     # The sync task commits and closes the session, detaching/expiring the
     # fixtures' instances — capture plain ids up front.
-    model_pk, region_pk = model.id, test_region.id
+    model_pk, region_pk, model_key = model.id, test_region.id, model.model_id
 
     instance = mock_service_cls.return_value
     instance.get_model_deployment_ids = AsyncMock(return_value=[])
     instance.add_model = AsyncMock(return_value={})
+    instance.list_access_groups = AsyncMock(return_value=[])
+    instance.create_access_group = AsyncMock(return_value={})
 
     with patch("app.services.model_sync.get_db", lambda: iter([db])):
         asyncio.run(sync_model_to_region_task(model_pk, region_pk))
@@ -480,3 +482,58 @@ def test_model_sync_pushes_access_groups(mock_service_cls, client, db, test_regi
         .first()
     )
     assert refreshed.sync_status == "synced"
+    # The entity registry (what the LiteLLM UI lists) is reconciled too.
+    from app.services.access_groups import ACCESS_GROUP_MANAGED_DESCRIPTION
+
+    instance.create_access_group.assert_called_once_with(
+        "grp", [model_key], description=ACCESS_GROUP_MANAGED_DESCRIPTION
+    )
+
+
+@patch("app.services.model_sync.LiteLLMService")
+def test_model_sync_reconciles_access_group_entities(mock_service_cls, client, db, test_region):
+    """Drifted member lists are corrected, stale managed entities are deleted,
+    and hand-made entities (no marker description) are never touched."""
+    from app.services.access_groups import ACCESS_GROUP_MANAGED_DESCRIPTION
+    from app.services.model_sync import sync_model_to_region_task
+    import asyncio
+
+    model = _make_model(db)
+    _deploy_model(db, model, test_region, sync_status="pending")
+    _make_group(db, slug="grp", model_ids=[model.id], region_ids=[test_region.id])
+    model_pk, region_pk = model.id, test_region.id
+    model_key = model.model_id
+
+    instance = mock_service_cls.return_value
+    instance.get_model_deployment_ids = AsyncMock(return_value=[])
+    instance.add_model = AsyncMock(return_value={})
+    instance.list_access_groups = AsyncMock(
+        return_value=[
+            {
+                "access_group_id": "ag-1",
+                "access_group_name": "grp",
+                "description": ACCESS_GROUP_MANAGED_DESCRIPTION,
+                "access_model_names": ["stale-model"],
+            },
+            {
+                "access_group_id": "ag-2",
+                "access_group_name": "retired-group",
+                "description": ACCESS_GROUP_MANAGED_DESCRIPTION,
+                "access_model_names": [],
+            },
+            {
+                "access_group_id": "ag-3",
+                "access_group_name": "hand-made",
+                "description": "made in the UI",
+                "access_model_names": [],
+            },
+        ]
+    )
+    instance.update_access_group = AsyncMock(return_value={})
+    instance.delete_access_group = AsyncMock(return_value=None)
+
+    with patch("app.services.model_sync.get_db", lambda: iter([db])):
+        asyncio.run(sync_model_to_region_task(model_pk, region_pk))
+
+    instance.update_access_group.assert_called_once_with("ag-1", model_names=[model_key])
+    instance.delete_access_group.assert_called_once_with("ag-2")

--- a/tests/test_access_groups.py
+++ b/tests/test_access_groups.py
@@ -501,6 +501,9 @@ def test_model_sync_reconciles_access_group_entities(mock_service_cls, client, d
     model = _make_model(db)
     _deploy_model(db, model, test_region, sync_status="pending")
     _make_group(db, slug="grp", model_ids=[model.id], region_ids=[test_region.id])
+    # Deployed to the region but memberless — must still exist as an entity
+    # so teams can attach it before any model ships (e.g. 'preview').
+    _make_group(db, slug="empty-group", model_ids=[], region_ids=[test_region.id])
     model_pk, region_pk = model.id, test_region.id
     model_key = model.model_id
 
@@ -529,6 +532,7 @@ def test_model_sync_reconciles_access_group_entities(mock_service_cls, client, d
             },
         ]
     )
+    instance.create_access_group = AsyncMock(return_value={})
     instance.update_access_group = AsyncMock(return_value={})
     instance.delete_access_group = AsyncMock(return_value=None)
 
@@ -537,3 +541,6 @@ def test_model_sync_reconciles_access_group_entities(mock_service_cls, client, d
 
     instance.update_access_group.assert_called_once_with("ag-1", model_names=[model_key])
     instance.delete_access_group.assert_called_once_with("ag-2")
+    instance.create_access_group.assert_called_once_with(
+        "empty-group", [], description=ACCESS_GROUP_MANAGED_DESCRIPTION
+    )

--- a/tests/test_admin_models.py
+++ b/tests/test_admin_models.py
@@ -169,6 +169,7 @@ def test_sync_model_existing_deployment_updates(mock_litellm_class, db, test_reg
     mock_instance.get_model_deployment_ids = AsyncMock(return_value=["dep-123"])
     mock_instance.add_model = AsyncMock()
     mock_instance.update_model = AsyncMock(return_value={"status": "success"})
+    mock_instance.list_access_groups = AsyncMock(return_value=[])
     mock_litellm_class.return_value = mock_instance
 
     m = DBModel(
@@ -213,6 +214,7 @@ def test_sync_model_poisoned_session_never_commits_stale_synced(mock_litellm_cla
     mock_instance = MagicMock()
     mock_instance.get_model_deployment_ids = AsyncMock(return_value=[])
     mock_instance.add_model = AsyncMock(return_value={"status": "success"})
+    mock_instance.list_access_groups = AsyncMock(return_value=[])
     mock_litellm_class.return_value = mock_instance
 
     m = DBModel(
@@ -234,16 +236,16 @@ def test_sync_model_poisoned_session_never_commits_stale_synced(mock_litellm_cla
     db.commit()
 
     class PoisonedSession:
-        """Delegates to a real session; the 6th query (the error-path re-query,
-        after assoc/model/region/effective-params/access-group-slugs fetches)
-        raises as if the connection dropped."""
+        """Delegates to a real session; the 7th query (the error-path re-query,
+        after assoc/model/region/effective-params/access-group-slugs/entity-
+        reconcile fetches) raises as if the connection dropped."""
         def __init__(self, real):
             self._real = real
             self._queries = 0
 
         def query(self, *args, **kwargs):
             self._queries += 1
-            if self._queries > 5:
+            if self._queries > 6:
                 raise RuntimeError("connection lost")
             return self._real.query(*args, **kwargs)
 
@@ -276,6 +278,7 @@ def test_sync_model_global_deactivation_deregisters(mock_litellm_class, db, test
     mock_instance = MagicMock()
     mock_instance.get_model_deployment_ids = AsyncMock(return_value=["dep-1"])
     mock_instance.delete_model = AsyncMock(return_value=None)
+    mock_instance.list_access_groups = AsyncMock(return_value=[])
     mock_litellm_class.return_value = mock_instance
 
     m = DBModel(

--- a/tests/test_admin_models.py
+++ b/tests/test_admin_models.py
@@ -406,6 +406,9 @@ def test_alias_sync_writes_model_group_alias_and_removes_legacy_entry(
 
     mock_instance = MagicMock()
     mock_instance.get_model_deployment_ids = AsyncMock(return_value=["legacy-dep-1"])
+    mock_instance.get_model_info = AsyncMock(
+        return_value={"data": [{"model_name": "alias-target", "model_info": {"id": "t-1"}}]}
+    )
     mock_instance.delete_model = AsyncMock()
     mock_instance.set_model_group_aliases = AsyncMock()
     mock_instance.add_model = AsyncMock()
@@ -421,8 +424,35 @@ def test_alias_sync_writes_model_group_alias_and_removes_legacy_entry(
     mock_instance.set_model_group_aliases.assert_called_once_with(
         {"chat-alias": "alias-target"}
     )
+    # The map must land BEFORE the legacy entry is deleted — a failed delete
+    # then leaves both mechanisms serving, never neither.
+    method_order = [c[0] for c in mock_instance.mock_calls]
+    assert method_order.index("set_model_group_aliases") < method_order.index("delete_model")
     mock_instance.add_model.assert_not_called()
     mock_instance.update_model.assert_not_called()
+
+
+@patch("app.services.model_sync.LiteLLMService")
+def test_alias_sync_skips_target_missing_from_proxy(mock_litellm_class, db, test_region):
+    """A target that is active in the DB but absent from the proxy (its own
+    sync pending/failed) must not be routed to — the alias is marked failed
+    and retried by a later apply instead of 404ing."""
+    from app.services.model_sync import sync_model_to_region_task
+
+    alias, alias_assoc = _make_alias_with_target(db, test_region)
+
+    mock_instance = MagicMock()
+    mock_instance.get_model_deployment_ids = AsyncMock(return_value=[])
+    mock_instance.get_model_info = AsyncMock(return_value={"data": []})
+    mock_instance.set_model_group_aliases = AsyncMock()
+    mock_litellm_class.return_value = mock_instance
+
+    import asyncio
+    asyncio.run(sync_model_to_region_task(alias.id, test_region.id))
+
+    db.refresh(alias_assoc)
+    assert alias_assoc.sync_status == "failed"
+    mock_instance.set_model_group_aliases.assert_called_once_with({})
 
 
 @patch("app.services.model_sync.LiteLLMService")
@@ -435,6 +465,7 @@ def test_alias_sync_fails_when_target_not_deployed(mock_litellm_class, db, test_
 
     mock_instance = MagicMock()
     mock_instance.get_model_deployment_ids = AsyncMock(return_value=[])
+    mock_instance.get_model_info = AsyncMock(return_value={"data": []})
     mock_instance.set_model_group_aliases = AsyncMock()
     mock_litellm_class.return_value = mock_instance
 

--- a/tests/test_admin_models.py
+++ b/tests/test_admin_models.py
@@ -308,22 +308,62 @@ def test_sync_model_global_deactivation_deregisters(mock_litellm_class, db, test
 
 @patch("app.services.model_sync.LiteLLMService")
 def test_sync_error_scrubs_override_credentials(mock_litellm_class, db, test_region):
-    """sync_error must redact credentials from ALL params sources: base params,
-    the per-region override, and (for aliases) the target's effective params —
-    proxies can echo the full request payload in error bodies."""
-    from app.db.models import DBModelAliasTarget
+    """sync_error must redact credentials from ALL params sources: base params
+    and the per-region override — proxies can echo the full request payload in
+    error bodies."""
     from app.services.model_sync import sync_model_to_region_task
 
-    target = DBModel(
-        model_id="scrub-target",
-        display_name="Scrub Target",
+    model = DBModel(
+        model_id="scrub-model",
+        display_name="Scrub Model",
         provider="test",
         type="chat",
-        litellm_params={"model": "x", "aws_secret_access_key": "sk-target-secret99"},
+        litellm_params={"model": "x", "aws_secret_access_key": "sk-base-secret99"},
+    )
+    db.add(model)
+    db.commit()
+    assoc = DBModelRegion(
+        model_id=model.id,
+        region_id=test_region.id,
+        is_active=True,
+        sync_status="pending",
+        litellm_params_override={"api_key": "sk-override-secret99"},
+    )
+    db.add(assoc)
+    db.commit()
+
+    mock_instance = MagicMock()
+    mock_instance.get_model_deployment_ids = AsyncMock(return_value=[])
+    mock_instance.add_model = AsyncMock(
+        side_effect=Exception(
+            "422: payload rejected: aws_secret_access_key=sk-base-secret99 api_key=sk-override-secret99"
+        )
+    )
+    mock_litellm_class.return_value = mock_instance
+
+    import asyncio
+    asyncio.run(sync_model_to_region_task(model.id, test_region.id))
+
+    db.refresh(assoc)
+    assert assoc.sync_status == "failed"
+    assert "sk-base-secret99" not in assoc.sync_error
+    assert "sk-override-secret99" not in assoc.sync_error
+    assert "********" in assoc.sync_error
+
+
+def _make_alias_with_target(db, region, *, target_active=True):
+    from app.db.models import DBModelAliasTarget
+
+    target = DBModel(
+        model_id="alias-target",
+        display_name="Alias Target",
+        provider="test",
+        type="chat",
+        litellm_params={"model": "test/alias-target"},
     )
     alias = DBModel(
-        model_id="scrub-alias",
-        display_name="Scrub Alias",
+        model_id="chat-alias",
+        display_name="Chat Alias",
         provider="alias",
         type="chat",
         is_alias=True,
@@ -332,33 +372,67 @@ def test_sync_error_scrubs_override_credentials(mock_litellm_class, db, test_reg
     db.commit()
     db.add(
         DBModelAliasTarget(
-            alias_model_id=alias.id, region_id=test_region.id, target_model_id=target.id
+            alias_model_id=alias.id, region_id=region.id, target_model_id=target.id
         )
     )
     db.add(
         DBModelRegion(
             model_id=target.id,
-            region_id=test_region.id,
-            is_active=True,
-            litellm_params_override={"api_key": "sk-override-secret99"},
+            region_id=region.id,
+            is_active=target_active,
+            sync_status="synced",
         )
     )
     alias_assoc = DBModelRegion(
-        model_id=alias.id,
-        region_id=test_region.id,
-        is_active=True,
-        sync_status="pending",
+        model_id=alias.id, region_id=region.id, is_active=True, sync_status="pending"
     )
     db.add(alias_assoc)
     db.commit()
+    return alias, alias_assoc
+
+
+@patch("app.services.model_sync.LiteLLMService")
+def test_alias_sync_writes_model_group_alias_and_removes_legacy_entry(
+    mock_litellm_class, db, test_region
+):
+    """An alias must land as router_settings.model_group_alias, never as a
+    duplicate model entry — and any legacy alias-as-model entry is deleted."""
+    from app.services.model_sync import sync_model_to_region_task
+
+    alias, alias_assoc = _make_alias_with_target(db, test_region)
+
+    mock_instance = MagicMock()
+    mock_instance.get_model_deployment_ids = AsyncMock(return_value=["legacy-dep-1"])
+    mock_instance.delete_model = AsyncMock()
+    mock_instance.set_model_group_aliases = AsyncMock()
+    mock_instance.add_model = AsyncMock()
+    mock_instance.update_model = AsyncMock()
+    mock_litellm_class.return_value = mock_instance
+
+    import asyncio
+    asyncio.run(sync_model_to_region_task(alias.id, test_region.id))
+
+    db.refresh(alias_assoc)
+    assert alias_assoc.sync_status == "synced"
+    mock_instance.delete_model.assert_called_once_with("chat-alias", ["legacy-dep-1"])
+    mock_instance.set_model_group_aliases.assert_called_once_with(
+        {"chat-alias": "alias-target"}
+    )
+    mock_instance.add_model.assert_not_called()
+    mock_instance.update_model.assert_not_called()
+
+
+@patch("app.services.model_sync.LiteLLMService")
+def test_alias_sync_fails_when_target_not_deployed(mock_litellm_class, db, test_region):
+    """An active alias whose target is not actively deployed in the region
+    drops out of the pushed map and is marked failed, not silently synced."""
+    from app.services.model_sync import sync_model_to_region_task
+
+    alias, alias_assoc = _make_alias_with_target(db, test_region, target_active=False)
 
     mock_instance = MagicMock()
     mock_instance.get_model_deployment_ids = AsyncMock(return_value=[])
-    mock_instance.add_model = AsyncMock(
-        side_effect=Exception(
-            "422: payload rejected: aws_secret_access_key=sk-target-secret99 api_key=sk-override-secret99"
-        )
-    )
+    mock_instance.set_model_group_aliases = AsyncMock()
     mock_litellm_class.return_value = mock_instance
 
     import asyncio
@@ -366,9 +440,8 @@ def test_sync_error_scrubs_override_credentials(mock_litellm_class, db, test_reg
 
     db.refresh(alias_assoc)
     assert alias_assoc.sync_status == "failed"
-    assert "sk-target-secret99" not in alias_assoc.sync_error
-    assert "sk-override-secret99" not in alias_assoc.sync_error
-    assert "********" in alias_assoc.sync_error
+    assert "no active target deployment" in alias_assoc.sync_error
+    mock_instance.set_model_group_aliases.assert_called_once_with({})
 
 
 def test_admin_get_model_redacts_credentials(client, admin_token, db):


### PR DESCRIPTION
## Problem

Two gaps in how model management lands on LiteLLM proxies:

1. **Aliases** (`chat`, `embeddings`, `claude-3-5-*`, …) are synced as full duplicate model entries carrying their target's litellm_params — the same 'fake alias' pattern the old k0rdent configs used, and which `app/api/public.py` already documents as migration debt.
2. **Access groups** exist on the proxy only as `model_info.access_groups` tags + team `models` lists. Enforcement works, but the LiteLLM admin UI lists access groups from the newer `/v1/access_group` entity store, which we never wrote — so the UI shows no access groups at all.

## Changes

### Aliases → `router_settings.model_group_alias`

- Alias syncs write LiteLLM's native alias mechanism via `POST /config/update`, persisted in LiteLLM's DB config row (verified working against the us1 proxy, `main-stable`).
- The alias map is router-level state, so every alias sync recomputes and rewrites the region's **full** map — activation, retargeting and deactivation are all 'recompute the map'.
- Each alias sync deletes any legacy alias-as-model entry it finds, so regions migrate automatically as their aliases re-sync.
- An active alias whose target is not actively deployed in the region is marked `failed` with a clear error.
- Access control keeps working: LiteLLM resolves the alias to its target during auth (BerriAI/litellm#12440), so team access-group restrictions apply to the target's tags.

### Access groups → mirrored into the `/v1/access_group` entity registry

- Every (non-alias) model sync reconciles the region's access groups into the entity store the admin UI reads: create missing groups, fix drifted member lists, delete stale ones.
- Only entities carrying our description marker ("Managed by the amazee.ai model catalog") are ever deleted — groups made by hand in the UI survive.
- Tags remain the enforcement path; the entity registry is the operator-visible half.

## Rollout note

Deployment rows sitting at `synced` won't re-sync on their own. After deploying, flip the managed regions' rows to `pending` and run the catalog apply — the resync sweep from #675 pushes everything: aliases move into `model_group_alias`, legacy alias entries get deleted, and the access-group registry populates.

## Tests

- `test_alias_sync_writes_model_group_alias_and_removes_legacy_entry`, `test_alias_sync_fails_when_target_not_deployed`
- `test_model_sync_pushes_access_groups` extended to assert entity creation; new `test_model_sync_reconciles_access_group_entities` covers drift correction, stale deletion, and hand-made preservation
- Credential-scrub test now uses a plain model (aliases no longer push params)
- All affected suites pass (55 tests)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR migrates catalog aliases from duplicate LiteLLM model deployments to native router aliases and mirrors catalog access groups into LiteLLM’s entity registry.
- Recomputes and serializes each region’s complete `model_group_alias` map.
- Verifies alias targets against models currently present on the proxy and safely removes legacy alias deployments.
- Reconciles managed access-group entities while preserving manually created groups.
- Adds LiteLLM client operations and coverage for alias migration, target availability, and access-group reconciliation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/services/model_sync.py | Replaces duplicate alias deployments with a serialized native alias-map reconciliation and safely orders migration writes. |
| app/services/access_groups.py | Adds region-wide access-group entity reconciliation with managed-entity deletion safeguards. |
| app/services/litellm.py | Adds wrappers for router alias configuration and LiteLLM access-group entity operations. |
| tests/test_admin_models.py | Covers live-target validation, native alias migration, and revised synchronization behavior. |
| tests/test_access_groups.py | Covers creation, correction, deletion, and preservation behavior for access-group entities. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Apply as Catalog Apply
    participant DB as PostgreSQL
    participant Sync as Model Sync
    participant Proxy as LiteLLM
    Apply->>DB: Commit model and alias state
    Apply->>Sync: Queue target syncs before aliases
    Sync->>Proxy: Add or update target model
    Sync->>DB: Acquire per-region advisory lock
    Sync->>DB: Recompute complete alias map
    Sync->>Proxy: Read live model names
    Sync->>Proxy: Replace model_group_alias map
    Sync->>Proxy: Delete legacy alias deployment
    Sync->>DB: Record sync result and release lock
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: create access-group entities even w..."](https://github.com/amazeeio/amazee.ai/commit/4b0307d03ac733a1a129f2c4d4cf6544c3d825c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51802556)</sub>

<!-- /greptile_comment -->