### PR TITLE
fix: compute the alias map from DB state only, never live proxy state

### DIFF
--- a/app/services/model_sync.py
+++ b/app/services/model_sync.py
@@ -185,17 +185,15 @@ async def sync_model_to_region_task(model_id: int, region_id: int) -> None:
                 text("SELECT pg_advisory_xact_lock(:ns, :region)"),
                 {"ns": ALIAS_MAP_LOCK_NAMESPACE, "region": region_id},
             )
+            # The map is computed from DB state ONLY — deliberately not
+            # filtered against the proxy's live /model/info. During a rollout
+            # the proxy's model list is mid-churn (replica lag, router
+            # reloads), and a stale read here would bake missing aliases into
+            # the map with sync_status happily 'synced' (observed on us1: the
+            # last writer's stale snapshot shrank the map to one entry). A
+            # target whose own sync has not landed yet merely 404s until it
+            # does — the name-based mapping then works with no alias rewrite.
             alias_map = region_model_group_alias_map(db, region_id)
-            # A DB row saying the target is deployed is not enough — its own
-            # sync may still be pending or failed. Only route to model groups
-            # that actually exist on the proxy, or the alias would 404.
-            info = await litellm_service.get_model_info()
-            live_names = {
-                entry.get("model_name")
-                for entry in (info.get("data") or [])
-                if isinstance(entry, dict)
-            }
-            alias_map = {a: t for a, t in alias_map.items() if t in live_names}
             # Write the map before deleting any legacy alias-as-model entry:
             # if the delete then fails, both mechanisms briefly coexist (which
             # still serves requests) and the retry cleans up — the reverse
@@ -211,8 +209,7 @@ async def sync_model_to_region_task(model_id: int, region_id: int) -> None:
             ):
                 assoc.sync_status = "failed"
                 assoc.sync_error = (
-                    f"Alias '{model.model_id}' has no active target deployment "
-                    "in this region (or its target has not synced yet)."
+                    f"Alias '{model.model_id}' has no active target deployment in this region."
                 )
                 db.commit()
                 logger.error(f"Sync failed for model_id={model_id}, region_id={region_id}: {assoc.sync_error}")

--- a/tests/test_admin_models.py
+++ b/tests/test_admin_models.py
@@ -406,9 +406,6 @@ def test_alias_sync_writes_model_group_alias_and_removes_legacy_entry(
 
     mock_instance = MagicMock()
     mock_instance.get_model_deployment_ids = AsyncMock(return_value=["legacy-dep-1"])
-    mock_instance.get_model_info = AsyncMock(
-        return_value={"data": [{"model_name": "alias-target", "model_info": {"id": "t-1"}}]}
-    )
     mock_instance.delete_model = AsyncMock()
     mock_instance.set_model_group_aliases = AsyncMock()
     mock_instance.add_model = AsyncMock()
@@ -433,16 +430,18 @@ def test_alias_sync_writes_model_group_alias_and_removes_legacy_entry(
 
 
 @patch("app.services.model_sync.LiteLLMService")
-def test_alias_sync_skips_target_missing_from_proxy(mock_litellm_class, db, test_region):
-    """A target that is active in the DB but absent from the proxy (its own
-    sync pending/failed) must not be routed to — the alias is marked failed
-    and retried by a later apply instead of 404ing."""
+def test_alias_map_is_computed_from_db_not_proxy_state(mock_litellm_class, db, test_region):
+    """The pushed map must come from DB truth alone. Filtering against the
+    proxy's live model list bakes mid-rollout replica lag into the map (a
+    stale last writer once shrank us1's map to one entry) — a target that
+    hasn't landed yet just 404s until its own sync completes."""
     from app.services.model_sync import sync_model_to_region_task
 
     alias, alias_assoc = _make_alias_with_target(db, test_region)
 
     mock_instance = MagicMock()
     mock_instance.get_model_deployment_ids = AsyncMock(return_value=[])
+    # Proxy reports NO models at all — the map must still be written whole.
     mock_instance.get_model_info = AsyncMock(return_value={"data": []})
     mock_instance.set_model_group_aliases = AsyncMock()
     mock_litellm_class.return_value = mock_instance
@@ -451,8 +450,10 @@ def test_alias_sync_skips_target_missing_from_proxy(mock_litellm_class, db, test
     asyncio.run(sync_model_to_region_task(alias.id, test_region.id))
 
     db.refresh(alias_assoc)
-    assert alias_assoc.sync_status == "failed"
-    mock_instance.set_model_group_aliases.assert_called_once_with({})
+    assert alias_assoc.sync_status == "synced"
+    mock_instance.set_model_group_aliases.assert_called_once_with(
+        {"chat-alias": "alias-target"}
+    )
 
 
 @patch("app.services.model_sync.LiteLLMService")
@@ -465,7 +466,6 @@ def test_alias_sync_fails_when_target_not_deployed(mock_litellm_class, db, test_
 
     mock_instance = MagicMock()
     mock_instance.get_model_deployment_ids = AsyncMock(return_value=[])
-    mock_instance.get_model_info = AsyncMock(return_value={"data": []})
     mock_instance.set_model_group_aliases = AsyncMock()
     mock_litellm_class.return_value = mock_instance
 


### PR DESCRIPTION
## Problem

Follow-up to #676, found during the us1 rollout. The alias sync filtered the `model_group_alias` map against the proxy's live `/model/info` before pushing. During the migration the proxy's model list was mid-churn (31 model updates + 6 legacy alias deletes, replica lag, router reloads), so each alias sync saw a progressively staler list. The last writer pushed a map with a **single entry** (`text_to_image`) while every alias row read `synced`, and `claude-3-5-sonnet` / `chat_with_image_vision` failed with a misleading 'target not synced' error on both regions.

## Fix

The map is computed from DB state only — the truth the proxy converges to. A target whose own sync hasn't landed yet just 404s until it does; being name-based, the mapping then works without any alias rewrite. Failed targets keep retrying via the #675 resync sweep. Whole-map writes remain serialized by the per-region advisory lock, so the last writer is always the freshest DB state.

## Rollout

Nothing manual needed: the two `failed` alias rows are picked up by the next catalog apply's resync sweep, and any single alias sync rewrites the full region map — us1 and de1 heal in one pass.

## Tests

- `test_alias_map_is_computed_from_db_not_proxy_state` — proxy reporting zero models must not shrink the pushed map
- All 56 affected tests pass

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR changes alias synchronization to derive the complete regional alias map exclusively from database state, avoiding destructive map shrinkage caused by stale live-proxy snapshots.

- Removes the live `/model/info` filtering step before writing aliases.
- Simplifies the inactive-target error to reflect the database eligibility check.
- Replaces the stale-proxy test with coverage proving an empty proxy model list cannot shrink the database-derived map.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The changed synchronization path preserves the complete database-derived alias map during proxy churn, while existing database eligibility checks, serialization, and target resynchronization behavior remain intact.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/services/model_sync.py | Removes stale live-proxy filtering so serialized whole-map writes consistently reflect active database alias and target associations. |
| tests/test_admin_models.py | Updates alias synchronization tests to assert that an empty proxy snapshot does not remove database-defined aliases. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Task as Alias sync task
    participant DB as PostgreSQL
    participant Proxy as LiteLLM proxy
    Task->>DB: Acquire per-region advisory lock
    Task->>DB: Read complete active alias map
    DB-->>Task: Alias-to-target names
    Task->>Proxy: Replace model_group_alias map
    Task->>Proxy: Remove legacy alias deployment
    Task->>DB: Mark alias association synced
    Note over Proxy: An unresolved target may 404 until its own sync lands
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: compute the alias map from DB state..."](https://github.com/amazeeio/amazee.ai/commit/d552a6771f6fec175e88136107af4798b66d3467) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51832195)</sub>

<!-- /greptile_comment -->