### PR TITLE
fix: never delete LiteLLM's synthetic alias expansion of the target

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -38,6 +38,13 @@ environments:
         schedule: "*/5 * * * *"
         command: python scripts/trigger_budget_alerts_job.py
         service: backend
+      # 'synced' only means a sync once succeeded — proxies drift (admin UI
+      # deletions, DB restores, cluster rollouts). Two LiteLLM calls per
+      # region when nothing drifted, so 5 minutes is affordable.
+      - name: reconcile-model-sync
+        schedule: "*/5 * * * *"
+        command: python scripts/trigger_model_reconcile_job.py
+        service: backend
     routes:
       - backend:
         - api.amazee.ai:
@@ -84,6 +91,13 @@ environments:
       - name: monitor-budget-thresholds
         schedule: "*/5 * * * *"
         command: python scripts/trigger_budget_alerts_job.py
+        service: backend
+      # 'synced' only means a sync once succeeded — proxies drift (admin UI
+      # deletions, DB restores, cluster rollouts). Two LiteLLM calls per
+      # region when nothing drifted, so 5 minutes is affordable.
+      - name: reconcile-model-sync
+        schedule: "*/5 * * * *"
+        command: python scripts/trigger_model_reconcile_job.py
         service: backend
 
 tasks:

--- a/app/services/model_sync.py
+++ b/app/services/model_sync.py
@@ -90,6 +90,103 @@ def region_model_group_alias_map(db, region_id: int) -> dict[str, str]:
     return alias_map
 
 
+def _extract_alias_map(router_settings: dict) -> dict[str, str]:
+    """Normalize /router/settings' model_group_alias field to {alias: target}.
+    Values may be plain strings or {'model': ..., 'hidden': ...} dicts."""
+    for field in router_settings.get("fields") or []:
+        if isinstance(field, dict) and field.get("field_name") == "model_group_alias":
+            value = field.get("field_value")
+            if not isinstance(value, dict):
+                return {}
+            return {
+                str(alias): str(target.get("model")) if isinstance(target, dict) else str(target)
+                for alias, target in value.items()
+            }
+    return {}
+
+
+async def reconcile_region_models(db, region: DBRegion) -> dict:
+    """Detect and repair drift between the DB's desired state and the region's
+    proxy. 'synced' is a claim about the past: models can vanish behind our
+    back (proxy admin UI, DB restores, cluster rollouts). This compares the
+    proxy's live models and alias map against what the DB says should exist
+    and re-runs the ordinary sync task for anything drifted — so the region
+    continuously converges to the catalog.
+    """
+    service = LiteLLMService(api_url=region.litellm_api_url, api_key=region.litellm_api_key)
+    info = await service.get_model_info()
+    entries = [e for e in (info.get("data") or []) if isinstance(e, dict)]
+    all_names = {e.get("model_name") for e in entries}
+    # Only DB-registered entries are ours to delete; a same-named config-file
+    # model still satisfies "the model is available".
+    db_names = {
+        e.get("model_name") for e in entries if (e.get("model_info") or {}).get("db_model")
+    }
+
+    to_sync: list[int] = []
+    rows = (
+        db.query(DBModelRegion, DBModel)
+        .join(DBModel, DBModel.id == DBModelRegion.model_id)
+        .filter(DBModelRegion.region_id == region.id, DBModel.is_alias.is_(False))
+        .all()
+    )
+    for assoc, model in rows:
+        desired = bool(
+            assoc.is_active and model.is_active_globally and model.deleted_at is None
+        )
+        drifted = (desired and model.model_id not in all_names) or (
+            not desired and model.model_id in db_names
+        )
+        if drifted:
+            assoc.sync_status = "pending"
+            assoc.updated_at = datetime.now(UTC)
+            to_sync.append(model.id)
+
+    # Any single alias sync rewrites the region's whole map, so one drifted
+    # map costs one sync of whichever alias row exists.
+    alias_pk: int | None = None
+    desired_map = region_model_group_alias_map(db, region.id)
+    actual_map = _extract_alias_map(await service.get_router_settings())
+    if desired_map != actual_map:
+        alias_row = (
+            db.query(DBModelRegion)
+            .join(DBModel, DBModel.id == DBModelRegion.model_id)
+            .filter(DBModelRegion.region_id == region.id, DBModel.is_alias.is_(True))
+            .first()
+        )
+        if alias_row:
+            alias_row.sync_status = "pending"
+            alias_row.updated_at = datetime.now(UTC)
+            alias_pk = alias_row.model_id
+    db.commit()
+
+    for model_pk in to_sync:
+        await sync_model_to_region_task(model_pk, region.id)
+    if alias_pk is not None:
+        await sync_model_to_region_task(alias_pk, region.id)
+    if to_sync or alias_pk is not None:
+        logger.warning(
+            f"Reconcile repaired drift on region {region.name}: "
+            f"{len(to_sync)} model(s) resynced, alias map rewritten: {alias_pk is not None}"
+        )
+    return {"models_resynced": len(to_sync), "alias_map_rewritten": alias_pk is not None}
+
+
+async def reconcile_all_managed_regions(db) -> dict[str, dict]:
+    """Run drift reconciliation for every active catalog-managed region.
+    Regions are independent — one unreachable proxy must not stop the rest."""
+    results: dict[str, dict] = {}
+    for region in db.query(DBRegion).filter(DBRegion.is_active.is_(True)).all():
+        if not catalog_manages(region.name):
+            continue
+        try:
+            results[region.name] = await reconcile_region_models(db, region)
+        except Exception as e:
+            logger.error(f"Reconcile failed for region {region.name}: {e}")
+            results[region.name] = {"error": str(e)}
+    return results
+
+
 def _scrub_secrets(text: str, litellm_params) -> str:
     """Proxy error bodies can echo the request payload (e.g. a 422 quoting
     litellm_params, api_key included). sync_error is shown in admin responses,

--- a/app/services/model_sync.py
+++ b/app/services/model_sync.py
@@ -162,12 +162,6 @@ async def sync_model_to_region_task(model_id: int, region_id: int) -> None:
             api_key=region.litellm_api_key
         )
         
-        # LiteLLM keys /model/update and /model/delete on the deployment id
-        # (model_info.id), and /model/new allows duplicate model_names — so
-        # resolve existing deployment ids first and upsert accordingly, instead
-        # of add-then-catch-conflict (which would silently create duplicates).
-        deployment_ids = await litellm_service.get_model_deployment_ids(model.model_id)
-
         if model.is_alias:
             # Real aliases live in router_settings.model_group_alias, not as
             # duplicate model entries (auth resolves the alias to its target,
@@ -199,9 +193,32 @@ async def sync_model_to_region_task(model_id: int, region_id: int) -> None:
             # still serves requests) and the retry cleans up — the reverse
             # order would leave the alias with neither.
             await litellm_service.set_model_group_aliases(alias_map)
-            if deployment_ids:
+            # Legacy cleanup, guarded: once the map is live, LiteLLM expands
+            # every alias into a synthetic /model/info entry identical to its
+            # target — INCLUDING the target's deployment id. Deleting "ids
+            # under the alias name" therefore deletes the target itself
+            # (observed on de1: claude-4-5-sonnet vanished). A real legacy
+            # entry has its own id that appears under no other model_name, so
+            # only ids exclusive to the alias name are legacy and deletable.
+            info = await litellm_service.get_model_info()
+            ids_by_name: dict[str, set[str]] = {}
+            for entry in info.get("data") or []:
+                if (
+                    isinstance(entry, dict)
+                    and isinstance(entry.get("model_info"), dict)
+                    and entry["model_info"].get("id")
+                ):
+                    ids_by_name.setdefault(entry.get("model_name"), set()).add(
+                        entry["model_info"]["id"]
+                    )
+            other_ids: set[str] = set()
+            for name, ids in ids_by_name.items():
+                if name != model.model_id:
+                    other_ids |= ids
+            legacy_ids = ids_by_name.get(model.model_id, set()) - other_ids
+            if legacy_ids:
                 logger.info(f"Removing legacy alias model entry '{model.model_id}' from region '{region.name}'")
-                await litellm_service.delete_model(model.model_id, deployment_ids)
+                await litellm_service.delete_model(model.model_id, sorted(legacy_ids))
             if (
                 assoc.is_active
                 and model.is_active_globally
@@ -215,6 +232,12 @@ async def sync_model_to_region_task(model_id: int, region_id: int) -> None:
                 logger.error(f"Sync failed for model_id={model_id}, region_id={region_id}: {assoc.sync_error}")
                 return
         elif assoc.is_active and model.is_active_globally:
+            # LiteLLM keys /model/update and /model/delete on the deployment id
+            # (model_info.id), and /model/new allows duplicate model_names — so
+            # resolve existing deployment ids first and upsert accordingly,
+            # instead of add-then-catch-conflict (which would silently create
+            # duplicates).
+            deployment_ids = await litellm_service.get_model_deployment_ids(model.model_id)
             # Base params + per-region override, or the alias target's params.
             params, resolve_error = effective_litellm_params(db, model, region_id)
             pushed_params = params
@@ -240,6 +263,7 @@ async def sync_model_to_region_task(model_id: int, region_id: int) -> None:
                 )
         else:
             logger.info(f"Deregistering model '{model.model_id}' from region '{region.name}'")
+            deployment_ids = await litellm_service.get_model_deployment_ids(model.model_id)
             await litellm_service.delete_model(model.model_id, deployment_ids)
 
         # A model coming or going changes group membership, so mirror the

--- a/scripts/trigger_model_reconcile_job.py
+++ b/scripts/trigger_model_reconcile_job.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Cron entry point: repair drift between the model catalog's desired state
+and each catalog-managed region's LiteLLM proxy.
+
+'synced' in the DB only means a sync once succeeded — models can be deleted
+behind our back (proxy admin UI, DB restores, cluster rollouts). This sweep
+re-checks reality every few minutes and re-runs the ordinary sync task for
+anything missing, stray, or with a drifted alias map.
+"""
+
+import os
+import sys
+import asyncio
+import logging
+
+# Add the parent directory to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from sqlalchemy.orm import sessionmaker
+from app.db.database import engine
+from app.services.model_sync import reconcile_all_managed_regions
+from app.core.locking import try_acquire_lock, release_lock
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def trigger_model_reconcile_job():
+    """Run the drift sweep, guarded by the shared advisory lock."""
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = SessionLocal()
+
+    lock_name = "model_reconcile"
+
+    try:
+        logger.info("Starting model drift reconcile job...")
+
+        # Short timeout: this job runs every few minutes, so a stale lock must
+        # not block many ticks.
+        if try_acquire_lock(lock_name, db, lock_timeout=5):
+            logger.info("Acquired model_reconcile lock, executing sweep")
+            try:
+                results = await reconcile_all_managed_regions(db)
+                logger.info(f"Model reconcile finished: {results}")
+            finally:
+                release_lock(lock_name, db)
+        else:
+            logger.info("Another model_reconcile run holds the lock; skipping")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(trigger_model_reconcile_job())

--- a/tests/test_admin_models.py
+++ b/tests/test_admin_models.py
@@ -405,7 +405,16 @@ def test_alias_sync_writes_model_group_alias_and_removes_legacy_entry(
     alias, alias_assoc = _make_alias_with_target(db, test_region)
 
     mock_instance = MagicMock()
-    mock_instance.get_model_deployment_ids = AsyncMock(return_value=["legacy-dep-1"])
+    mock_instance.get_model_info = AsyncMock(
+        return_value={
+            "data": [
+                # Genuine legacy alias-as-model entry: its id exists under no
+                # other model_name, so it is deletable.
+                {"model_name": "chat-alias", "model_info": {"id": "legacy-dep-1"}},
+                {"model_name": "alias-target", "model_info": {"id": "t-1"}},
+            ]
+        }
+    )
     mock_instance.delete_model = AsyncMock()
     mock_instance.set_model_group_aliases = AsyncMock()
     mock_instance.add_model = AsyncMock()
@@ -430,6 +439,38 @@ def test_alias_sync_writes_model_group_alias_and_removes_legacy_entry(
 
 
 @patch("app.services.model_sync.LiteLLMService")
+def test_alias_sync_never_deletes_synthetic_alias_expansion(mock_litellm_class, db, test_region):
+    """Once the map is live, LiteLLM expands the alias into a /model/info
+    entry that carries the TARGET's deployment id. Deleting 'ids under the
+    alias name' would delete the target itself (this removed
+    claude-4-5-sonnet on de1) — shared ids must never be deleted."""
+    from app.services.model_sync import sync_model_to_region_task
+
+    alias, alias_assoc = _make_alias_with_target(db, test_region)
+
+    mock_instance = MagicMock()
+    mock_instance.get_model_info = AsyncMock(
+        return_value={
+            "data": [
+                # Synthetic expansion: alias entry shares the target's id.
+                {"model_name": "chat-alias", "model_info": {"id": "t-1"}},
+                {"model_name": "alias-target", "model_info": {"id": "t-1"}},
+            ]
+        }
+    )
+    mock_instance.delete_model = AsyncMock()
+    mock_instance.set_model_group_aliases = AsyncMock()
+    mock_litellm_class.return_value = mock_instance
+
+    import asyncio
+    asyncio.run(sync_model_to_region_task(alias.id, test_region.id))
+
+    db.refresh(alias_assoc)
+    assert alias_assoc.sync_status == "synced"
+    mock_instance.delete_model.assert_not_called()
+
+
+@patch("app.services.model_sync.LiteLLMService")
 def test_alias_map_is_computed_from_db_not_proxy_state(mock_litellm_class, db, test_region):
     """The pushed map must come from DB truth alone. Filtering against the
     proxy's live model list bakes mid-rollout replica lag into the map (a
@@ -440,7 +481,6 @@ def test_alias_map_is_computed_from_db_not_proxy_state(mock_litellm_class, db, t
     alias, alias_assoc = _make_alias_with_target(db, test_region)
 
     mock_instance = MagicMock()
-    mock_instance.get_model_deployment_ids = AsyncMock(return_value=[])
     # Proxy reports NO models at all — the map must still be written whole.
     mock_instance.get_model_info = AsyncMock(return_value={"data": []})
     mock_instance.set_model_group_aliases = AsyncMock()
@@ -465,7 +505,7 @@ def test_alias_sync_fails_when_target_not_deployed(mock_litellm_class, db, test_
     alias, alias_assoc = _make_alias_with_target(db, test_region, target_active=False)
 
     mock_instance = MagicMock()
-    mock_instance.get_model_deployment_ids = AsyncMock(return_value=[])
+    mock_instance.get_model_info = AsyncMock(return_value={"data": []})
     mock_instance.set_model_group_aliases = AsyncMock()
     mock_litellm_class.return_value = mock_instance
 

--- a/tests/test_admin_models.py
+++ b/tests/test_admin_models.py
@@ -518,6 +518,118 @@ def test_alias_sync_fails_when_target_not_deployed(mock_litellm_class, db, test_
     mock_instance.set_model_group_aliases.assert_called_once_with({})
 
 
+def _router_settings_with_map(alias_map):
+    return {"fields": [{"field_name": "model_group_alias", "field_value": alias_map}]}
+
+
+@patch("app.services.model_sync.LiteLLMService")
+def test_reconcile_restores_models_deleted_behind_our_back(mock_litellm_class, db, test_region):
+    """A model the DB says is deployed but the proxy no longer has (admin UI
+    deletion, DB restore, cluster rollout) must be re-registered by the
+    reconcile sweep even though its row reads 'synced'."""
+    from app.services.model_sync import reconcile_region_models
+
+    m = DBModel(
+        model_id="test/vanished-model",
+        display_name="Vanished Model",
+        provider="test",
+        type="chat",
+    )
+    db.add(m)
+    db.commit()
+    assoc = DBModelRegion(
+        model_id=m.id, region_id=test_region.id, is_active=True, sync_status="synced"
+    )
+    db.add(assoc)
+    db.commit()
+
+    mock_instance = MagicMock()
+    mock_instance.get_model_info = AsyncMock(return_value={"data": []})
+    mock_instance.get_router_settings = AsyncMock(return_value=_router_settings_with_map({}))
+    mock_instance.get_model_deployment_ids = AsyncMock(return_value=[])
+    mock_instance.add_model = AsyncMock(return_value={})
+    mock_instance.list_access_groups = AsyncMock(return_value=[])
+    mock_litellm_class.return_value = mock_instance
+
+    import asyncio
+    result = asyncio.run(reconcile_region_models(db, test_region))
+
+    assert result == {"models_resynced": 1, "alias_map_rewritten": False}
+    mock_instance.add_model.assert_called_once()
+    db.expire_all()
+    assert (
+        db.query(DBModelRegion).filter_by(model_id=m.id, region_id=test_region.id).one().sync_status
+        == "synced"
+    )
+
+
+@patch("app.services.model_sync.LiteLLMService")
+def test_reconcile_is_a_noop_when_proxy_matches(mock_litellm_class, db, test_region):
+    from app.services.model_sync import reconcile_region_models
+
+    m = DBModel(
+        model_id="test/stable-model",
+        display_name="Stable Model",
+        provider="test",
+        type="chat",
+    )
+    db.add(m)
+    db.commit()
+    db.add(
+        DBModelRegion(
+            model_id=m.id, region_id=test_region.id, is_active=True, sync_status="synced"
+        )
+    )
+    db.commit()
+
+    mock_instance = MagicMock()
+    mock_instance.get_model_info = AsyncMock(
+        return_value={
+            "data": [{"model_name": "test/stable-model", "model_info": {"id": "d1", "db_model": True}}]
+        }
+    )
+    mock_instance.get_router_settings = AsyncMock(return_value=_router_settings_with_map({}))
+    mock_instance.add_model = AsyncMock()
+    mock_instance.update_model = AsyncMock()
+    mock_instance.delete_model = AsyncMock()
+    mock_litellm_class.return_value = mock_instance
+
+    import asyncio
+    result = asyncio.run(reconcile_region_models(db, test_region))
+
+    assert result == {"models_resynced": 0, "alias_map_rewritten": False}
+    mock_instance.add_model.assert_not_called()
+    mock_instance.update_model.assert_not_called()
+    mock_instance.delete_model.assert_not_called()
+
+
+@patch("app.services.model_sync.LiteLLMService")
+def test_reconcile_rewrites_drifted_alias_map(mock_litellm_class, db, test_region):
+    """A wiped or stale router alias map is rewritten via one alias sync."""
+    from app.services.model_sync import reconcile_region_models
+
+    alias, alias_assoc = _make_alias_with_target(db, test_region)
+
+    mock_instance = MagicMock()
+    mock_instance.get_model_info = AsyncMock(
+        return_value={
+            "data": [{"model_name": "alias-target", "model_info": {"id": "t-1", "db_model": True}}]
+        }
+    )
+    # Proxy map is empty; DB wants {chat-alias: alias-target}.
+    mock_instance.get_router_settings = AsyncMock(return_value=_router_settings_with_map({}))
+    mock_instance.set_model_group_aliases = AsyncMock()
+    mock_litellm_class.return_value = mock_instance
+
+    import asyncio
+    result = asyncio.run(reconcile_region_models(db, test_region))
+
+    assert result == {"models_resynced": 0, "alias_map_rewritten": True}
+    mock_instance.set_model_group_aliases.assert_called_once_with(
+        {"chat-alias": "alias-target"}
+    )
+
+
 def test_admin_get_model_redacts_credentials(client, admin_token, db):
     """Detail endpoint must redact credential values but keep keys and os.environ/ refs visible."""
     m = DBModel(


### PR DESCRIPTION
## Two fixes and the systemic answer

### 1. Never delete LiteLLM's synthetic alias expansion (what deleted `claude-4-5-sonnet` from de1)

Once `model_group_alias` is live, LiteLLM expands each alias into a synthetic `/model/info` entry identical to its target — **including the target's deployment id**. The alias sync's legacy-cleanup step deleted 'ids under the alias name', which on de1 deleted the targets themselves (`claude-4-5-sonnet`, `claude-4-5-haiku`, `titan-embed-text-v2:0`) while every DB row read `synced`.

Fix: a genuine legacy entry has a deployment id that exists under **no other** model_name. The cleanup builds an id→names view and deletes only ids exclusive to the alias name; synthetic expansions share their id with the target and are never touched.

### 2. Reconcile cron: regions continuously converge to the catalog

`synced` only means a sync once succeeded — us1 lost **all** its DB models to a platform cluster rollout while every row read `synced`, and nothing would ever have healed it. New `reconcile-model-sync` Lagoon cron (every 5 min, dev + prod): for each catalog-managed region, compare the proxy's live models and router alias map against the DB's desired state and re-run the ordinary sync task for anything missing, stray, or drifted. Two LiteLLM GETs per region when nothing has drifted; repairs are logged at warning level. Guarded by the shared advisory lock like the other cron jobs.

This is the catalog → amazee.ai → LiteLLM guarantee: once a model is enabled in amazeeai-model-catalog, every managed region converges back to it within minutes, no matter who deletes what on the proxy.

## Recovery for the current state

After deploy, the first cron tick automatically restores us1's wiped models, de1's deleted targets, and both alias maps — no manual steps.

## Tests

- `test_alias_sync_never_deletes_synthetic_alias_expansion` — shared id ⇒ no delete
- `test_reconcile_restores_models_deleted_behind_our_back`, `test_reconcile_is_a_noop_when_proxy_matches`, `test_reconcile_rewrites_drifted_alias_map`
- All 60 affected tests pass