### PR TITLE
chore: drop unused locals flagged by code quality on #678

### DIFF
--- a/tests/test_admin_models.py
+++ b/tests/test_admin_models.py
@@ -608,7 +608,7 @@ def test_reconcile_rewrites_drifted_alias_map(mock_litellm_class, db, test_regio
     """A wiped or stale router alias map is rewritten via one alias sync."""
     from app.services.model_sync import reconcile_region_models
 
-    alias, alias_assoc = _make_alias_with_target(db, test_region)
+    _make_alias_with_target(db, test_region)
 
     mock_instance = MagicMock()
     mock_instance.get_model_info = AsyncMock(


### PR DESCRIPTION
Addresses the two github-code-quality comments on #678: `test_reconcile_rewrites_drifted_alias_map` unpacked `alias, alias_assoc` from `_make_alias_with_target` without using either. The helper is now called for its side effects only. Tests pass.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR removes two unused local assignments from an alias-map reconciliation test while preserving the helper call and its database side effects.
- Calls `_make_alias_with_target` without unpacking its unused return values.
- Leaves the test setup, reconciliation execution, and assertions unchanged.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it only removes unused assignments while preserving the side-effecting helper invocation.

The changed test still creates the alias and target records through the same helper call, then exercises and verifies the same reconciliation behavior.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/test_admin_models.py | Removes unused test-local variables without changing test behavior or coverage. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: drop unused locals flagged by cod..."](https://github.com/amazeeio/amazee.ai/commit/0283b5c5bba0837e0eaa5f690e8628905da07933) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52122675)</sub>

<!-- /greptile_comment -->