### PR TITLE
perf: cut backend test suite from ~18min to ~1min

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,16 +11,22 @@ test-network:
 backend-test-build:
 	docker build -t amazee-backend-test -f Dockerfile.test .
 
-# Start PostgreSQL container for testing
+# Start PostgreSQL container for testing.
+# Durability is off and data lives on tmpfs: the DB is throwaway, and the
+# test suite is DDL/commit-heavy enough that fsync dominates otherwise.
 test-postgres: test-network
 	docker run -d \
 		--name amazee-test-postgres \
 		--network amazeeai_default \
+		--tmpfs /var/lib/postgresql/data \
 		-e POSTGRES_USER=postgres \
 		-e POSTGRES_PASSWORD=postgres \
 		-e POSTGRES_DB=postgres_service \
-		pgvector/pgvector:pg16 && \
-	sleep 5
+		pgvector/pgvector:pg16 \
+		-c fsync=off -c synchronous_commit=off -c full_page_writes=off && \
+	i=0; until docker exec amazee-test-postgres pg_isready -U postgres >/dev/null 2>&1; do \
+		i=$$((i+1)); [ $$i -ge 60 ] && echo "postgres not ready after 60s" && exit 1; sleep 1; \
+	done; sleep 1
 
 # Teardown: stop and remove test containers, network, and image
 test-teardown:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,29 +40,45 @@ DATABASE_URL = os.getenv(
 engine = create_engine(DATABASE_URL)
 TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
+# Hashing at production cost (~250ms/hash) ran thousands of times per suite via
+# the user/token fixtures; 4 is bcrypt's minimum and plenty for tests.
+from app.core.security import pwd_context  # noqa: E402
 
-@pytest.fixture
-def db():
-    # Drop custom type before tables to avoid duplicate key violations
+pwd_context.update(bcrypt__rounds=4)
+
+
+@pytest.fixture(scope="session")
+def _schema():
+    """Create the schema once per test session.
+
+    Per-test isolation comes from the TRUNCATE in the db fixture (~30ms),
+    not a full drop/create of every table per test (~1s×2), which used to
+    dominate CI runtime. The enum drop mirrors the old fixture: drop_all
+    doesn't remove custom types, and create_all would collide with it.
+    """
     with engine.connect() as conn:
         conn.execute(text("DROP TYPE IF EXISTS budget_type_enum CASCADE"))
         conn.commit()
-
-    # Create the test database and tables
     Base.metadata.drop_all(bind=engine)
     Base.metadata.create_all(bind=engine)
 
-    # Create a new session for the test
+
+_ALL_TABLES = ", ".join(f'"{t.name}"' for t in Base.metadata.sorted_tables)
+
+
+@pytest.fixture
+def db(_schema):
+    # Truncate on setup (not teardown) so rows leaked outside the fixture's
+    # session — e.g. via the app's own SessionLocal — can't poison this test.
+    with engine.connect() as conn:
+        conn.execute(text(f"TRUNCATE {_ALL_TABLES} RESTART IDENTITY CASCADE"))
+        conn.commit()
+
     db = TestingSessionLocal()
     try:
         yield db
     finally:
         db.close()
-        # Clean up after test
-        Base.metadata.drop_all(bind=engine)
-        with engine.connect() as conn:
-            conn.execute(text("DROP TYPE IF EXISTS budget_type_enum CASCADE"))
-            conn.commit()
 
 
 @pytest.fixture

--- a/tests/test_internal_provision_key.py
+++ b/tests/test_internal_provision_key.py
@@ -6,37 +6,17 @@ to create a LiteLLM token + vector DB as part of the external key provisioning
 flow.  Auth is the standard amazee.ai admin API token mechanism.
 """
 
-import os
 import pytest
 from unittest.mock import patch, AsyncMock, Mock
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
 
 from app.main import app
 from app.db.database import get_db
-from app.db.models import Base, DBRegion, DBUser, DBTeam
+from app.db.models import DBRegion, DBUser, DBTeam
 from app.core.security import get_password_hash
 
-DATABASE_URL = os.getenv(
-    "DATABASE_URL",
-    "postgresql://postgres:postgres@amazee-test-postgres/postgres_service",
-)
-
-engine = create_engine(DATABASE_URL)
-TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
-
-@pytest.fixture
-def db():
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
-    db = TestingSessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
-        Base.metadata.drop_all(bind=engine)
+# The db fixture comes from tests/conftest.py; the module used to run its own
+# drop_all/create_all copy, whose teardown left the DB with no tables at all.
 
 
 @pytest.fixture


### PR DESCRIPTION
## What

Backend CI takes 15–20 min (e.g. [this run](https://github.com/amazeeio/amazee.ai/actions/runs/31404414485?pr=678): 19m24s, of which 18m06s is pytest itself). This PR gets the same suite to ~1 min without dropping any tests or isolation guarantees.

**Local before/after (`make backend-test-cov`): 18m06s → 63.79s. 1409 passed, 2 skipped.**

## Why it was slow

1. **The `db` fixture dropped and recreated the entire schema for every test** — `Base.metadata.drop_all` + `create_all` ran twice per test × 1409 tests. This was the bulk of the 18 minutes.
2. **bcrypt at production cost (12 rounds, ~250ms/hash)** in every user fixture, plus a hash verify in every `*_token` login fixture.
3. Test postgres ran with full durability (fsync on every commit) for a throwaway DB, plus a flat `sleep 5` on startup.

## Changes

- **conftest**: schema is created once per session; each test gets isolation via a single `TRUNCATE … RESTART IDENTITY CASCADE` (~30ms) instead of full drop/create. Same empty-DB-per-test guarantee. The truncate runs at setup, so rows leaked outside the fixture's session can't poison the next test.
- **conftest**: `pwd_context.update(bcrypt__rounds=4)` — bcrypt's minimum, plenty for tests.
- **Makefile**: test postgres gets `-c fsync=off -c synchronous_commit=off -c full_page_writes=off`, data on tmpfs, and a bounded `pg_isready` wait instead of `sleep 5`.
- **test_internal_provision_key.py**: had a private copy of the old `db` fixture whose teardown left the DB with no tables; now uses the shared fixture.

## Not in this PR

`pytest-xdist -n auto` (one DB per worker) could take this to ~20–30s, but it can surface hidden cross-test state and isn't worth the risk until this lands. Happy to follow up if wanted.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR substantially accelerates backend tests while preserving the suite’s current row-level isolation model.
- Creates the database schema once per pytest session and truncates all mapped tables before each test.
- Reduces bcrypt cost for test-generated credentials.
- Runs disposable PostgreSQL storage on tmpfs with durability disabled and readiness polling.
- Removes a test module’s private schema-recreating database fixture in favor of the shared fixture.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The current suite does not mutate database schema state, dynamically register tables, depend on production bcrypt cost, or bypass the shared fixture session in a way that breaks the new truncation-based isolation.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Makefile | Configures a faster disposable PostgreSQL container and replaces the fixed startup delay with a bounded readiness check. |
| tests/conftest.py | Replaces per-test schema recreation with session-scoped schema setup and per-test truncation, and lowers bcrypt cost for tests. |
| tests/test_internal_provision_key.py | Removes the module-local database fixture so these tests use the shared isolation lifecycle. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start backend test target] --> B[Start PostgreSQL on tmpfs]
    B --> C[Wait for pg_isready]
    C --> D[Create schema once per pytest session]
    D --> E[Before each database test]
    E --> F[TRUNCATE mapped tables and restart identities]
    F --> G[Open shared test session]
    G --> H[Run test]
    H --> I[Close session]
    I --> E
```
</details>

<sub>Reviews (1): Last reviewed commit: ["perf: cut backend test suite from ~18min..."](https://github.com/amazeeio/amazee.ai/commit/7e2ecaef71b276e94b9269989e4a928a7f3f4f12) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52175493)</sub>

<!-- /greptile_comment -->