### PR TITLE
feat(database): add schema verification against SQLAlchemy models

### DIFF
--- a/app/migrations/versions/20260317_130000_3c1a9f7b2d11_repair_teams_columns_drift.py
+++ b/app/migrations/versions/20260317_130000_3c1a9f7b2d11_repair_teams_columns_drift.py
@@ -1,0 +1,67 @@
+"""repair_teams_columns_drift
+
+Revision ID: 3c1a9f7b2d11
+Revises: 06fc68e254b7
+Create Date: 2026-03-17 13:00:00.000000+00:00
+
+"""
+
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "3c1a9f7b2d11"
+down_revision: Union[str, None] = "06fc68e254b7"
+
+
+def _column_exists(bind, table_name: str, column_name: str) -> bool:
+    insp = sa.inspect(bind)
+    try:
+        cols = insp.get_columns(table_name)
+    except Exception:
+        return False
+    return any(col["name"] == column_name for col in cols)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'budget_type_enum') THEN
+                CREATE TYPE budget_type_enum AS ENUM ('periodic', 'pool');
+            END IF;
+        END $$;
+        """
+    )
+
+    if not _column_exists(bind, "teams", "budget_type"):
+        op.add_column(
+            "teams",
+            sa.Column(
+                "budget_type",
+                sa.Enum(
+                    "periodic", "pool", name="budget_type_enum", create_constraint=True
+                ),
+                nullable=False,
+                server_default="periodic",
+            ),
+        )
+
+    if not _column_exists(bind, "teams", "last_pool_purchase"):
+        op.add_column(
+            "teams",
+            sa.Column("last_pool_purchase", sa.DateTime(timezone=True), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if _column_exists(bind, "teams", "last_pool_purchase"):
+        op.drop_column("teams", "last_pool_purchase")
+    if _column_exists(bind, "teams", "budget_type"):
+        op.drop_column("teams", "budget_type")

--- a/backend-start.sh
+++ b/backend-start.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Wait for PostgreSQL to be ready and create database if needed
 echo "Waiting for PostgreSQL to be ready..."

--- a/scripts/initialise_resources.py
+++ b/scripts/initialise_resources.py
@@ -23,6 +23,34 @@ from scripts.migrate_pricing_tables import migrate_pricing_tables
 from app.core.limit_service import setup_default_limits
 
 
+def verify_schema_matches_models() -> None:
+    """Ensure DB schema includes all SQLAlchemy model tables/columns."""
+    inspector = inspect(engine)
+    db_tables = set(inspector.get_table_names())
+
+    missing_tables = []
+    missing_columns = []
+
+    for table in Base.metadata.sorted_tables:
+        table_name = table.name
+        if table_name not in db_tables:
+            missing_tables.append(table_name)
+            continue
+
+        db_columns = {col["name"] for col in inspector.get_columns(table_name)}
+        model_columns = set(table.columns.keys())
+        for col_name in sorted(model_columns - db_columns):
+            missing_columns.append(f"{table_name}.{col_name}")
+
+    if missing_tables or missing_columns:
+        details = []
+        if missing_tables:
+            details.append(f"missing tables: {', '.join(sorted(missing_tables))}")
+        if missing_columns:
+            details.append(f"missing columns: {', '.join(missing_columns)}")
+        raise RuntimeError("Schema verification failed - " + "; ".join(details))
+
+
 def init_database() -> Session:
     # Check if database is empty (no tables exist)
     inspector = inspect(engine)
@@ -48,16 +76,12 @@ def init_database() -> Session:
         print("Stamped alembic version for future migrations")
     else:
         print("Tables already exist - running migrations...")
-        # Run database migrations
-        try:
-            alembic.command.upgrade(alembic_cfg, "head")
-            print("Database migrations completed successfully!")
-        except Exception as e:
-            print(f"Migration failed: {str(e)}")
-            print("Attempting to stamp current version and continue...")
-            # If migration fails, stamp the current version
-            alembic.command.stamp(alembic_cfg, "head")
-            print("Database version stamped successfully!")
+        alembic.command.upgrade(alembic_cfg, "head")
+        print("Database migrations completed successfully!")
+
+    print("Verifying schema against models...")
+    verify_schema_matches_models()
+    print("Schema verification passed!")
 
     # Create initial admin user if none exists
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes database initialization fail closed on migration or model-schema drift and adds a defensive migration repairing missing team budget columns.
- Adds model-to-database table and column verification after initialization or migration.
- Stops stamping over failed migrations.
- Adds a repair revision for `teams.budget_type` and `teams.last_pool_purchase`.
- Enables strict Bash error handling during backend startup.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until local Docker Compose startup handles an unset LAGOON_ENVIRONMENT without exiting.

The new nounset mode terminates the container entrypoint in the supported local configuration before its development Uvicorn fallback can run.

**Files Needing Attention:** backend-start.sh
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/migrations/versions/20260317_130000_3c1a9f7b2d11_repair_teams_columns_drift.py | Adds an idempotent repair migration for the two model-required team columns on the correct Alembic head. |
| scripts/initialise_resources.py | Adds model-schema completeness verification and correctly propagates migration failures instead of stamping over them. |
| backend-start.sh | Strict nounset handling breaks local Docker Compose startup because LAGOON_ENVIRONMENT is optional and expanded without a default. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Backend container starts] --> B[Wait for PostgreSQL]
  B --> C[Initialize resources]
  C --> D{Database empty?}
  D -->|Yes| E[Create model tables and stamp head]
  D -->|No| F[Upgrade Alembic to head]
  E --> G[Verify model tables and columns]
  F --> G
  G -->|Mismatch or migration error| H[Exit nonzero]
  G -->|Valid schema| I{LAGOON_ENVIRONMENT set?}
  I -->|Yes| J[Start production Uvicorn]
  I -->|No| K[Start development Uvicorn]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(migrations): add migration to repai..."](https://github.com/amazeeio/amazee.ai/commit/b7c42f17d9d5100a01953fa7116a06c27040f00d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52898218)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Database models, session, and migrations](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/database-models.md)

<!-- /greptile_comment -->