### PR TITLE
ci: bump every annotated version in the Helm charts

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,9 +9,18 @@
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         "app/__version__.py",
-        "helm/Chart.yaml",
-        "helm/charts/backend/Chart.yaml",
-        "helm/charts/frontend/Chart.yaml",
+        {
+          "type": "generic",
+          "path": "helm/Chart.yaml"
+        },
+        {
+          "type": "generic",
+          "path": "helm/charts/backend/Chart.yaml"
+        },
+        {
+          "type": "generic",
+          "path": "helm/charts/frontend/Chart.yaml"
+        },
         {
           "type": "json",
           "path": "frontend/package.json",


### PR DESCRIPTION
## Problem

The release PR for `2.2.0` fails the Helm chart check ([run 31933889100](https://github.com/amazeeio/amazee.ai/actions/runs/31933889100)):

```
Error: dependency backend at version 2.2.0 does not satisfy the constraint 2.1.0
```

`release-please-config.json` listed the three `Chart.yaml` files as plain path strings. release-please then chose its **YAML** updater from the `.yaml` extension, which bumps only the top-level `version` key. On the release branch:

| File / key | Result |
| --- | --- |
| `helm/Chart.yaml` `version` | 2.2.0 ✅ |
| `helm/Chart.yaml` `appVersion` | 2.1.0 ❌ |
| `helm/Chart.yaml` `dependencies[backend].version` | 2.1.0 ❌ |
| `helm/Chart.yaml` `dependencies[frontend].version` | 2.1.0 ❌ |
| `helm/charts/backend/Chart.yaml` `version` | 2.2.0 ✅ |
| `helm/charts/frontend/Chart.yaml` `version` | 2.2.0 ✅ |

The parent chart became 2.2.0 while still pinning `backend: 2.1.0`, and the backend subchart had moved to 2.2.0. Helm refuses that combination.

The YAML round trip also stripped every `# x-release-please-version` marker, the quotes on `appVersion`, and the blank lines.

Without this fix every future release breaks the same way, and `appVersion` never moves.

## Fix

Declare the three chart files with `"type": "generic"`. The generic updater works from the `x-release-please-version` markers rather than from a YAML key, so it bumps all four annotated lines in `helm/Chart.yaml` — the dependency pins included — and keeps the comments.

`generic` is a documented `extra-files` type in the [release-please config schema](https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json).

## Notes

- `dev` still has all the markers, and release-please rebuilds its release branch on every push, so the open `2.2.0` release PR repairs itself once this merges.
- README already describes the intended behaviour (`helm/Chart.yaml` — version, `appVersion`, and subchart dependency pins), so no doc change is needed.
- No ticket exists for this, hence the `scratch-` branch name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR configures release-please to use its generic updater for all three Helm charts, ensuring every annotated chart version, application version, and dependency pin advances together while preserving the annotations.
- Replaces plain Helm chart paths with explicit generic updater entries.
- Keeps parent and subchart versions synchronized during releases.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| release-please-config.json | Correctly selects the supported generic updater for each annotated Helm chart without changing unrelated release configuration. |

</details>

<sub>Reviews (2): Last reviewed commit: ["ci: bump every annotated version in the ..."](https://github.com/amazeeio/amazee.ai/commit/135d78a94ac01d7ee90c896430aa4f3035c26ec4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53732420)</sub>

<!-- /greptile_comment -->