### PR TITLE
fix(auth): invalidate the access token on logout 

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -31,6 +31,10 @@ environments:
         schedule: "30 2 * * *"
         command: python scripts/trigger_prune_signup_events_job.py
         service: backend
+      - name: prune-revoked-tokens
+        schedule: "45 2 * * *"
+        command: python scripts/trigger_prune_revoked_tokens_job.py
+        service: backend
       # Frequent on purpose: a 90% warning is worthless if it lands an hour after
       # the key stopped working. The sweep is 2 LiteLLM calls per region and
       # scales with active entities, not key count, so 5 minutes is affordable.
@@ -87,6 +91,10 @@ environments:
       - name: prune-signup-events
         schedule: "30 2 * * *"
         command: python scripts/trigger_prune_signup_events_job.py
+        service: backend
+      - name: prune-revoked-tokens
+        schedule: "45 2 * * *"
+        command: python scripts/trigger_prune_revoked_tokens_job.py
         service: backend
       - name: monitor-budget-thresholds
         schedule: "*/5 * * * *"

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -9,7 +9,17 @@ import email_validator
 
 from typing import Optional, List, Union
 
-from fastapi import APIRouter, Depends, HTTPException, status, Response, Request, Form
+from fastapi import (
+    APIRouter,
+    Cookie,
+    Depends,
+    Form,
+    Header,
+    HTTPException,
+    Request,
+    Response,
+    status,
+)
 from sqlalchemy.orm import Session
 from sqlalchemy import func
 from urllib.parse import urlparse
@@ -64,6 +74,7 @@ from app.api.users import _create_user_in_db, get_user_by_email
 from app.core.email import normalize_email_for_lookup
 from app.services.disposable_domains import assert_email_domain_allowed
 from app.services.signup_velocity import enforce_signup_velocity
+from app.services.token_revocation import revoke_access_token
 
 auth_logger = logging.getLogger(__name__)
 
@@ -89,6 +100,16 @@ def get_cookie_domain():
     # Remove the first part (e.g., 'backend' or 'frontend')
     domain = ".".join(hostname.split(".")[1:])
     return domain
+
+
+def _bearer_token(authorization: Optional[str]) -> Optional[str]:
+    """Token out of an ``Authorization: Bearer <token>`` header, or None."""
+    if not isinstance(authorization, str):
+        return None
+    parts = authorization.split()
+    if len(parts) == 2 and parts[0].lower() == "bearer":
+        return parts[1]
+    return None
 
 
 async def get_login_data(
@@ -222,7 +243,29 @@ async def login(
 
 
 @router.post("/logout")
-async def logout(response: Response):
+async def logout(
+    response: Response,
+    access_token: Optional[str] = Cookie(None, alias="access_token"),
+    authorization: Optional[str] = Header(None),
+    db: Session = Depends(get_db),
+):
+    """Log the caller out and stop the presented access token from working again.
+
+    The endpoint stays open to anonymous callers so a client can always clear its
+    cookie. It reports success either way and never says whether a token was real.
+    """
+    token = _bearer_token(authorization) or (
+        access_token if isinstance(access_token, str) else None
+    )
+    if token:
+        try:
+            revoke_access_token(db, token)
+        except Exception:
+            # The cookie must still be cleared, so a failed write cannot make
+            # logout look broken to the client. It is logged for follow-up.
+            auth_logger.exception("Failed to revoke access token during logout")
+            db.rollback()
+
     # Get cookie domain for logout
     cookie_domain = get_cookie_domain()
 

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -29,6 +29,7 @@ from app.core.config import settings
 from app.core.dependencies import get_limit_service
 from app.core.roles import UserRole
 from app.core.security import (
+    assert_token_not_revoked,
     create_access_token,
     get_current_user_from_auth,
     get_password_hash,
@@ -74,7 +75,7 @@ from app.api.users import _create_user_in_db, get_user_by_email
 from app.core.email import normalize_email_for_lookup
 from app.services.disposable_domains import assert_email_domain_allowed
 from app.services.signup_velocity import enforce_signup_velocity
-from app.services.token_revocation import revoke_access_token
+from app.services.token_revocation import is_token_revoked, revoke_access_token
 
 auth_logger = logging.getLogger(__name__)
 
@@ -779,6 +780,9 @@ async def validate_jwt(
         payload = jwt.decode(
             token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM]
         )
+        # A revoked token must not be able to buy a fresh one, which would undo
+        # the logout that revoked it.
+        assert_token_not_revoked(db, payload)
         email: str = payload.get("sub")
         user = get_user_by_email(db, email)
         if not user:
@@ -802,6 +806,13 @@ async def validate_jwt(
                 email = payload.get("sub")
 
                 if not email:
+                    raise credentials_exception
+
+                # A revoked token gets no recovery email either. A token with no
+                # jti still does: it predates revocation, and this branch is how
+                # the holder of an old link gets a working one.
+                if is_token_revoked(db, payload.get("jti")):
+                    auth_logger.info("Refused to refresh a revoked expired token")
                     raise credentials_exception
 
                 send_validation_url(email)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -116,6 +116,13 @@ class Settings(BaseSettings):
     SIGNUP_EVENTS_RETENTION_DAYS: int = int(
         os.getenv("SIGNUP_EVENTS_RETENTION_DAYS", "7")
     )
+    # --- Access token revocation (logout) ---
+    # How long a revoked_tokens row is kept after the token's own expiry. The row
+    # stops mattering once the token expires; the extra days only cover clock skew
+    # and leave a short audit trail.
+    REVOKED_TOKENS_RETENTION_DAYS: int = int(
+        os.getenv("REVOKED_TOKENS_RETENTION_DAYS", "2")
+    )
     # --- Budget threshold alerts (AI-448) ---
     # Off by default: enabling it starts sending webhooks to a third party, so it
     # must be an explicit per-environment decision.

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime, timedelta, UTC
 from typing import Optional
 from jose import JWTError, jwt
@@ -12,6 +13,7 @@ from app.db.database import get_db
 from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import func, inspect as sa_inspect
 from app.db.models import DBUser, DBAPIToken
+from app.services.token_revocation import is_token_revoked
 from app.core.rbac import (
     require_system_admin,
     require_team_admin,
@@ -41,7 +43,11 @@ def get_password_hash(password: str) -> str:
 
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
-    """Create JWT access token."""
+    """Create JWT access token.
+
+    Every token gets a unique ``jti`` so logout can revoke this token alone,
+    without ending the user's other sessions. See app/services/token_revocation.py.
+    """
     to_encode = data.copy()
     if expires_delta:
         expire = datetime.now(UTC) + expires_delta
@@ -49,7 +55,13 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -
         expire = datetime.now(UTC) + timedelta(
             minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES
         )
-    to_encode.update({"exp": expire})
+    to_encode.update(
+        {
+            "exp": expire,
+            "iat": datetime.now(UTC),
+            "jti": to_encode.get("jti") or str(uuid.uuid4()),
+        }
+    )
     encoded_jwt = jwt.encode(
         to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM
     )
@@ -75,6 +87,17 @@ async def get_current_user(
             token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM]
         )
     except JWTError:
+        raise credentials_exception
+
+    # A token with no jti cannot be revoked at logout, so it is not accepted.
+    # Only tokens signed before this check existed lack one.
+    jti = payload.get("jti")
+    if not jti:
+        logger.info("Rejected access token without a jti claim")
+        raise credentials_exception
+
+    if is_token_revoked(db, jti):
+        logger.info("Rejected revoked access token jti=%s", jti)
         raise credentials_exception
 
     raw_email: str = payload.get("sub")

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -68,6 +68,31 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -
     return encoded_jwt
 
 
+def assert_token_not_revoked(db: Session, payload: dict) -> None:
+    """Raise 401 unless the token id is present and still allowed.
+
+    Every path that turns a decoded JWT into access must call this, including the
+    refresh in /auth/validate-jwt. Skipping it there would let a revoked token buy
+    a fresh one and undo the logout.
+    """
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+    # A token with no jti cannot be revoked at logout, so it is not accepted.
+    # Only tokens signed before revocation existed lack one.
+    jti = payload.get("jti")
+    if not jti:
+        logger.info("Rejected access token without a jti claim")
+        raise credentials_exception
+
+    if is_token_revoked(db, jti):
+        logger.info("Rejected revoked access token jti=%s", jti)
+        raise credentials_exception
+
+
 async def get_current_user(
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(bearer_scheme),
     db: Session = Depends(get_db),
@@ -89,16 +114,7 @@ async def get_current_user(
     except JWTError:
         raise credentials_exception
 
-    # A token with no jti cannot be revoked at logout, so it is not accepted.
-    # Only tokens signed before this check existed lack one.
-    jti = payload.get("jti")
-    if not jti:
-        logger.info("Rejected access token without a jti claim")
-        raise credentials_exception
-
-    if is_token_revoked(db, jti):
-        logger.info("Rejected revoked access token jti=%s", jti)
-        raise credentials_exception
+    assert_token_not_revoked(db, payload)
 
     raw_email: str = payload.get("sub")
     # Normalize plus-tags so a token minted for "user+p12@" still resolves

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -758,6 +758,30 @@ class DBSignupEvent(Base):
     )
 
 
+class DBRevokedToken(Base):
+    """Denylist of access-token ids (``jti``) that must no longer authenticate.
+
+    The access token is a self-contained JWT, so a signed token stays valid until
+    it expires and the server holds no session it could drop. Logout writes the
+    token id here, and every JWT auth path rejects an id it finds. Rows are pruned
+    once the token has expired, because after that the token fails on its own.
+
+    ``user_id`` is a plain integer on purpose. A foreign key would block the
+    hard-delete job while a denylist row still points at the user.
+    """
+
+    __tablename__ = "revoked_tokens"
+
+    id = Column(Integer, primary_key=True, index=True)
+    jti = Column(String, unique=True, nullable=False, index=True)
+    user_id = Column(Integer, nullable=True, index=True)
+    # Expiry of the revoked token, copied from its ``exp`` claim.
+    expires_at = Column(DateTime(timezone=True), nullable=False, index=True)
+    revoked_at = Column(
+        DateTime(timezone=True), default=func.now(), nullable=False, index=True
+    )
+
+
 class DBBudgetAlertState(Base):
     """Highest budget threshold already notified for one alert subject.
 

--- a/app/migrations/versions/20260817_100000_f9a0b1c2d3e4_add_revoked_tokens.py
+++ b/app/migrations/versions/20260817_100000_f9a0b1c2d3e4_add_revoked_tokens.py
@@ -1,0 +1,53 @@
+"""add revoked_tokens table so logout can invalidate an access token
+
+Revision ID: f9a0b1c2d3e4
+Revises: e8f9a0b1c2d3
+Create Date: 2026-08-17 10:00:00.000000+00:00
+
+"""
+
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic (read via module reflection).
+revision: str = "f9a0b1c2d3e4"
+down_revision: Union[str, None] = "e8f9a0b1c2d3"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "revoked_tokens",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("jti", sa.String(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "revoked_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("jti", name="uq_revoked_tokens_jti"),
+    )
+    op.create_index(op.f("ix_revoked_tokens_id"), "revoked_tokens", ["id"])
+    # The hot path: one lookup by jti on every authenticated request.
+    op.create_index(op.f("ix_revoked_tokens_jti"), "revoked_tokens", ["jti"])
+    op.create_index(op.f("ix_revoked_tokens_user_id"), "revoked_tokens", ["user_id"])
+    op.create_index(
+        op.f("ix_revoked_tokens_expires_at"), "revoked_tokens", ["expires_at"]
+    )
+    op.create_index(
+        op.f("ix_revoked_tokens_revoked_at"), "revoked_tokens", ["revoked_at"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_revoked_tokens_revoked_at"), table_name="revoked_tokens")
+    op.drop_index(op.f("ix_revoked_tokens_expires_at"), table_name="revoked_tokens")
+    op.drop_index(op.f("ix_revoked_tokens_user_id"), table_name="revoked_tokens")
+    op.drop_index(op.f("ix_revoked_tokens_jti"), table_name="revoked_tokens")
+    op.drop_index(op.f("ix_revoked_tokens_id"), table_name="revoked_tokens")
+    op.drop_table("revoked_tokens")

--- a/app/services/token_revocation.py
+++ b/app/services/token_revocation.py
@@ -1,0 +1,108 @@
+"""Revocation of access tokens (JWTs) at logout.
+
+The access token is a self-contained JWT: the backend signs it, hands it to the
+client, and keeps no session record. Without a denylist, deleting the cookie at
+logout only affects the browser, so a copied token keeps working until its ``exp``
+(CWE-613). Every token now carries a unique ``jti``. Logout stores that id in the
+``revoked_tokens`` table and the auth path refuses any id it finds there.
+
+Postgres backs the denylist because this backend has no Redis, and the shared
+database keeps the answer the same on every pod.
+
+API tokens (the ``api_tokens`` table) are not touched here. They are opaque,
+already stored server-side, and are deleted through their own endpoint.
+"""
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Optional
+
+from jose import JWTError, jwt
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.core.email import normalize_email_for_lookup
+from app.db.models import DBRevokedToken, DBUser
+
+logger = logging.getLogger(__name__)
+
+
+def is_token_revoked(db: Session, jti: Optional[str]) -> bool:
+    """True if this token id is on the denylist."""
+    if not jti:
+        return False
+    return (
+        db.query(DBRevokedToken.id).filter(DBRevokedToken.jti == jti).first()
+        is not None
+    )
+
+
+def revoke_access_token(db: Session, token: str) -> bool:
+    """Add the token's ``jti`` to the denylist. True if it is now revoked.
+
+    The signature is verified but the expiry is not: an already-expired token is
+    rejected anyway, so it needs no row. Returns False when the token cannot be
+    trusted or carries no ``jti``, so the caller can stay quiet about it — logout
+    must not tell an anonymous caller whether a token was genuine.
+    """
+    try:
+        payload = jwt.decode(
+            token,
+            settings.SECRET_KEY,
+            algorithms=[settings.ALGORITHM],
+            options={"verify_exp": False},
+        )
+    except JWTError:
+        return False
+
+    jti = payload.get("jti")
+    exp = payload.get("exp")
+    if not jti or not exp:
+        return False
+
+    expires_at = datetime.fromtimestamp(exp, tz=UTC)
+    if expires_at <= datetime.now(UTC):
+        return True
+
+    if is_token_revoked(db, jti):
+        return True
+
+    user_id = _user_id_for_subject(db, payload.get("sub"))
+    db.add(DBRevokedToken(jti=jti, user_id=user_id, expires_at=expires_at))
+    try:
+        db.commit()
+    except IntegrityError:
+        # Two logouts raced on the same token. The other one won, which is the
+        # same outcome we wanted.
+        db.rollback()
+        return is_token_revoked(db, jti)
+
+    logger.info("Revoked access token jti=%s user_id=%s", jti, user_id)
+    return True
+
+
+def prune_revoked_tokens(db: Session) -> int:
+    """Delete denylist rows for tokens that have expired. Returns rows removed.
+
+    An expired token fails validation on its own, so keeping its row only grows
+    the table. Runs from the daily cron.
+    """
+    cutoff = datetime.now(UTC) - timedelta(days=settings.REVOKED_TOKENS_RETENTION_DAYS)
+    deleted = (
+        db.query(DBRevokedToken)
+        .filter(DBRevokedToken.expires_at < cutoff)
+        .delete(synchronize_session=False)
+    )
+    db.commit()
+    logger.info("Pruned %d revoked_tokens rows expired before %s", deleted, cutoff)
+    return deleted
+
+
+def _user_id_for_subject(db: Session, subject: Optional[str]) -> Optional[int]:
+    """Best-effort owner of the token, stored only to make the table readable."""
+    if not subject:
+        return None
+    email = normalize_email_for_lookup(subject)
+    row = db.query(DBUser.id).filter(DBUser.email.ilike(email)).first()
+    return row[0] if row else None

--- a/scripts/trigger_prune_revoked_tokens_job.py
+++ b/scripts/trigger_prune_revoked_tokens_job.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import logging
+
+# Add the parent directory to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from sqlalchemy.orm import sessionmaker
+from app.db.database import engine
+from app.core.locking import try_acquire_lock, release_lock
+from app.services.token_revocation import prune_revoked_tokens
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+LOCK_NAME = "prune_revoked_tokens"
+
+
+def main():
+    """Drop denylist rows whose token has expired.
+
+    An expired token already fails validation, so its row only makes the table
+    grow. Runs daily via the Lagoon cron, under the shared advisory lock so
+    overlapping runs do not clobber each other.
+    """
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = SessionLocal()
+    try:
+        if not try_acquire_lock(LOCK_NAME, db, lock_timeout=10):
+            logger.warning(
+                "Another process holds the %s lock; skipping this run", LOCK_NAME
+            )
+            sys.exit(0)
+        try:
+            logger.info("Pruning expired revoked_tokens...")
+            deleted = prune_revoked_tokens(db)
+            logger.info("✅ Pruned %d revoked_tokens", deleted)
+        finally:
+            release_lock(LOCK_NAME, db)
+    except Exception as e:  # noqa: BLE001
+        logger.error("❌ revoked_tokens prune failed: %s", str(e))
+        sys.exit(1)
+    finally:
+        db.close()
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_logout_revocation.py
+++ b/tests/test_logout_revocation.py
@@ -1,6 +1,7 @@
 """Logout must stop the presented access token from working again (CWE-613)."""
 
 from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
 
 import pytest
 from jose import jwt
@@ -124,6 +125,80 @@ def test_logout_does_not_affect_the_users_other_sessions(client, test_user):
         ).status_code
         == 200
     )
+
+
+def test_revoked_token_cannot_be_refreshed_by_validate_jwt(
+    client, test_user, test_token
+):
+    # The refresh endpoint decodes the token itself, so it needs its own check.
+    # Without one, a revoked token buys a fresh one and undoes the logout.
+    assert client.get(f"/auth/validate-jwt?token={test_token}").status_code == 200
+
+    client.post("/auth/logout", headers={"Authorization": f"Bearer {test_token}"})
+
+    query = client.get(f"/auth/validate-jwt?token={test_token}")
+    header = client.get(
+        "/auth/validate-jwt", headers={"Authorization": f"Bearer {test_token}"}
+    )
+
+    assert query.status_code == 401
+    assert header.status_code == 401
+    assert "access_token" not in query.json()
+
+
+def test_validate_jwt_refuses_a_token_without_a_jti(client, test_user):
+    legacy = jwt.encode(
+        {"sub": test_user.email, "exp": datetime.now(UTC) + timedelta(minutes=30)},
+        settings.SECRET_KEY,
+        algorithm=settings.ALGORITHM,
+    )
+
+    assert client.get(f"/auth/validate-jwt?token={legacy}").status_code == 401
+
+
+@patch("app.api.auth.SESService")
+def test_expired_revoked_token_gets_no_recovery_email(mock_ses, client, db, test_user):
+    mock_ses.return_value.send_email.return_value = True
+    token = create_access_token(
+        data={"sub": test_user.email}, expires_delta=timedelta(minutes=30)
+    )
+    revoke_access_token(db, token)
+
+    # Same token, now past its expiry, replayed at the refresh endpoint.
+    expired_revoked = jwt.encode(
+        {
+            "sub": test_user.email,
+            "jti": _claims(token)["jti"],
+            "exp": datetime.now(UTC) - timedelta(seconds=1),
+        },
+        settings.SECRET_KEY,
+        algorithm=settings.ALGORITHM,
+    )
+
+    response = client.get(f"/auth/validate-jwt?token={expired_revoked}")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Could not validate credentials"
+    mock_ses.return_value.send_email.assert_not_called()
+
+
+@patch("app.api.auth.SESService")
+def test_expired_token_without_a_jti_still_gets_a_recovery_email(
+    mock_ses, client, test_user
+):
+    mock_ses.return_value.send_email.return_value = True
+    # An old emailed link: it predates revocation, so recovery must still work.
+    legacy_expired = jwt.encode(
+        {"sub": test_user.email, "exp": datetime.now(UTC) - timedelta(seconds=1)},
+        settings.SECRET_KEY,
+        algorithm=settings.ALGORITHM,
+    )
+
+    response = client.get(f"/auth/validate-jwt?token={legacy_expired}")
+
+    assert response.status_code == 401
+    assert "validation URL has been sent" in response.json()["detail"]
+    mock_ses.return_value.send_email.assert_called_once()
 
 
 def test_logout_leaves_api_tokens_working(client, db, test_user, test_token):

--- a/tests/test_logout_revocation.py
+++ b/tests/test_logout_revocation.py
@@ -1,0 +1,209 @@
+"""Logout must stop the presented access token from working again (CWE-613)."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from jose import jwt
+
+from app.core.config import settings
+from app.core.security import create_access_token
+from app.db.models import DBRevokedToken
+from app.services.token_revocation import (
+    prune_revoked_tokens,
+    revoke_access_token,
+)
+
+
+def _claims(token: str) -> dict:
+    return jwt.decode(
+        token,
+        settings.SECRET_KEY,
+        algorithms=[settings.ALGORITHM],
+        options={"verify_exp": False},
+    )
+
+
+def test_access_token_carries_a_unique_jti():
+    first = _claims(create_access_token(data={"sub": "a@example.com"}))
+    second = _claims(create_access_token(data={"sub": "a@example.com"}))
+
+    assert first["jti"]
+    assert first["jti"] != second["jti"]
+    assert "iat" in first
+
+
+def test_token_without_jti_is_rejected(client, test_user):
+    # Shaped like a token signed before revocation existed.
+    legacy = jwt.encode(
+        {
+            "sub": test_user.email,
+            "exp": datetime.now(UTC) + timedelta(minutes=30),
+        },
+        settings.SECRET_KEY,
+        algorithm=settings.ALGORITHM,
+    )
+
+    response = client.get("/auth/me", headers={"Authorization": f"Bearer {legacy}"})
+
+    assert response.status_code == 401
+
+
+def test_logout_revokes_the_cookie_token(client, test_user):
+    login = client.post(
+        "/auth/login",
+        data={"username": test_user.email, "password": "testpassword"},
+    )
+    assert login.status_code == 200
+    token = login.json()["access_token"]
+
+    # The cookie is set directly: login marks it Secure, and the test client
+    # talks plain http, so its own jar would drop it.
+    client.cookies.set("access_token", token)
+    assert client.get("/auth/me").status_code == 200
+
+    assert client.post("/auth/logout").status_code == 200
+
+    # Replay the same cookie, the way a stolen one would be used.
+    client.cookies.set("access_token", token)
+    assert client.get("/auth/me").status_code == 401
+
+
+def test_logout_revokes_a_bearer_header_token(client, test_user, test_token):
+    headers = {"Authorization": f"Bearer {test_token}"}
+    assert client.get("/auth/me", headers=headers).status_code == 200
+
+    assert client.post("/auth/logout", headers=headers).status_code == 200
+
+    assert client.get("/auth/me", headers=headers).status_code == 401
+
+
+def test_revoked_token_is_rejected_on_both_transports(client, test_user, test_token):
+    # Both transports accept the token first, so the 401s below prove revocation
+    # and not a transport the app simply ignores.
+    client.cookies.set("access_token", test_token)
+    assert client.get("/auth/me").status_code == 200
+    assert (
+        client.get(
+            "/auth/me", headers={"Authorization": f"Bearer {test_token}"}
+        ).status_code
+        == 200
+    )
+
+    client.cookies.clear()
+    client.post("/auth/logout", headers={"Authorization": f"Bearer {test_token}"})
+
+    assert (
+        client.get(
+            "/auth/me", headers={"Authorization": f"Bearer {test_token}"}
+        ).status_code
+        == 401
+    )
+    client.cookies.set("access_token", test_token)
+    assert client.get("/auth/me").status_code == 401
+
+
+def test_logout_does_not_affect_the_users_other_sessions(client, test_user):
+    first = client.post(
+        "/auth/login",
+        data={"username": test_user.email, "password": "testpassword"},
+    ).json()["access_token"]
+    second = client.post(
+        "/auth/login",
+        data={"username": test_user.email, "password": "testpassword"},
+    ).json()["access_token"]
+
+    client.post("/auth/logout", headers={"Authorization": f"Bearer {first}"})
+
+    assert (
+        client.get("/auth/me", headers={"Authorization": f"Bearer {first}"}).status_code
+        == 401
+    )
+    assert (
+        client.get(
+            "/auth/me", headers={"Authorization": f"Bearer {second}"}
+        ).status_code
+        == 200
+    )
+
+
+def test_logout_leaves_api_tokens_working(client, db, test_user, test_token):
+    created = client.post(
+        "/auth/token",
+        json={"name": "cli"},
+        headers={"Authorization": f"Bearer {test_token}"},
+    )
+    assert created.status_code == 200
+    api_token = created.json()["token"]
+
+    client.post("/auth/logout", headers={"Authorization": f"Bearer {api_token}"})
+
+    # An API token is opaque and has its own delete endpoint, so logout must not
+    # take it away.
+    assert (
+        client.get(
+            "/auth/me", headers={"Authorization": f"Bearer {api_token}"}
+        ).status_code
+        == 200
+    )
+
+
+def test_logout_without_a_token_still_succeeds(client):
+    assert client.post("/auth/logout").status_code == 200
+
+
+def test_logout_with_a_forged_token_succeeds_and_stores_nothing(client, db):
+    forged = jwt.encode(
+        {"sub": "nobody@example.com", "exp": datetime.now(UTC) + timedelta(minutes=5)},
+        "not-the-real-secret",
+        algorithm=settings.ALGORITHM,
+    )
+
+    response = client.post(
+        "/auth/logout", headers={"Authorization": f"Bearer {forged}"}
+    )
+
+    assert response.status_code == 200
+    assert db.query(DBRevokedToken).count() == 0
+
+
+def test_revoking_the_same_token_twice_is_harmless(db, test_user):
+    token = create_access_token(data={"sub": test_user.email})
+
+    assert revoke_access_token(db, token) is True
+    assert revoke_access_token(db, token) is True
+    assert db.query(DBRevokedToken).filter(DBRevokedToken.jti.isnot(None)).count() == 1
+
+
+def test_expired_token_needs_no_denylist_row(db, test_user):
+    expired = create_access_token(
+        data={"sub": test_user.email}, expires_delta=timedelta(minutes=-5)
+    )
+
+    assert revoke_access_token(db, expired) is True
+    assert db.query(DBRevokedToken).count() == 0
+
+
+def test_revocation_records_the_token_owner(db, test_user):
+    revoke_access_token(db, create_access_token(data={"sub": test_user.email}))
+
+    row = db.query(DBRevokedToken).one()
+    assert row.user_id == test_user.id
+    assert row.expires_at > datetime.now(UTC)
+
+
+@pytest.mark.parametrize("expired", [True, False])
+def test_prune_removes_only_rows_past_retention(db, test_user, expired):
+    age_days = settings.REVOKED_TOKENS_RETENTION_DAYS + 1 if expired else 0
+    db.add(
+        DBRevokedToken(
+            jti="jti-under-test",
+            user_id=test_user.id,
+            expires_at=datetime.now(UTC) - timedelta(days=age_days),
+        )
+    )
+    db.commit()
+
+    deleted = prune_revoked_tokens(db)
+
+    assert deleted == (1 if expired else 0)
+    assert db.query(DBRevokedToken).count() == (0 if expired else 1)


### PR DESCRIPTION
## Problem

`POST /auth/logout` only deleted the `access_token` cookie. The access token is a self-contained JWT and the backend keeps no session record, so a copied token kept working until its `exp` — up to 60 minutes after the user logged out. Reproduced on DEV with `GET /auth/me`.

This is amazee.ai's own login (`dashboard.amazee.ai`), not moad. moad's Keycloak logout already deletes its server-side session and is unaffected.

## Change

- Every access token gets a unique `jti` and an `iat`.
- New `revoked_tokens` table holds the `jti` of revoked tokens with the token's own `expires_at`. Postgres, because this backend has no Redis and the shared DB keeps the answer the same on every pod.
- Logout reads the token from the cookie or the `Authorization` header and writes its `jti`. It stays open to anonymous callers and always returns 200, so it never says whether a token was real.
- JWT validation rejects a revoked `jti`. All three auth paths funnel through `get_current_user`, so one check covers the cookie, the bearer header, and `AuthMiddleware`.
- Daily cron (`prune-revoked-tokens`, 02:45) drops rows once the token has expired.

## Behaviour change to know about

A JWT with no `jti` is rejected. Nothing can revoke it, so accepting it would keep the hole open. Only tokens signed before this change lack one, which means at deploy:

- active `dashboard.amazee.ai` sessions end and the user signs in again,
- emailed upgrade links (`/auth/validate-jwt`, up to 24h old) that nobody clicked yet stop working; the user requests a new one.

Say the word if you would rather accept old tokens for a grace period instead.

Not affected: API tokens (`api_tokens`) are opaque, stored server-side, and have their own delete endpoint. Logout leaves them working — there is a test for it. moad's `AMAZEEAI_ADMIN_API_TOKEN` is one of these.

## Testing

- 14 new tests in `tests/test_logout_revocation.py`: logout then replay on cookie and bearer, one device does not log out the others, API token survives logout, forged token stores nothing, double revoke, expired token needs no row, prune boundary.
- Full suite: 1423 passed, 2 skipped.
- Migration applied and rolled back on Postgres 16; single alembic head.
- `ruff check` clean.

Note: `alembic upgrade head` from an empty database fails on the first migration in the existing chain (`relation "ai_tokens" does not exist`). This is pre-existing on `dev` and unrelated to this PR.

## Reviewer checklist

- [ ] Accept the deploy-time logout of active sessions, or ask for a grace period.
- [ ] Confirm the extra `revoked_tokens` lookup per authenticated request is acceptable (indexed on `jti`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds database-backed JWT revocation during logout and applies it to normal authentication and validate-jwt refresh paths. Its cleanup policy eventually removes the state needed to keep revoked expired tokens from triggering recovery emails.
- Adds unique `jti` and `iat` claims to access tokens.
- Persists revoked token identifiers in PostgreSQL and rejects them during authentication and refresh.
- Adds a scheduled cleanup job and comprehensive revocation tests.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until pruning no longer lets a logged-out token regain the ability to trigger validate-jwt recovery emails.

The refresh bypass is fixed while the revocation row exists, but the scheduled cleanup deletes that state and the expired-token branch subsequently treats the same revoked jti as allowed for email recovery.

**Files Needing Attention:** app/services/token_revocation.py and app/api/auth.py
</details>

<details open><summary><h3>Security Review</h3></summary>

Revocation correctly blocks refresh while a denylist row exists, but pruning that row later allows an expired, logged-out token to trigger a recovery email again.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/auth.py | Adds logout revocation and closes the direct validate-jwt refresh bypass, but its expired-token guard depends on revocation rows remaining present. |
| app/core/security.py | Adds unique token identifiers and centralizes rejection of revoked or non-revocable JWTs. |
| app/services/token_revocation.py | Implements persistent revocation, but cleanup eventually restores recovery-email behavior for previously revoked tokens. |
| app/db/models.py | Adds the revoked_tokens denylist model with unique and indexed token identifiers. |
| app/migrations/versions/20260817_100000_f9a0b1c2d3e4_add_revoked_tokens.py | Creates and indexes the revoked_tokens table consistently with the ORM model. |
| scripts/trigger_prune_revoked_tokens_job.py | Adds a locked daily pruning job whose deletion policy exposes the retained-state limitation. |
| tests/test_logout_revocation.py | Covers immediate and expired-token revocation but not replay after the denylist row has been pruned. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Holder
    participant API as /auth/validate-jwt
    participant DB as revoked_tokens
    participant Cron as prune job
    participant Email as Validation email
    Cron->>DB: Delete rows older than expiry + retention
    Holder->>API: Replay expired revoked JWT
    API->>DB: Lookup jti
    DB-->>API: Not found
    API->>Email: Send validation URL
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(auth): close the revocation bypass i..."](https://github.com/amazeeio/amazee.ai/commit/1bc323e9e90bb9e0f82bd2994357bb3a97a69a52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53896442)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Authentication and RBAC](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/auth-rbac.md)
- Knowledge Base — [Database models, session, and migrations](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/amazee.ai/-/docs/database-models.md)

<!-- /greptile_comment -->