### PR TITLE
fix: release limited_resources counters when the owner goes away

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -1110,6 +1110,10 @@ async def generate_trial_access(
             )
         try:
             if user:
+                # The MANUAL budget row set above has no foreign key to the
+                # user; left behind, it would pin a future user with the same
+                # id to the trial budget cap.
+                limit_service.delete_limits(OwnerType.USER, user.id, commit=False)
                 db.delete(user)
                 db.commit()
         except Exception as cleanup_error:

--- a/app/api/private_ai_keys.py
+++ b/app/api/private_ai_keys.py
@@ -1462,6 +1462,11 @@ def _pin_user_to_key_team(
 
     Idempotent: no-op when the user is already on the key's team. Skipped
     for keys without a team (team_id is None) since there is nothing to pin.
+
+    The pin is exempt from check_team_user_limit on purpose: moad already
+    created the key under the target team, and rejecting the pin here would
+    strand a live key the user can never see. Both teams' member counters are
+    re-derived from the real members on their next member addition.
     """
     if db_key.team_id is None or current_user.team_id == db_key.team_id:
         return

--- a/app/api/teams.py
+++ b/app/api/teams.py
@@ -36,6 +36,7 @@ from app.db.models import (
     DBTeamRegion,
     DBUser,
 )
+from app.schemas.limits import OwnerType
 from app.schemas.models import (
     BudgetType,
     SalesProduct,
@@ -449,6 +450,10 @@ async def delete_team(team_id: int, db: Session = Depends(get_db)):
     db.query(DBBudgetAlertState).filter(DBBudgetAlertState.team_id == team_id).delete(
         synchronize_session=False
     )
+
+    # Limit rows point at the team by id with no foreign key, so they would stay
+    # behind for good and give a later team with the same id a used-up counter.
+    LimitService(db).delete_limits(OwnerType.TEAM, team_id, commit=False)
 
     # Delete the team
     db.delete(db_team)

--- a/app/api/teams.py
+++ b/app/api/teams.py
@@ -1053,7 +1053,13 @@ async def merge_teams(
                 except Exception as e:
                     logger.error(f"Failed to update LiteLLM key {key.id}: {str(e)}")
 
-        # Delete source team
+        # Delete source team. Its limit rows must go with it, same as in
+        # delete_team: owner_id has no foreign key, so they would outlive the
+        # team and give a later team with the same id a used-up counter.
+        # The target team takes the members without a cap check: the merge is
+        # a system-admin operation, and its member counter is re-derived from
+        # the real members on the next member addition.
+        LimitService(db).delete_limits(OwnerType.TEAM, source_team.id, commit=False)
         db.delete(source_team)
         db.commit()
 

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -16,10 +16,10 @@ from app.core.litellm_user_sync import (
     sync_remove_user_from_team,
     sync_update_user_team_role,
 )
-from app.core.limit_service import LimitNotFoundError, LimitService
+from app.core.limit_service import LimitService
 from app.db.database import get_db
 from app.core.dependencies import get_limit_service
-from app.schemas.limits import OwnerType, ResourceType
+from app.schemas.limits import OwnerType
 from app.schemas.models import (
     User,
     AdminUserUpdate,
@@ -844,10 +844,6 @@ async def _create_user_in_db(user: UserCreate, db: Session) -> DBUser:
     # user-creation choke point (covers create_user, sign-in auto-provision, trial).
     assert_email_domain_allowed(db, user.email)
 
-    limit_service = get_limit_service(db)
-    if settings.ENABLE_LIMITS and user.team_id is not None:
-        limit_service.check_team_user_limit(user.team_id)
-
     # Validate role if provided
     if user.role and user.role not in UserRole.get_all_roles():
         raise HTTPException(
@@ -862,6 +858,12 @@ async def _create_user_in_db(user: UserCreate, db: Session) -> DBUser:
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="system_admin role cannot be assigned via user creation.",
         )
+
+    # Take the seat only after every validation that can reject the request,
+    # so a rejected request does not hold a seat until the next recount.
+    limit_service = get_limit_service(db)
+    if settings.ENABLE_LIMITS and user.team_id is not None:
+        limit_service.check_team_user_limit(user.team_id)
 
     # Default to the lowest permissions for a user in a team
     if user.role is None and user.team_id is not None:
@@ -1047,18 +1049,6 @@ async def update_user(
     return db_user
 
 
-def release_team_user_seat(db: Session, team_id: int) -> None:
-    """
-    Give one member seat back to a team when a member leaves, is deleted, or never got in.
-
-    A team that never reached the limit service has no counter to release.
-    """
-    try:
-        LimitService(db).decrement_resource(OwnerType.TEAM, team_id, ResourceType.USER)
-    except LimitNotFoundError:
-        logger.info(f"Team {team_id} has no user limit to release")
-
-
 @router.post(
     "/{user_id}/add-to-team",
     response_model=User,
@@ -1115,8 +1105,6 @@ async def add_user_to_team(
         db.refresh(db_user)
     except Exception:
         db.rollback()
-        if settings.ENABLE_LIMITS:
-            release_team_user_seat(db, team_operation.team_id)
         raise
 
     try:
@@ -1126,8 +1114,6 @@ async def add_user_to_team(
             db_user.team_id = None
             db.commit()
             db.refresh(db_user)
-            if settings.ENABLE_LIMITS:
-                release_team_user_seat(db, team_operation.team_id)
         except Exception:
             db.rollback()
             logger.exception(
@@ -1217,11 +1203,8 @@ async def remove_user_from_team(
             )
         raise
 
-    # The counter went up when this member was created, so give the seat back.
-    # Done after the removal is final, so a failed removal keeps the seat taken.
-    if settings.ENABLE_LIMITS:
-        release_team_user_seat(db, previous_team_id)
-
+    # No counter update here: the member counter is re-derived from the real
+    # members on the next check, so the freed seat is picked up there.
     return db_user
 
 
@@ -1263,10 +1246,6 @@ async def delete_user(
     except Exception:
         db.rollback()
         raise
-
-    # The counter went up when this member was created, so give the seat back.
-    if settings.ENABLE_LIMITS and team_id is not None:
-        release_team_user_seat(db, team_id)
 
     try:
         await sync_delete_user_across_regions(db=db, db_user=db_user, team_id=team_id)

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -1047,6 +1047,18 @@ async def update_user(
     return db_user
 
 
+def release_team_user_seat(db: Session, team_id: int) -> None:
+    """
+    Give one member seat back to a team when a member leaves, is deleted, or never got in.
+
+    A team that never reached the limit service has no counter to release.
+    """
+    try:
+        LimitService(db).decrement_resource(OwnerType.TEAM, team_id, ResourceType.USER)
+    except LimitNotFoundError:
+        logger.info(f"Team {team_id} has no user limit to release")
+
+
 @router.post(
     "/{user_id}/add-to-team",
     response_model=User,
@@ -1091,6 +1103,11 @@ async def add_user_to_team(
     if not db_team:
         raise HTTPException(status_code=404, detail="Team not found")
 
+    # This is the second door into a team, next to creating a member outright,
+    # so it has to take a seat as well. Without it a team can pass its cap.
+    if settings.ENABLE_LIMITS:
+        get_limit_service(db).check_team_user_limit(team_operation.team_id)
+
     # Add user to team
     db_user.team_id = team_operation.team_id
     try:
@@ -1098,6 +1115,8 @@ async def add_user_to_team(
         db.refresh(db_user)
     except Exception:
         db.rollback()
+        if settings.ENABLE_LIMITS:
+            release_team_user_seat(db, team_operation.team_id)
         raise
 
     try:
@@ -1107,6 +1126,8 @@ async def add_user_to_team(
             db_user.team_id = None
             db.commit()
             db.refresh(db_user)
+            if settings.ENABLE_LIMITS:
+                release_team_user_seat(db, team_operation.team_id)
         except Exception:
             db.rollback()
             logger.exception(
@@ -1115,18 +1136,6 @@ async def add_user_to_team(
             )
         raise
     return db_user
-
-
-def release_team_user_seat(db: Session, team_id: int) -> None:
-    """
-    Give one member seat back to a team after a member leaves or is deleted.
-
-    A team that never reached the limit service has no counter to release.
-    """
-    try:
-        LimitService(db).decrement_resource(OwnerType.TEAM, team_id, ResourceType.USER)
-    except LimitNotFoundError:
-        logger.info(f"Team {team_id} has no user limit to release")
 
 
 @router.post(

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -16,9 +16,10 @@ from app.core.litellm_user_sync import (
     sync_remove_user_from_team,
     sync_update_user_team_role,
 )
-from app.core.limit_service import LimitService
+from app.core.limit_service import LimitNotFoundError, LimitService
 from app.db.database import get_db
 from app.core.dependencies import get_limit_service
+from app.schemas.limits import OwnerType, ResourceType
 from app.schemas.models import (
     User,
     AdminUserUpdate,
@@ -1116,6 +1117,18 @@ async def add_user_to_team(
     return db_user
 
 
+def release_team_user_seat(db: Session, team_id: int) -> None:
+    """
+    Give one member seat back to a team after a member leaves or is deleted.
+
+    A team that never reached the limit service has no counter to release.
+    """
+    try:
+        LimitService(db).decrement_resource(OwnerType.TEAM, team_id, ResourceType.USER)
+    except LimitNotFoundError:
+        logger.info(f"Team {team_id} has no user limit to release")
+
+
 @router.post(
     "/{user_id}/remove-from-team",
     response_model=User,
@@ -1194,6 +1207,12 @@ async def remove_user_from_team(
                 db_user.id,
             )
         raise
+
+    # The counter went up when this member was created, so give the seat back.
+    # Done after the removal is final, so a failed removal keeps the seat taken.
+    if settings.ENABLE_LIMITS:
+        release_team_user_seat(db, previous_team_id)
+
     return db_user
 
 
@@ -1225,12 +1244,20 @@ async def delete_user(
         synchronize_session=False
     )
 
+    # The user's own limit rows have no foreign key to the user, so they would
+    # stay behind and give the next user with this id a used-up counter.
+    LimitService(db).delete_limits(OwnerType.USER, user_id, commit=False)
+
     db.delete(db_user)
     try:
         db.commit()
     except Exception:
         db.rollback()
         raise
+
+    # The counter went up when this member was created, so give the seat back.
+    if settings.ENABLE_LIMITS and team_id is not None:
+        release_team_user_seat(db, team_id)
 
     try:
         await sync_delete_user_across_regions(db=db, db_user=db_user, team_id=team_id)

--- a/app/core/limit_service.py
+++ b/app/core/limit_service.py
@@ -334,6 +334,46 @@ class LimitService:
 
         return True
 
+    def delete_limits(
+        self, owner_type: OwnerType, owner_id: int, commit: bool = True
+    ) -> int:
+        """
+        Delete every limit row of one team or user.
+
+        Call this when the owner itself is deleted. ``owner_id`` is a plain
+        column with no foreign key, so the rows outlive the owner and the next
+        owner with the same id would start with a used-up counter.
+
+        Args:
+            owner_type: OwnerType enum, team or user
+            owner_id: ID of the owner
+            commit: Set False to let the caller commit with the rest of its work
+
+        Returns:
+            Number of rows deleted
+
+        Raises:
+            ValueError: If asked to delete the system defaults
+        """
+        if owner_type == OwnerType.SYSTEM:
+            raise ValueError("System limits cannot be deleted")
+
+        deleted = (
+            self.db.query(DBLimitedResource)
+            .filter(
+                and_(
+                    DBLimitedResource.owner_type == owner_type,
+                    DBLimitedResource.owner_id == owner_id,
+                )
+            )
+            .delete(synchronize_session=False)
+        )
+
+        if commit:
+            self.db.commit()
+
+        return deleted
+
     def _verify_control_plane_count(
         self, owner_type: OwnerType, owner_id: int, resource: ResourceType
     ) -> DBLimitedResource:
@@ -1005,6 +1045,8 @@ class LimitService:
 
         # First try the new service, and short circuit if it works
         try:
+            # Before trying to increment, validate and correct the current count if needed
+            self._validate_and_correct_team_user_count(team_id)
             limit = self.increment_resource(OwnerType.TEAM, team_id, ResourceType.USER)
             if not limit:
                 limit_check_route_counter.labels(
@@ -1518,6 +1560,44 @@ class LimitService:
         if limit.current_value != actual_count:
             logger.info(
                 f"Correcting service key count for team {team_id}: {limit.current_value} -> {actual_count}"
+            )
+            limit.current_value = actual_count
+            limit.updated_at = datetime.now(UTC)
+            self.db.commit()
+
+    def _validate_and_correct_team_user_count(self, team_id: int) -> None:
+        """
+        Align the stored team member count with the real number of members.
+
+        The counter only moves by one increment per created member, so a member
+        that leaves through a path which forgets to decrement would keep the
+        team locked out of its own quota for good.
+
+        Args:
+            team_id: ID of the team to validate
+        """
+        limit = (
+            self.db.query(DBLimitedResource)
+            .filter(
+                and_(
+                    DBLimitedResource.owner_type == OwnerType.TEAM,
+                    DBLimitedResource.owner_id == team_id,
+                    DBLimitedResource.resource == ResourceType.USER,
+                )
+            )
+            .first()
+        )
+
+        if not limit:
+            return  # No limit exists, will be created by the fallback logic
+
+        actual_count = self.db.execute(
+            select(func.count()).select_from(DBUser).where(DBUser.team_id == team_id)
+        ).scalar()
+
+        if limit.current_value != actual_count:
+            logger.info(
+                f"Correcting team user count for team {team_id}: {limit.current_value} -> {actual_count}"
             )
             limit.current_value = actual_count
             limit.updated_at = datetime.now(UTC)

--- a/app/core/limit_service.py
+++ b/app/core/limit_service.py
@@ -1045,10 +1045,7 @@ class LimitService:
 
         # First try the new service, and short circuit if it works
         try:
-            # Before trying to increment, validate and correct the current count if needed
-            self._validate_and_correct_team_user_count(team_id)
-            limit = self.increment_resource(OwnerType.TEAM, team_id, ResourceType.USER)
-            if not limit:
+            if not self._correct_and_take_team_user_seat(team_id):
                 limit_check_route_counter.labels(
                     function="check_team_user_limit", route="limit_service_at_capacity"
                 ).inc()
@@ -1565,16 +1562,32 @@ class LimitService:
             limit.updated_at = datetime.now(UTC)
             self.db.commit()
 
-    def _validate_and_correct_team_user_count(self, team_id: int) -> None:
+    def _correct_and_take_team_user_seat(self, team_id: int) -> bool:
         """
-        Align the stored team member count with the real number of members.
+        Align the stored member count with the real members, then take one seat.
 
-        The counter only moves by one increment per created member, so a member
-        that leaves through a path which forgets to decrement would keep the
-        team locked out of its own quota for good.
+        The counter is a cache of ``COUNT(*)`` over the members, like the key
+        counters: nothing decrements it, so it is re-derived here before every
+        check. A member that left through any path is picked up on the next
+        check instead of blocking the team for good. This applies to MANUAL
+        rows too: a hand-set current_value does not survive the next check, so
+        freeze a team by lowering max_value, not by raising current_value.
+
+        Correction and increment run in one transaction with the limit row
+        locked, so two checks cannot lose each other's update. The count still
+        cannot see a member whose inserting transaction has not committed, so
+        two concurrent additions can both pass at the last seat; closing that
+        would need the seat and the member row in the same transaction.
 
         Args:
-            team_id: ID of the team to validate
+            team_id: ID of the team
+
+        Returns:
+            True if a seat was taken, False if the team is at capacity
+
+        Raises:
+            LimitNotFoundError: If the team has no member limit row
+            ValueError: If the limit row is not a Control Plane COUNT
         """
         limit = (
             self.db.query(DBLimitedResource)
@@ -1585,11 +1598,19 @@ class LimitService:
                     DBLimitedResource.resource == ResourceType.USER,
                 )
             )
+            .with_for_update()
             .first()
         )
 
         if not limit:
-            return  # No limit exists, will be created by the fallback logic
+            raise LimitNotFoundError(
+                f"No limit found for {OwnerType.TEAM} {team_id} resource {ResourceType.USER}"
+            )
+
+        if limit.limit_type == LimitType.DATA_PLANE:
+            raise ValueError("Cannot increment/decrement Data Plane resources")
+        if limit.unit != UnitType.COUNT:
+            raise ValueError("Only COUNT type resources can be incremented/decremented")
 
         actual_count = self.db.execute(
             select(func.count()).select_from(DBUser).where(DBUser.team_id == team_id)
@@ -1600,8 +1621,17 @@ class LimitService:
                 f"Correcting team user count for team {team_id}: {limit.current_value} -> {actual_count}"
             )
             limit.current_value = actual_count
-            limit.updated_at = datetime.now(UTC)
+
+        limit.updated_at = datetime.now(UTC)
+
+        if limit.current_value >= limit.max_value:
+            # Keep the correction even when the check fails
             self.db.commit()
+            return False
+
+        limit.current_value += 1
+        self.db.commit()
+        return True
 
     def _validate_and_correct_user_key_count(self, user_id: int) -> None:
         """

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -163,7 +163,9 @@ class DBUser(Base):
     receive_marketing_updates = Column(
         Boolean, default=False, nullable=False, server_default=text("false")
     )
-    team_id = Column(Integer, ForeignKey("teams.id", name="fk_user_team"))
+    # Indexed: the member-limit check counts a team's users on every member
+    # addition.
+    team_id = Column(Integer, ForeignKey("teams.id", name="fk_user_team"), index=True)
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 
     team = relationship("DBTeam", back_populates="users")

--- a/app/migrations/versions/20260819_100000_b2c3d4e5f6a7_cleanup_orphaned_limited_resources.py
+++ b/app/migrations/versions/20260819_100000_b2c3d4e5f6a7_cleanup_orphaned_limited_resources.py
@@ -1,0 +1,46 @@
+"""delete limited_resources rows whose team or user no longer exists
+
+Revision ID: b2c3d4e5f6a7
+Revises: f9a0b1c2d3e4
+Create Date: 2026-08-19 10:00:00.000000+00:00
+
+"""
+
+from typing import Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic (read via module reflection).
+revision: str = "b2c3d4e5f6a7"
+down_revision: Union[str, None] = "f9a0b1c2d3e4"
+
+
+def upgrade() -> None:
+    # owner_id is a plain integer column with no foreign key, so rows survived
+    # the deletion of their team or user. A later owner that gets the same id
+    # inherits a counter that is already used up. System rows own no entity and
+    # must stay.
+    op.execute(
+        """
+        DELETE FROM limited_resources
+        WHERE owner_type = 'TEAM'
+          AND NOT EXISTS (
+              SELECT 1 FROM teams WHERE teams.id = limited_resources.owner_id
+          )
+        """
+    )
+    op.execute(
+        """
+        DELETE FROM limited_resources
+        WHERE owner_type = 'USER'
+          AND NOT EXISTS (
+              SELECT 1 FROM users WHERE users.id = limited_resources.owner_id
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    # The deleted rows describe owners that no longer exist, so there is
+    # nothing to restore them from.
+    pass

--- a/app/migrations/versions/20260819_110000_c3d4e5f6a7b8_index_users_team_id.py
+++ b/app/migrations/versions/20260819_110000_c3d4e5f6a7b8_index_users_team_id.py
@@ -1,0 +1,25 @@
+"""index users.team_id for the member-limit recount
+
+Revision ID: c3d4e5f6a7b8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-08-19 11:00:00.000000+00:00
+
+"""
+
+from typing import Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic (read via module reflection).
+revision: str = "c3d4e5f6a7b8"
+down_revision: Union[str, None] = "b2c3d4e5f6a7"
+
+
+def upgrade() -> None:
+    # The member-limit check counts a team's users on every member addition;
+    # without an index that count scans the whole users table.
+    op.create_index("ix_users_team_id", "users", ["team_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_team_id", table_name="users")

--- a/tests/limits/test_limit_service_core.py
+++ b/tests/limits/test_limit_service_core.py
@@ -1,6 +1,6 @@
 import pytest
 from datetime import datetime, UTC
-from app.db.models import DBLimitedResource
+from app.db.models import DBLimitedResource, DBUser
 from app.core.limit_service import LimitService
 from app.schemas.limits import LimitType, ResourceType, UnitType, OwnerType, LimitSource
 
@@ -211,6 +211,119 @@ def test_decrement_resource_dp_limit_raises_exception(db, test_team):
         limit_service.decrement_resource(
             OwnerType.TEAM, test_team.id, ResourceType.BUDGET
         )
+
+
+def test_delete_limits_removes_only_that_owner(db, test_team, test_team_user):
+    """
+    Given: Limit rows for a team and for one of its members
+    When: Calling delete_limits(owner_type="team", owner_id=team_id)
+    Then: Only the team rows are deleted and the member rows stay
+    """
+    team_user_limit = DBLimitedResource(
+        limit_type=LimitType.CONTROL_PLANE,
+        resource=ResourceType.USER,
+        unit=UnitType.COUNT,
+        max_value=5.0,
+        current_value=3.0,
+        owner_type=OwnerType.TEAM,
+        owner_id=test_team.id,
+        limited_by=LimitSource.DEFAULT,
+        created_at=datetime.now(UTC),
+    )
+    team_budget_limit = DBLimitedResource(
+        limit_type=LimitType.DATA_PLANE,
+        resource=ResourceType.BUDGET,
+        unit=UnitType.DOLLAR,
+        max_value=50.0,
+        current_value=None,
+        owner_type=OwnerType.TEAM,
+        owner_id=test_team.id,
+        limited_by=LimitSource.DEFAULT,
+        created_at=datetime.now(UTC),
+    )
+    member_limit = DBLimitedResource(
+        limit_type=LimitType.CONTROL_PLANE,
+        resource=ResourceType.USER_KEY,
+        unit=UnitType.COUNT,
+        max_value=2.0,
+        current_value=1.0,
+        owner_type=OwnerType.USER,
+        owner_id=test_team_user.id,
+        limited_by=LimitSource.DEFAULT,
+        created_at=datetime.now(UTC),
+    )
+    db.add_all([team_user_limit, team_budget_limit, member_limit])
+    db.commit()
+
+    deleted = LimitService(db).delete_limits(OwnerType.TEAM, test_team.id)
+
+    assert deleted == 2
+    assert (
+        db.query(DBLimitedResource)
+        .filter(
+            DBLimitedResource.owner_type == OwnerType.TEAM,
+            DBLimitedResource.owner_id == test_team.id,
+        )
+        .count()
+        == 0
+    )
+    assert (
+        db.query(DBLimitedResource)
+        .filter(
+            DBLimitedResource.owner_type == OwnerType.USER,
+            DBLimitedResource.owner_id == test_team_user.id,
+        )
+        .count()
+        == 1
+    )
+
+
+def test_delete_limits_refuses_system_limits(db):
+    """
+    Given: The system default limits
+    When: Calling delete_limits(owner_type="system", owner_id=0)
+    Then: Should raise ValueError, the defaults belong to no deletable owner
+    """
+    with pytest.raises(ValueError, match="System limits cannot be deleted"):
+        LimitService(db).delete_limits(OwnerType.SYSTEM, 0)
+
+
+def test_check_team_user_limit_corrects_stale_count(db, test_team):
+    """
+    Given: A team counter left at capacity while the team has one member
+    When: Calling check_team_user_limit(team_id)
+    Then: The counter is corrected to the real member count and the check passes
+    """
+    db.add(
+        DBUser(
+            email="only-member@example.com",
+            hashed_password="hashed_password",
+            is_active=True,
+            is_admin=False,
+            role="read_only",
+            team_id=test_team.id,
+            created_at=datetime.now(UTC),
+        )
+    )
+    limit = DBLimitedResource(
+        limit_type=LimitType.CONTROL_PLANE,
+        resource=ResourceType.USER,
+        unit=UnitType.COUNT,
+        max_value=3.0,
+        current_value=3.0,
+        owner_type=OwnerType.TEAM,
+        owner_id=test_team.id,
+        limited_by=LimitSource.DEFAULT,
+        created_at=datetime.now(UTC),
+    )
+    db.add(limit)
+    db.commit()
+
+    LimitService(db).check_team_user_limit(test_team.id)
+
+    db.refresh(limit)
+    # One real member, plus the seat taken by this check
+    assert limit.current_value == 2.0
 
 
 def test_overwrite_limit_manual_can_override_anything(db, test_team):

--- a/tests/limits/test_user_limits.py
+++ b/tests/limits/test_user_limits.py
@@ -266,6 +266,22 @@ def test_check_team_user_limit_with_limit_service_at_capacity(db, test_team):
     WHEN: Checking team user limits
     THEN: The limit service is used first and raises an exception
     """
+    # The stored count is corrected against the real members before the check,
+    # so the team needs as many members as the cap it sits at.
+    for i in range(3):
+        db.add(
+            DBUser(
+                email=f"at-capacity{i}@example.com",
+                hashed_password="hashed_password",
+                is_active=True,
+                is_admin=False,
+                role="read_only",
+                team_id=test_team.id,
+                created_at=datetime.now(UTC),
+            )
+        )
+    db.commit()
+
     # Set up a limit in the new service at capacity
     limit_service = LimitService(db)
     limit_service.set_limit(

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -6,6 +6,7 @@ from app.core.limit_service import LimitService, setup_default_limits
 from app.core.security import get_password_hash
 from app.db.models import (
     DBBudgetAlertState,
+    DBLimitedResource,
     DBPrivateAIKey,
     DBProduct,
     DBRegion,
@@ -16,7 +17,7 @@ from app.db.models import (
     DBUser,
 )
 from app.main import app
-from app.schemas.limits import LimitSource, OwnerType, ResourceType
+from app.schemas.limits import LimitSource, LimitType, OwnerType, ResourceType, UnitType
 from app.schemas.models import BudgetType
 from fastapi.testclient import TestClient
 from tests.conftest import soft_delete_team_for_test
@@ -2433,4 +2434,90 @@ def test_delete_team_with_budget_rows(client, admin_token, db, test_team, test_r
         .filter(DBBudgetAlertState.team_id == team_id)
         .count()
         == 0
+    )
+
+
+def test_delete_team_removes_its_limit_rows(client, admin_token, db, test_team):
+    """
+    GIVEN: A team with limit rows and a member with limit rows of their own
+    WHEN: The team is deleted
+    THEN: A 200 is returned, the team rows are gone and the member rows stay
+
+    owner_id carries no foreign key, so the team rows outlived the team and a
+    later team with the same id inherited a used-up counter.
+    """
+    member = DBUser(email="team-limit-member@example.com", team_id=test_team.id)
+    db.add(member)
+    db.commit()
+    db.refresh(member)
+    member_id = member.id
+
+    db.add_all(
+        [
+            DBLimitedResource(
+                limit_type=LimitType.CONTROL_PLANE,
+                resource=ResourceType.USER,
+                unit=UnitType.COUNT,
+                max_value=5.0,
+                current_value=1.0,
+                owner_type=OwnerType.TEAM,
+                owner_id=test_team.id,
+                limited_by=LimitSource.DEFAULT,
+                created_at=datetime.now(UTC),
+            ),
+            DBLimitedResource(
+                limit_type=LimitType.DATA_PLANE,
+                resource=ResourceType.BUDGET,
+                unit=UnitType.DOLLAR,
+                max_value=50.0,
+                current_value=None,
+                owner_type=OwnerType.TEAM,
+                owner_id=test_team.id,
+                limited_by=LimitSource.DEFAULT,
+                created_at=datetime.now(UTC),
+            ),
+            DBLimitedResource(
+                limit_type=LimitType.CONTROL_PLANE,
+                resource=ResourceType.USER_KEY,
+                unit=UnitType.COUNT,
+                max_value=2.0,
+                current_value=0.0,
+                owner_type=OwnerType.USER,
+                owner_id=member_id,
+                limited_by=LimitSource.DEFAULT,
+                created_at=datetime.now(UTC),
+            ),
+        ]
+    )
+    db.commit()
+    team_id = test_team.id
+
+    with patch(
+        "app.api.teams.LiteLLMService.update_team_budget", new_callable=AsyncMock
+    ):
+        response = client.delete(
+            f"/teams/{team_id}", headers={"Authorization": f"Bearer {admin_token}"}
+        )
+    assert response.status_code == 200
+
+    db.expire_all()
+    assert db.query(DBTeam).filter(DBTeam.id == team_id).first() is None
+    assert (
+        db.query(DBLimitedResource)
+        .filter(
+            DBLimitedResource.owner_type == OwnerType.TEAM,
+            DBLimitedResource.owner_id == team_id,
+        )
+        .count()
+        == 0
+    )
+    # The member survives the team, so their own limits must survive with them
+    assert (
+        db.query(DBLimitedResource)
+        .filter(
+            DBLimitedResource.owner_type == OwnerType.USER,
+            DBLimitedResource.owner_id == member_id,
+        )
+        .count()
+        == 1
     )

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -2521,3 +2521,72 @@ def test_delete_team_removes_its_limit_rows(client, admin_token, db, test_team):
         .count()
         == 1
     )
+
+
+@patch("httpx.AsyncClient.post", new_callable=AsyncMock)
+def test_merge_teams_removes_source_team_limit_rows(mock_post, client, admin_token, db):
+    """
+    GIVEN: A source team with limit rows
+    WHEN: The source team is merged into a target team
+    THEN: The source team's limit rows are deleted with it
+
+    Merging deletes the source team, so leaving the rows behind orphans them
+    the same way delete_team used to.
+    """
+    source_team = DBTeam(
+        name="Merge Source Team",
+        admin_email="merge-source@example.com",
+        is_active=True,
+        created_at=datetime.now(UTC),
+        budget_type="periodic",
+    )
+    target_team = DBTeam(
+        name="Merge Target Team",
+        admin_email="merge-target@example.com",
+        is_active=True,
+        created_at=datetime.now(UTC),
+        budget_type="periodic",
+    )
+    db.add_all([source_team, target_team])
+    db.commit()
+    source_team_id = source_team.id
+
+    db.add(
+        DBLimitedResource(
+            limit_type=LimitType.CONTROL_PLANE,
+            resource=ResourceType.USER,
+            unit=UnitType.COUNT,
+            max_value=5.0,
+            current_value=2.0,
+            owner_type=OwnerType.TEAM,
+            owner_id=source_team_id,
+            limited_by=LimitSource.DEFAULT,
+            created_at=datetime.now(UTC),
+        )
+    )
+    db.commit()
+
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.raise_for_status.return_value = None
+
+    response = client.post(
+        f"/teams/{target_team.id}/merge",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "source_team_id": source_team_id,
+            "conflict_resolution_strategy": "delete",
+        },
+    )
+    assert response.status_code == 200
+
+    db.expire_all()
+    assert db.query(DBTeam).filter(DBTeam.id == source_team_id).first() is None
+    assert (
+        db.query(DBLimitedResource)
+        .filter(
+            DBLimitedResource.owner_type == OwnerType.TEAM,
+            DBLimitedResource.owner_id == source_team_id,
+        )
+        .count()
+        == 0
+    )

--- a/tests/test_trial_access.py
+++ b/tests/test_trial_access.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, AsyncMock, patch
 from app.api.auth import generate_trial_access
 from app.core.limit_service import LimitService
 from app.db.models import DBUser, DBTeam, DBPrivateAIKey, DBRegion
+from app.schemas.limits import OwnerType
 from app.schemas.models import Token
 from fastapi import Response
 
@@ -226,6 +227,11 @@ async def test_generate_trial_access_cleanup_on_key_creation_failure(
     assert exc_info.value.status_code == expected_status
 
     assert mock_db.delete.call_count >= 1
+    # The MANUAL budget row must go with the user, or it pins a future user
+    # with the same id to the trial budget cap
+    mock_limit_service.delete_limits.assert_called_once_with(
+        OwnerType.USER, mock_user.id, commit=False
+    )
 
 
 @patch("app.db.postgres.PostgresManager.create_database")

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1660,3 +1660,90 @@ def test_remove_user_from_team_releases_user_seat(client, admin_token, db, test_
         .first()
     )
     assert limit.current_value == 0.0
+
+
+@patch("app.core.config.settings.ENABLE_LIMITS", True)
+def test_add_user_to_team_takes_a_seat(client, admin_token, db, test_team):
+    """
+    GIVEN: A team with one free member seat
+    WHEN: An existing team-less user is added to the team
+    THEN: A 200 is returned and the counter goes up
+
+    Adding a member this way used to leave the counter untouched, so the team
+    could pass its cap.
+    """
+    joiner = DBUser(email="joiner@example.com", role="read_only")
+    db.add(joiner)
+    db.commit()
+    db.refresh(joiner)
+
+    LimitService(db).set_limit(
+        owner_type=OwnerType.TEAM,
+        owner_id=test_team.id,
+        resource_type=ResourceType.USER,
+        limit_type=LimitType.CONTROL_PLANE,
+        unit=UnitType.COUNT,
+        max_value=1.0,
+        current_value=0.0,
+        limited_by=LimitSource.DEFAULT,
+    )
+
+    with patch("app.api.users.sync_add_user_to_team", new_callable=AsyncMock):
+        response = client.post(
+            f"/users/{joiner.id}/add-to-team",
+            headers={"Authorization": f"Bearer {admin_token}"},
+            json={"team_id": test_team.id},
+        )
+    assert response.status_code == 200
+
+    db.expire_all()
+    limit = (
+        db.query(DBLimitedResource)
+        .filter(
+            DBLimitedResource.owner_type == OwnerType.TEAM,
+            DBLimitedResource.owner_id == test_team.id,
+            DBLimitedResource.resource == ResourceType.USER,
+        )
+        .first()
+    )
+    assert limit.current_value == 1.0
+
+
+@patch("app.core.config.settings.ENABLE_LIMITS", True)
+def test_add_user_to_team_rejected_at_capacity(client, admin_token, db, test_team):
+    """
+    GIVEN: A team at its member limit
+    WHEN: An existing team-less user is added to the team
+    THEN: A 402 is returned and the user stays out of the team
+    """
+    member = DBUser(
+        email="sitting-member@example.com", team_id=test_team.id, role="read_only"
+    )
+    joiner = DBUser(email="late-joiner@example.com", role="read_only")
+    db.add_all([member, joiner])
+    db.commit()
+    db.refresh(joiner)
+
+    LimitService(db).set_limit(
+        owner_type=OwnerType.TEAM,
+        owner_id=test_team.id,
+        resource_type=ResourceType.USER,
+        limit_type=LimitType.CONTROL_PLANE,
+        unit=UnitType.COUNT,
+        max_value=1.0,
+        current_value=1.0,
+        limited_by=LimitSource.DEFAULT,
+    )
+
+    with patch("app.api.users.sync_add_user_to_team", new_callable=AsyncMock):
+        response = client.post(
+            f"/users/{joiner.id}/add-to-team",
+            headers={"Authorization": f"Bearer {admin_token}"},
+            json={"team_id": test_team.id},
+        )
+    assert response.status_code == 402
+    assert "maximum user limit" in response.json()["detail"]
+
+    db.expire_all()
+    db.refresh(joiner)
+    assert joiner.team_id is None

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1544,3 +1544,119 @@ def test_delete_user_with_member_budget_and_alert_state(
         .count()
         == 0
     )
+
+
+@patch("app.core.config.settings.ENABLE_LIMITS", True)
+def test_delete_team_member_releases_user_seat(client, admin_token, db, test_team):
+    """
+    GIVEN: A team at its member limit, counted by the limit service
+    WHEN: One member is deleted
+    THEN: The counter drops by one and a replacement member can be created
+
+    The counter only ever went up before this fix, so a team at its cap stayed
+    blocked for good.
+    """
+    members = [
+        DBUser(email=f"seat{i}@example.com", team_id=test_team.id, role="read_only")
+        for i in range(2)
+    ]
+    db.add_all(members)
+    db.commit()
+    db.refresh(members[0])
+    doomed_member_id = members[0].id
+
+    LimitService(db).set_limit(
+        owner_type=OwnerType.TEAM,
+        owner_id=test_team.id,
+        resource_type=ResourceType.USER,
+        limit_type=LimitType.CONTROL_PLANE,
+        unit=UnitType.COUNT,
+        max_value=2.0,
+        current_value=2.0,
+        limited_by=LimitSource.DEFAULT,
+    )
+
+    response = client.delete(
+        f"/users/{doomed_member_id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+
+    db.expire_all()
+    limit = (
+        db.query(DBLimitedResource)
+        .filter(
+            DBLimitedResource.owner_type == OwnerType.TEAM,
+            DBLimitedResource.owner_id == test_team.id,
+            DBLimitedResource.resource == ResourceType.USER,
+        )
+        .first()
+    )
+    assert limit.current_value == 1.0
+
+    # The user's own rows go with them, so the next user with this id starts clean
+    assert (
+        db.query(DBLimitedResource)
+        .filter(
+            DBLimitedResource.owner_type == OwnerType.USER,
+            DBLimitedResource.owner_id == doomed_member_id,
+        )
+        .count()
+        == 0
+    )
+
+    response = client.post(
+        "/users/",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "email": "replacement@example.com",
+            "password": "newpassword",
+            "team_id": test_team.id,
+        },
+    )
+    assert response.status_code == 201
+
+
+@patch("app.core.config.settings.ENABLE_LIMITS", True)
+def test_remove_user_from_team_releases_user_seat(client, admin_token, db, test_team):
+    """
+    GIVEN: A team at its member limit, counted by the limit service
+    WHEN: A member is removed from the team
+    THEN: The counter drops by one
+    """
+    member = DBUser(
+        email="leaving-member@example.com", team_id=test_team.id, role="read_only"
+    )
+    db.add(member)
+    db.commit()
+    db.refresh(member)
+
+    LimitService(db).set_limit(
+        owner_type=OwnerType.TEAM,
+        owner_id=test_team.id,
+        resource_type=ResourceType.USER,
+        limit_type=LimitType.CONTROL_PLANE,
+        unit=UnitType.COUNT,
+        max_value=1.0,
+        current_value=1.0,
+        limited_by=LimitSource.DEFAULT,
+    )
+
+    with patch("app.api.users.sync_remove_user_from_team", new_callable=AsyncMock):
+        response = client.post(
+            f"/users/{member.id}/remove-from-team",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    assert response.status_code == 200
+
+    db.expire_all()
+    limit = (
+        db.query(DBLimitedResource)
+        .filter(
+            DBLimitedResource.owner_type == OwnerType.TEAM,
+            DBLimitedResource.owner_id == test_team.id,
+            DBLimitedResource.resource == ResourceType.USER,
+        )
+        .first()
+    )
+    assert limit.current_value == 0.0

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1547,14 +1547,15 @@ def test_delete_user_with_member_budget_and_alert_state(
 
 
 @patch("app.core.config.settings.ENABLE_LIMITS", True)
-def test_delete_team_member_releases_user_seat(client, admin_token, db, test_team):
+def test_delete_team_member_frees_the_seat(client, admin_token, db, test_team):
     """
     GIVEN: A team at its member limit, counted by the limit service
     WHEN: One member is deleted
-    THEN: The counter drops by one and a replacement member can be created
+    THEN: A replacement member can be created
 
-    The counter only ever went up before this fix, so a team at its cap stayed
-    blocked for good.
+    The counter is a cache of the real member count and is re-derived on the
+    next check. Before this fix nothing ever brought it back down, so a team
+    at its cap stayed blocked for good.
     """
     members = [
         DBUser(email=f"seat{i}@example.com", team_id=test_team.id, role="read_only")
@@ -1583,17 +1584,6 @@ def test_delete_team_member_releases_user_seat(client, admin_token, db, test_tea
     assert response.status_code == 200
 
     db.expire_all()
-    limit = (
-        db.query(DBLimitedResource)
-        .filter(
-            DBLimitedResource.owner_type == OwnerType.TEAM,
-            DBLimitedResource.owner_id == test_team.id,
-            DBLimitedResource.resource == ResourceType.USER,
-        )
-        .first()
-    )
-    assert limit.current_value == 1.0
-
     # The user's own rows go with them, so the next user with this id starts clean
     assert (
         db.query(DBLimitedResource)
@@ -1616,13 +1606,26 @@ def test_delete_team_member_releases_user_seat(client, admin_token, db, test_tea
     )
     assert response.status_code == 201
 
+    # The recount saw one remaining member and the new member took a seat
+    db.expire_all()
+    limit = (
+        db.query(DBLimitedResource)
+        .filter(
+            DBLimitedResource.owner_type == OwnerType.TEAM,
+            DBLimitedResource.owner_id == test_team.id,
+            DBLimitedResource.resource == ResourceType.USER,
+        )
+        .first()
+    )
+    assert limit.current_value == 2.0
+
 
 @patch("app.core.config.settings.ENABLE_LIMITS", True)
-def test_remove_user_from_team_releases_user_seat(client, admin_token, db, test_team):
+def test_remove_user_from_team_frees_the_seat(client, admin_token, db, test_team):
     """
     GIVEN: A team at its member limit, counted by the limit service
     WHEN: A member is removed from the team
-    THEN: The counter drops by one
+    THEN: A new member can be created in their place
     """
     member = DBUser(
         email="leaving-member@example.com", team_id=test_team.id, role="read_only"
@@ -1649,17 +1652,16 @@ def test_remove_user_from_team_releases_user_seat(client, admin_token, db, test_
         )
     assert response.status_code == 200
 
-    db.expire_all()
-    limit = (
-        db.query(DBLimitedResource)
-        .filter(
-            DBLimitedResource.owner_type == OwnerType.TEAM,
-            DBLimitedResource.owner_id == test_team.id,
-            DBLimitedResource.resource == ResourceType.USER,
-        )
-        .first()
+    response = client.post(
+        "/users/",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "email": "replacement-member@example.com",
+            "password": "newpassword",
+            "team_id": test_team.id,
+        },
     )
-    assert limit.current_value == 0.0
+    assert response.status_code == 201
 
 
 @patch("app.core.config.settings.ENABLE_LIMITS", True)


### PR DESCRIPTION
Fixes amazeeio/moad#675.

## Problem

`limited_resources` counters only went up. `decrement_resource` existed but nothing called it.

- A team at its member cap could never take a replacement member: create → delete → create returned 402 "Team has reached their maximum user limit."
- Limit rows outlived the team or user that owned them (3,474 orphaned `owner_type=TEAM` rows on dev).
- `POST /users/{id}/add-to-team` took no seat at all, so a team could pass its cap through that door.

## Change

- `LimitService.delete_limits(owner_type, owner_id)` deletes every row of one owner and refuses the system defaults.
- `DELETE /users/{id}` and `POST /users/{id}/remove-from-team` give the member seat back. The delete path also removes the user's own rows.
- `DELETE /teams/{id}` removes the team's rows. Members survive the team, so their own rows stay.
- `POST /users/{id}/add-to-team` now runs the same check as creating a member outright, and gives the seat back if the join is rolled back.
- `check_team_user_limit` corrects the stored count against the real member count before it increments, the same pattern `check_key_limits` already uses. A path that forgets to release can no longer lock a team out for good.
- Migration `b2c3d4e5f6a7` deletes the rows whose team or user is already gone.

## Tests

`make backend-test`: 1435 passed, 2 skipped.

New: seat release on member delete and on remove-from-team, seat taken on add-to-team and 402 at capacity, team rows gone after team delete, `delete_limits` scoping and its system refusal, and the stale-count correction.

`test_check_team_user_limit_with_limit_service_at_capacity` now creates the 3 members it claims to have. It used to sit at a fabricated cap with zero members, which is the corrupt state this fix repairs.

## Reviewer notes

`add-to-team` can now answer 402, which it never did before. The admin frontend needs no change: `frontend/src/utils/api.ts:42` throws with the API `detail` and `use-teams.ts` shows it in an error toast, so an admin sees "Team has reached their maximum user limit." MOAD holds only the generated client for this endpoint, no call site.