### PR TITLE
feat(worker): expire the region key snapshot after a TTL

### DIFF
--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import time
 from datetime import UTC, datetime, timedelta
 from functools import partial
 from sqlalchemy.orm import Session
@@ -129,6 +130,12 @@ region_key_snapshot_keys = Gauge(
     ["region_name"],
 )
 
+region_key_snapshot_refresh_total = Counter(
+    "region_key_snapshot_refresh_total",
+    "Total number of bulk /key/list snapshots re-listed because they aged past the TTL",
+    ["region_name"],
+)
+
 key_state_fallback_total = Counter(
     "key_state_fallback_total",
     "Total number of keys that fell back to a per-key /key/info lookup",
@@ -150,6 +157,13 @@ KEY_WRITE_CONCURRENCY = max(1, int(os.getenv("KEY_WRITE_CONCURRENCY", "10")))
 # the region has been read; when the bulk snapshot is unavailable each read
 # costs a round-trip, so that wait grows with the region's key count.
 KEY_WRITE_BATCH = max(1, int(os.getenv("KEY_WRITE_BATCH", "500")))
+
+# How long a region's bulk key snapshot stays usable. Spend is read as of the
+# snapshot, so this caps how stale that read can be no matter how long the run
+# takes. Set to 0 to re-list on every team.
+REGION_SNAPSHOT_TTL_SECONDS = max(
+    0.0, float(os.getenv("REGION_SNAPSHOT_TTL_SECONDS", "600"))
+)
 
 # Retention metrics
 team_retention_warning_sent_total = Counter(
@@ -1794,25 +1808,51 @@ async def apply_product_for_team(
 
 
 class RegionKeyStateCache:
-    """Per-run cache of bulk ``/key/list`` snapshots, keyed by region id.
+    """Cache of bulk ``/key/list`` snapshots, keyed by region id.
 
     ``monitor_teams`` reconciles ~1.1k teams that share a handful of regions, so
-    the snapshot must be fetched once per region per run and reused across every
-    team in it. Fetching per team would re-paginate the same region up to 1.1k
-    times and be far worse than the per-key loop it replaces.
+    the snapshot must be fetched once per region and reused across every team in
+    it. Fetching per team would re-paginate the same region up to 1.1k times and
+    be far worse than the per-key loop it replaces.
 
-    A failed snapshot is cached as an empty mapping so one broken region is
-    retried once per run, not once per team.
+    Spend is read as of the snapshot, so a region is re-listed once its snapshot
+    is older than ``ttl_seconds``. That bounds staleness by wall-clock time
+    instead of by however long the run happens to take.
+
+    A failed snapshot is cached as an empty mapping, so a broken region falls
+    back to per-key lookups and is retried once per TTL window, not once per
+    team.
     """
 
-    def __init__(self) -> None:
-        self._snapshots: Dict[int, Dict[str, dict]] = {}
+    def __init__(
+        self,
+        ttl_seconds: Optional[float] = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        # (taken_at, snapshot) per region.
+        self._snapshots: Dict[int, tuple[float, Dict[str, dict]]] = {}
+        self._ttl_seconds = (
+            REGION_SNAPSHOT_TTL_SECONDS
+            if ttl_seconds is None
+            else max(0.0, ttl_seconds)
+        )
+        self._clock = clock
 
     async def get(
         self, region: DBRegion, litellm_service: LiteLLMService
     ) -> Dict[str, dict]:
-        if region.id in self._snapshots:
-            return self._snapshots[region.id]
+        now = self._clock()
+        cached = self._snapshots.get(region.id)
+        if cached is not None:
+            taken_at, snapshot = cached
+            if now - taken_at < self._ttl_seconds:
+                return snapshot
+            region_key_snapshot_refresh_total.labels(region_name=region.name).inc()
+            logger.info(
+                "Bulk key snapshot for region %s is older than %.0fs, re-listing",
+                region.name,
+                self._ttl_seconds,
+            )
 
         snapshot: Dict[str, dict] = {}
         try:
@@ -1838,7 +1878,9 @@ class RegionKeyStateCache:
             )
             snapshot = {}
 
-        self._snapshots[region.id] = snapshot
+        # Stamp after the call, not before: a slow listing must not spend its
+        # own duration out of the TTL it is about to start.
+        self._snapshots[region.id] = (self._clock(), snapshot)
         return snapshot
 
 

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -1847,12 +1847,15 @@ class RegionKeyStateCache:
             taken_at, snapshot = cached
             if now - taken_at < self._ttl_seconds:
                 return snapshot
-            region_key_snapshot_refresh_total.labels(region_name=region.name).inc()
-            logger.info(
-                "Bulk key snapshot for region %s is older than %.0fs, re-listing",
-                region.name,
-                self._ttl_seconds,
-            )
+            # TTL 0 means caching is off: every get re-lists by design, so it
+            # is not a refresh event worth a counter tick or a log line each.
+            if self._ttl_seconds > 0:
+                region_key_snapshot_refresh_total.labels(region_name=region.name).inc()
+                logger.info(
+                    "Bulk key snapshot for region %s is older than %.0fs, re-listing",
+                    region.name,
+                    self._ttl_seconds,
+                )
 
         snapshot: Dict[str, dict] = {}
         try:
@@ -1877,6 +1880,9 @@ class RegionKeyStateCache:
                 str(e),
             )
             snapshot = {}
+            # The gauge must not keep the last good count while the region is
+            # on the per-key fallback.
+            region_key_snapshot_keys.labels(region_name=region.name).set(0)
 
         # Stamp after the call, not before: a slow listing must not spend its
         # own duration out of the TTL it is about to start.
@@ -1972,9 +1978,9 @@ async def reconcile_team_keys(
         expire_keys: Whether to expire keys (set duration to 0)
         renewal_period_days: Optional renewal period in days. If provided, will check for and update keys renewed within the last hour.
         max_budget_amount: Optional maximum budget amount. If provided, will update the budget amount for the keys.
-        key_state_cache: Shared per-run snapshot cache. Callers reconciling more
-            than one team must pass a single instance so each region is listed
-            once per run; when omitted a private cache is used.
+        key_state_cache: Shared snapshot cache. Callers reconciling more than
+            one team must pass a single instance so each region is listed once
+            per TTL window; when omitted a private cache is used.
 
     Returns:
         float: Total spend across all keys for the team
@@ -2645,7 +2651,8 @@ async def monitor_teams(db: Session):
 
         logger.info(f"Found {len(teams)} teams to track")
         limit_service = LimitService(db)
-        # Shared across every team so each region is bulk-listed once per run
+        # Shared across every team so each region is bulk-listed once per TTL
+        # window instead of once per team
         key_state_cache = RegionKeyStateCache()
         for team in teams:
             try:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3695,6 +3695,108 @@ async def test_region_key_state_cache_rejects_non_dict(test_region):
     assert result == {}
 
 
+class FakeClock:
+    """Hand-advanced monotonic clock, so TTL tests need no sleeping."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest.mark.asyncio
+async def test_region_key_state_cache_reuses_within_ttl(test_region):
+    """A snapshot younger than the TTL is reused, not re-listed."""
+    service = AsyncMock()
+    service.list_all_keys.return_value = {"hash-1": {"spend": 1.0}}
+    clock = FakeClock()
+
+    cache = RegionKeyStateCache(ttl_seconds=600, clock=clock)
+    await cache.get(test_region, service)
+    clock.advance(599)
+    await cache.get(test_region, service)
+
+    assert service.list_all_keys.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_region_key_state_cache_relists_after_ttl(test_region):
+    """Past the TTL the region is listed again, so spend cannot go stale silently."""
+    service = AsyncMock()
+    service.list_all_keys.side_effect = [
+        {"hash-1": {"spend": 1.0}},
+        {"hash-1": {"spend": 7.0}},
+    ]
+    clock = FakeClock()
+
+    cache = RegionKeyStateCache(ttl_seconds=600, clock=clock)
+    first = await cache.get(test_region, service)
+    clock.advance(601)
+    second = await cache.get(test_region, service)
+
+    assert first == {"hash-1": {"spend": 1.0}}
+    assert second == {"hash-1": {"spend": 7.0}}
+    assert service.list_all_keys.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_region_key_state_cache_ttl_starts_after_the_listing(test_region):
+    """The TTL is stamped when the listing returns, not when it was requested."""
+    clock = FakeClock()
+
+    async def slow_list():
+        clock.advance(500)
+        return {"hash-1": {"spend": 1.0}}
+
+    service = AsyncMock()
+    service.list_all_keys.side_effect = slow_list
+
+    cache = RegionKeyStateCache(ttl_seconds=600, clock=clock)
+    await cache.get(test_region, service)
+    clock.advance(599)
+    await cache.get(test_region, service)
+
+    assert service.list_all_keys.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_region_key_state_cache_retries_failure_after_ttl(test_region):
+    """A broken region is retried once per TTL window, not once per team."""
+    service = AsyncMock()
+    service.list_all_keys.side_effect = [
+        Exception("litellm down"),
+        {"hash-1": {"spend": 1.0}},
+    ]
+    clock = FakeClock()
+
+    cache = RegionKeyStateCache(ttl_seconds=600, clock=clock)
+    assert await cache.get(test_region, service) == {}
+    clock.advance(599)
+    assert await cache.get(test_region, service) == {}
+    assert service.list_all_keys.call_count == 1
+
+    clock.advance(2)
+    assert await cache.get(test_region, service) == {"hash-1": {"spend": 1.0}}
+    assert service.list_all_keys.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_region_key_state_cache_zero_ttl_always_relists(test_region):
+    """A zero TTL turns the cache off, for an operator who needs every read fresh."""
+    service = AsyncMock()
+    service.list_all_keys.return_value = {"hash-1": {"spend": 1.0}}
+
+    cache = RegionKeyStateCache(ttl_seconds=0, clock=FakeClock())
+    await cache.get(test_region, service)
+    await cache.get(test_region, service)
+
+    assert service.list_all_keys.call_count == 2
+
+
 @pytest.mark.asyncio
 async def test_resolve_key_state_prefers_snapshot(test_region):
     """A key present in the snapshot must not trigger a /key/info call."""


### PR DESCRIPTION
Closes amazeeio/moad#651 (re-scoped — see [this comment](https://github.com/amazeeio/moad/issues/651#issuecomment-5338861776)).

## Why

`monitor_teams` reads spend from one bulk `/key/list` snapshot per region and reuses it for every team in the run. Nothing bounded how old that snapshot could get. Staleness was only ever as small as the run happened to be fast, and a run that slowed down would read older and older spend with no signal.

## What

- `RegionKeyStateCache` re-lists a region once its snapshot passes `REGION_SNAPSHOT_TTL_SECONDS` (default 600, `0` disables caching).
- The TTL is stamped when the listing returns, so a slow listing does not spend its own duration out of the window it starts.
- A failed region is retried once per TTL window instead of once per run. It still degrades to per-key `/key/info` in between.
- New counter `region_key_snapshot_refresh_total{region_name}` makes the re-listing visible.
- The clock is injectable, so the tests need no sleeping.

A no-op at current volume: the run takes 2 to 3 minutes, well inside one window.

## Not in scope

The other half of #651 — drift-filtering the `update_key_duration("0d")` expiry writes — was dropped. The 11.5k-key anonymous trial team was the whole case for it, and `271c6c20` exempted that team from expiry. In PROD, team 719 is now the only expiry-eligible team (non-POOL, no product) holding any keys at all, and it is the exempt one.

## Testing

Backend 1432 passed, 2 skipped. `ruff check` clean. `ruff format` clean on `app/core/worker.py` (`tests/test_worker.py` was already unformatted on `dev`).
