### PR TITLE
Derive team admin_email from the authenticated caller

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -495,7 +495,7 @@ async def sign_in(
                 budget_type=BudgetType.PERIODIC,
                 region_id=sign_up_region.id,
             )
-            team = await register_team(team_data, db)
+            team = await register_team(team_data, db, current_user=None)
 
         user_data = UserCreate(
             email=sign_in_username,
@@ -991,7 +991,7 @@ async def generate_trial_access(
                 is_active=True,
                 budget_type=BudgetType.PERIODIC,
             )
-            team = await register_team(team_data, db)
+            team = await register_team(team_data, db, current_user=None)
             # Ensure team has limit set
             team_limit = limit_service.set_limit(
                 owner_type=OwnerType.TEAM,

--- a/app/api/teams.py
+++ b/app/api/teams.py
@@ -412,11 +412,28 @@ async def update_team(
                 ),
             )
 
-    # Same blocklist gate as team creation, but only when the value changes.
+    # Same gates as team creation, but only when the value changes.
     if "admin_email" in update_data and not _field_value_unchanged(
         db_team, "admin_email", update_data["admin_email"]
     ):
         assert_email_domain_allowed(db, update_data["admin_email"])
+        # The DB unique index is case-sensitive, so a case variant would slip
+        # past it and leave two teams that sign-in could both re-attach to.
+        # Soft-deleted teams still hold the address, so they count as taken.
+        clash = (
+            db.query(DBTeam)
+            .filter(
+                func.lower(DBTeam.admin_email)
+                == func.lower(update_data["admin_email"]),
+                DBTeam.id != db_team.id,
+            )
+            .first()
+        )
+        if clash:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Email already registered",
+            )
 
     # Update team fields
     for key, value in update_data.items():

--- a/app/api/teams.py
+++ b/app/api/teams.py
@@ -123,6 +123,12 @@ async def register_team(
     # team is created (the sign-in auto-provision path creates a team first).
     assert_email_domain_allowed(db, team.admin_email)
 
+    # A non-admin caller may only register a team they administer themselves;
+    # only privileged callers may set an arbitrary admin_email. This keeps the
+    # sign-in auto-provision path working (a user creating their own team).
+    if not current_user.is_admin:
+        team.admin_email = current_user.email
+
     # Validate region — must be active and non-dedicated
     region = (
         db.query(DBRegion)

--- a/app/api/teams.py
+++ b/app/api/teams.py
@@ -62,6 +62,22 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["teams"])
 
 
+def _field_value_unchanged(team: DBTeam, field: str, new_value) -> bool:
+    """Is the submitted value the same as what the team already stores?
+
+    Emails are compared case-insensitively: the schema lowercases the incoming
+    address, so a stored mixed-case admin_email would otherwise look changed.
+    """
+    current = getattr(team, field)
+    if (
+        field == "admin_email"
+        and isinstance(current, str)
+        and isinstance(new_value, str)
+    ):
+        return current.lower() == new_value.lower()
+    return current == new_value
+
+
 def _create_default_limits_for_team(team: DBTeam, db: Session) -> None:
     """
     Create default limits for a newly created team.
@@ -82,7 +98,9 @@ def _create_default_limits_for_team(team: DBTeam, db: Session) -> None:
             # Don't fail team creation if limit creation fails
 
 
-async def _create_litellm_team_for_region(db: Session, team: DBTeam, region: DBRegion) -> None:
+async def _create_litellm_team_for_region(
+    db: Session, team: DBTeam, region: DBRegion
+) -> None:
     """
     Create a region-scoped LiteLLM team for the given team in the given region.
 
@@ -114,20 +132,25 @@ async def _create_litellm_team_for_region(db: Session, team: DBTeam, region: DBR
 async def register_team(
     team: TeamCreate,
     db: Session = Depends(get_db),
-    current_user: DBUser = Depends(get_current_user_from_auth),
+    current_user: Optional[DBUser] = Depends(get_current_user_from_auth),
 ):
     """
     Register a new team. Requires authentication.
+
+    A non-admin caller always becomes the team admin: `admin_email` from the
+    request body is ignored. Only system admins may name another admin.
+    Internal callers (sign-in auto-provision, anonymous trial) pass
+    `current_user=None` and set `admin_email` themselves.
     """
+    # A non-admin caller may only register a team they administer themselves;
+    # only privileged callers may set an arbitrary admin_email.
+    if current_user is not None and not current_user.is_admin:
+        team.admin_email = current_user.email
+
     # Defense-in-depth: block disposable / dynamic-DNS admin emails before any
     # team is created (the sign-in auto-provision path creates a team first).
+    # Runs after the override, so it checks the email that is actually stored.
     assert_email_domain_allowed(db, team.admin_email)
-
-    # A non-admin caller may only register a team they administer themselves;
-    # only privileged callers may set an arbitrary admin_email. This keeps the
-    # sign-in auto-provision path working (a user creating their own team).
-    if not current_user.is_admin:
-        team.admin_email = current_user.email
 
     # Validate region — must be active and non-dedicated
     region = (
@@ -359,6 +382,9 @@ async def update_team(
     # these would bypass the pool-purchase gate (require_purchase_for_requests),
     # remove an imposed key policy (force_user_keys), or change region
     # visibility / dedicated status (hide_public_regions drives is_dedicated).
+    # admin_email is admin-only for a different reason: sign-in re-attaches a
+    # first-time user to the team that already carries their address, so this
+    # field decides team membership rather than being a free-text contact.
     admin_only_fields = {
         "is_always_free",
         "budget_type",
@@ -366,6 +392,7 @@ async def update_team(
         "is_active",
         "force_user_keys",
         "hide_public_regions",
+        "admin_email",
     }
     if not current_user.is_admin:
         # Only block an actual CHANGE to an admin-only field. A GET-then-PUT
@@ -374,7 +401,7 @@ async def update_team(
         forbidden = {
             field
             for field in admin_only_fields & update_data.keys()
-            if getattr(db_team, field) != update_data[field]
+            if not _field_value_unchanged(db_team, field, update_data[field])
         }
         if forbidden:
             raise HTTPException(
@@ -384,6 +411,12 @@ async def update_team(
                     + ", ".join(sorted(forbidden))
                 ),
             )
+
+    # Same blocklist gate as team creation, but only when the value changes.
+    if "admin_email" in update_data and not _field_value_unchanged(
+        db_team, "admin_email", update_data["admin_email"]
+    ):
+        assert_email_domain_allowed(db, update_data["admin_email"])
 
     # Update team fields
     for key, value in update_data.items():

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -19,6 +19,7 @@ from app.db.models import (
 from app.main import app
 from app.schemas.limits import LimitSource, LimitType, OwnerType, ResourceType, UnitType
 from app.schemas.models import BudgetType
+from app.services.disposable_domains import refresh_disposable_domains
 from fastapi.testclient import TestClient
 from tests.conftest import soft_delete_team_for_test
 
@@ -2590,3 +2591,122 @@ def test_merge_teams_removes_source_team_limit_rows(mock_post, client, admin_tok
         .count()
         == 0
     )
+
+
+def test_register_team_non_admin_admin_email_is_forced_to_caller(
+    client, test_token, test_user, test_region
+):
+    """A non-admin caller cannot name someone else as the team admin."""
+    with patch("app.api.teams.LiteLLMService.create_team", new_callable=AsyncMock):
+        response = client.post(
+            "/teams/",
+            json={
+                "name": "Self Service Team",
+                "admin_email": "victim@example.com",
+                "phone": "1234567890",
+                "billing_address": "123 Test St, Test City, 12345",
+                "region_id": test_region.id,
+            },
+            headers={"Authorization": f"Bearer {test_token}"},
+        )
+    assert response.status_code == 201, response.text
+    assert response.json()["admin_email"] == test_user.email
+
+
+def test_register_team_admin_may_set_other_admin_email(
+    client, admin_token, test_region
+):
+    """A system admin may still register a team for another admin_email."""
+    with patch("app.api.teams.LiteLLMService.create_team", new_callable=AsyncMock):
+        response = client.post(
+            "/teams/",
+            json={
+                "name": "Delegated Team",
+                "admin_email": "delegated@example.com",
+                "phone": "1234567890",
+                "billing_address": "123 Test St, Test City, 12345",
+                "region_id": test_region.id,
+            },
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    assert response.status_code == 201, response.text
+    assert response.json()["admin_email"] == "delegated@example.com"
+
+
+def test_register_team_domain_check_uses_effective_email(
+    client, test_token, test_user, test_region, db
+):
+    """The blocklist check runs on the stored email, not the discarded body value."""
+    refresh_disposable_domains(db)
+
+    with patch("app.api.teams.LiteLLMService.create_team", new_callable=AsyncMock):
+        response = client.post(
+            "/teams/",
+            json={
+                "name": "Effective Email Team",
+                "admin_email": "throwaway@dynv6.net",
+                "phone": "1234567890",
+                "billing_address": "123 Test St, Test City, 12345",
+                "region_id": test_region.id,
+            },
+            headers={"Authorization": f"Bearer {test_token}"},
+        )
+    assert response.status_code == 201, response.text
+    assert response.json()["admin_email"] == test_user.email
+
+
+def test_update_team_admin_email_is_admin_only(
+    client, team_admin_token, test_team, test_team_admin
+):
+    """A team admin cannot move admin_email onto someone else's address."""
+    response = client.put(
+        f"/teams/{test_team.id}",
+        json={"admin_email": "victim@example.com"},
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code == 403
+    assert "admin_email" in response.json()["detail"]
+
+
+def test_update_team_admin_email_resent_unchanged_is_allowed(
+    client, team_admin_token, test_team, test_team_admin, db
+):
+    """A GET-then-PUT round-trip that re-sends the current email is a no-op."""
+    response = client.put(
+        f"/teams/{test_team.id}",
+        json={
+            "name": "Renamed Team",
+            "admin_email": test_team.admin_email.upper(),
+        },
+        headers={"Authorization": f"Bearer {team_admin_token}"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["name"] == "Renamed Team"
+
+
+def test_update_team_admin_email_allowed_for_system_admin(
+    client, admin_token, test_team
+):
+    """A system admin may still reassign the team admin."""
+    response = client.put(
+        f"/teams/{test_team.id}",
+        json={"admin_email": "newadmin@example.com"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["admin_email"] == "newadmin@example.com"
+
+
+def test_update_team_admin_email_blocks_disposable_domain(
+    client, admin_token, test_team, db
+):
+    """The blocklist also gates a changed admin_email on update."""
+    refresh_disposable_domains(db)
+
+    response = client.put(
+        f"/teams/{test_team.id}",
+        json={"admin_email": "throwaway@dynv6.net"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 422, response.text
+    assert response.json()["detail"] == "Invalid email domain."

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -2671,13 +2671,18 @@ def test_update_team_admin_email_is_admin_only(
 def test_update_team_admin_email_resent_unchanged_is_allowed(
     client, team_admin_token, test_team, test_team_admin, db
 ):
-    """A GET-then-PUT round-trip that re-sends the current email is a no-op."""
+    """A GET-then-PUT round-trip that re-sends the current email is a no-op.
+
+    The stored address is mixed case while the schema lowercases the incoming
+    one, so only a case-insensitive compare keeps this a no-op.
+    """
+    stored = test_team.admin_email
+    test_team.admin_email = stored.upper()
+    db.commit()
+
     response = client.put(
         f"/teams/{test_team.id}",
-        json={
-            "name": "Renamed Team",
-            "admin_email": test_team.admin_email.upper(),
-        },
+        json={"name": "Renamed Team", "admin_email": stored},
         headers={"Authorization": f"Bearer {team_admin_token}"},
     )
     assert response.status_code == 200, response.text
@@ -2710,3 +2715,37 @@ def test_update_team_admin_email_blocks_disposable_domain(
     )
     assert response.status_code == 422, response.text
     assert response.json()["detail"] == "Invalid email domain."
+
+
+def test_update_team_admin_email_rejects_a_case_variant_duplicate(
+    client, admin_token, test_team, test_region, db
+):
+    """The DB unique index is case-sensitive, so the check must not be."""
+    other = DBTeam(
+        name="Other Team",
+        admin_email="taken@example.com",
+        is_active=True,
+        created_at=datetime.now(UTC),
+        region_id=test_region.id,
+    )
+    db.add(other)
+    db.commit()
+
+    response = client.put(
+        f"/teams/{test_team.id}",
+        json={"admin_email": "TAKEN@example.com"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 400, response.text
+    assert response.json()["detail"] == "Email already registered"
+
+
+def test_update_team_admin_email_ignores_its_own_row(client, admin_token, test_team):
+    """The uniqueness check must not treat the team's own address as taken."""
+    response = client.put(
+        f"/teams/{test_team.id}",
+        json={"admin_email": "moved@example.com"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["admin_email"] == "moved@example.com"


### PR DESCRIPTION
`admin_email` on a team is now derived from the authenticated caller instead of taken from the request body.

### What
- `register_team`: a non-admin caller becomes the admin of the team they create; the body value is ignored. System admins may still name another admin — the admin UI and support flows need that.
- `register_team`: `current_user` is now `Optional`. The two internal (non-HTTP) callers — sign-in auto-provision and anonymous trial team creation — pass `current_user=None` and keep setting `admin_email` themselves.
- `register_team`: the disposable-domain check moved after the override, so it validates the address that is actually stored instead of a discarded body value.
- `update_team`: `admin_email` joins the admin-only field set, compared case-insensitively so a GET-then-PUT round-trip that re-sends the current address is still a no-op. A changed value also goes through the disposable-domain check and the same case-insensitive uniqueness check `register_team` has — the DB unique index is case-sensitive, so a case variant would otherwise be stored silently, and an exact duplicate surfaced as an unhandled IntegrityError.

Consistency matters on the update path too: sign-in re-attaches a first-time user to the team that already carries their address (`app/api/auth.py`), so `admin_email` decides team membership and is not a free-text field.

### Out of scope
- Restricting `POST /teams` to platform admins: self-service team creation is intended.
- Rate limiting team creation.

### Testing
`make backend-test` — 1450 passed, 2 skipped. 9 new tests in `tests/test_teams.py`. `ruff check` and `ruff format` clean on the changed files. Rebased onto current `dev`.

Closes amazeeio/moad#721
