### PR TITLE
Read validate-jwt token from the Authorization header only

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -748,15 +748,12 @@ async def delete_token(
 async def validate_jwt(
     request: Request,
     response: Response,
-    token: Optional[str] = None,
     db: Session = Depends(get_db),
 ):
     """
     Validate a JWT token and either refresh it or send a new validation URL.
 
-    The token can be provided either:
-    - As a query parameter: ?token=your_token
-    - In the Authorization header: Bearer your_token
+    The token must be provided in the Authorization header: Bearer your_token
 
     Returns:
     - If token is valid: A new access token with cookies set
@@ -768,12 +765,11 @@ async def validate_jwt(
         headers={"WWW-Authenticate": "Bearer"},
     )
 
-    # Get token from Authorization header if not provided as parameter
-    if not token:
-        auth_header = request.headers.get("Authorization")
-        if not auth_header or not auth_header.startswith("Bearer "):
-            raise credentials_exception
-        token = auth_header.split(" ")[1]
+    # Token is read only from the Authorization header.
+    auth_header = request.headers.get("Authorization")
+    if not auth_header or not auth_header.startswith("Bearer "):
+        raise credentials_exception
+    token = auth_header.split(" ")[1]
 
     try:
         # Try to validate the token

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -926,7 +926,9 @@ def test_validate_jwt_cookie_expiration_regular_user(client, test_user, test_tok
     When the user validates their JWT token
     Then the cookie should expire in 30 minutes (1800 seconds)
     """
-    response = client.get(f"/auth/validate-jwt?token={test_token}")
+    response = client.get(
+        "/auth/validate-jwt", headers={"Authorization": f"Bearer {test_token}"}
+    )
     assert response.status_code == 200
 
     # Check that the cookie is set with 30-minute expiration
@@ -944,7 +946,9 @@ def test_validate_jwt_cookie_expiration_system_admin(client, test_admin, admin_t
     When the system admin validates their JWT token
     Then the cookie should expire in 8 hours (28800 seconds)
     """
-    response = client.get(f"/auth/validate-jwt?token={admin_token}")
+    response = client.get(
+        "/auth/validate-jwt", headers={"Authorization": f"Bearer {admin_token}"}
+    )
     assert response.status_code == 200
 
     # Check that the cookie is set with 8-hour expiration

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -45,26 +45,6 @@ def test_generate_pricing_url(db, test_team, test_team_admin):
     assert decoded["sub"] == admin_email
 
 
-def test_validate_jwt_valid_token_query_param(client, test_team_admin):
-    """Test validating a valid JWT token provided as query parameter"""
-    # Create a valid token
-    token = create_access_token(data={"sub": test_team_admin.email})
-
-    # Validate token via query parameter
-    response = client.get(f"/auth/validate-jwt?token={token}")
-    assert response.status_code == 200
-    data = response.json()
-    assert "access_token" in data
-    assert data["token_type"] == "bearer"
-
-    # Verify new token is valid
-    new_token = data["access_token"]
-    decoded = jwt.decode(
-        new_token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM]
-    )
-    assert decoded["sub"] == test_team_admin.email
-
-
 def test_validate_jwt_valid_token_auth_header(client, test_team_admin):
     """Test validating a valid JWT token provided in Authorization header"""
     # Create a valid token
@@ -85,36 +65,6 @@ def test_validate_jwt_valid_token_auth_header(client, test_team_admin):
         new_token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM]
     )
     assert decoded["sub"] == test_team_admin.email
-
-
-@patch("app.api.auth.SESService")
-def test_validate_jwt_expired_token_query_param(mock_ses, client, test_team_admin):
-    """Test validating an expired JWT token provided as query parameter"""
-    # Mock SES service
-    mock_ses_instance = mock_ses.return_value
-    mock_ses_instance.send_email.return_value = True
-
-    # Create an expired token by using a negative timedelta
-    token = create_access_token(
-        data={"sub": test_team_admin.email},
-        expires_delta=timedelta(seconds=-1),  # Set expiration to 1 second in the past
-    )
-
-    # Validate token via query parameter
-    response = client.get(f"/auth/validate-jwt?token={token}")
-    assert response.status_code == 401
-    data = response.json()
-    assert "detail" in data
-    assert (
-        data["detail"]
-        == "Token expired. A new validation URL has been sent to your email."
-    )
-
-    # Verify SES service was called (DynamoDB is not used for URL validation)
-    mock_ses_instance.send_email.assert_called_once()
-    # Verify the template data contains validation_url
-    call_args = mock_ses_instance.send_email.call_args
-    assert call_args[1]["template_data"]["validation_url"] is not None
 
 
 @patch("app.api.auth.SESService")
@@ -149,19 +99,6 @@ def test_validate_jwt_expired_token_auth_header(mock_ses, client, test_team_admi
     assert call_args[1]["template_data"]["validation_url"] is not None
 
 
-def test_validate_jwt_invalid_token_query_param(client):
-    """Test validating an invalid JWT token provided as query parameter"""
-    # Create an invalid token
-    token = "invalid.token.here"
-
-    # Validate token via query parameter
-    response = client.get(f"/auth/validate-jwt?token={token}")
-    assert response.status_code == 401
-    data = response.json()
-    assert "detail" in data
-    assert "Could not validate credentials" in data["detail"]
-
-
 def test_validate_jwt_invalid_token_auth_header(client):
     """Test validating an invalid JWT token provided in Authorization header"""
     # Create an invalid token
@@ -187,6 +124,22 @@ def test_validate_jwt_missing_token(client):
     assert "Could not validate credentials" in data["detail"]
 
 
+@patch("app.api.auth.SESService")
+def test_validate_jwt_rejects_query_param_token(mock_ses, client, test_team_admin):
+    """A token in the query string is ignored: keeping tokens out of URLs."""
+    mock_ses_instance = mock_ses.return_value
+    mock_ses_instance.send_email.return_value = True
+    token = create_access_token(data={"sub": test_team_admin.email})
+
+    response = client.get(f"/auth/validate-jwt?token={token}")
+
+    assert response.status_code == 401
+    assert "Could not validate credentials" in response.json()["detail"]
+    assert "access_token" not in response.json()
+    # No renewal email either — the request never identified a user.
+    mock_ses_instance.send_email.assert_not_called()
+
+
 def test_validate_jwt_invalid_auth_header_format(client):
     """Test validating with an invalid Authorization header format"""
     # Test with missing Bearer prefix
@@ -200,19 +153,6 @@ def test_validate_jwt_invalid_auth_header_format(client):
 
     # Test with empty Authorization header
     response = client.get("/auth/validate-jwt", headers={"Authorization": ""})
-    assert response.status_code == 401
-    data = response.json()
-    assert "detail" in data
-    assert "Could not validate credentials" in data["detail"]
-
-
-def test_validate_jwt_wrong_user_query_param(client):
-    """Test validating a token for a non-existent user provided as query parameter"""
-    # Create token for non-existent user
-    token = create_access_token(data={"sub": "nonexistent@example.com"})
-
-    # Validate token via query parameter
-    response = client.get(f"/auth/validate-jwt?token={token}")
     assert response.status_code == 401
     data = response.json()
     assert "detail" in data

--- a/tests/test_logout_revocation.py
+++ b/tests/test_logout_revocation.py
@@ -132,18 +132,21 @@ def test_revoked_token_cannot_be_refreshed_by_validate_jwt(
 ):
     # The refresh endpoint decodes the token itself, so it needs its own check.
     # Without one, a revoked token buys a fresh one and undoes the logout.
-    assert client.get(f"/auth/validate-jwt?token={test_token}").status_code == 200
+    assert (
+        client.get(
+            "/auth/validate-jwt", headers={"Authorization": f"Bearer {test_token}"}
+        ).status_code
+        == 200
+    )
 
     client.post("/auth/logout", headers={"Authorization": f"Bearer {test_token}"})
 
-    query = client.get(f"/auth/validate-jwt?token={test_token}")
-    header = client.get(
+    refreshed = client.get(
         "/auth/validate-jwt", headers={"Authorization": f"Bearer {test_token}"}
     )
 
-    assert query.status_code == 401
-    assert header.status_code == 401
-    assert "access_token" not in query.json()
+    assert refreshed.status_code == 401
+    assert "access_token" not in refreshed.json()
 
 
 def test_validate_jwt_refuses_a_token_without_a_jti(client, test_user):
@@ -153,7 +156,12 @@ def test_validate_jwt_refuses_a_token_without_a_jti(client, test_user):
         algorithm=settings.ALGORITHM,
     )
 
-    assert client.get(f"/auth/validate-jwt?token={legacy}").status_code == 401
+    assert (
+        client.get(
+            "/auth/validate-jwt", headers={"Authorization": f"Bearer {legacy}"}
+        ).status_code
+        == 401
+    )
 
 
 @patch("app.api.auth.SESService")
@@ -175,7 +183,9 @@ def test_expired_revoked_token_gets_no_recovery_email(mock_ses, client, db, test
         algorithm=settings.ALGORITHM,
     )
 
-    response = client.get(f"/auth/validate-jwt?token={expired_revoked}")
+    response = client.get(
+        "/auth/validate-jwt", headers={"Authorization": f"Bearer {expired_revoked}"}
+    )
 
     assert response.status_code == 401
     assert response.json()["detail"] == "Could not validate credentials"
@@ -194,7 +204,9 @@ def test_expired_token_without_a_jti_still_gets_a_recovery_email(
         algorithm=settings.ALGORITHM,
     )
 
-    response = client.get(f"/auth/validate-jwt?token={legacy_expired}")
+    response = client.get(
+        "/auth/validate-jwt", headers={"Authorization": f"Bearer {legacy_expired}"}
+    )
 
     assert response.status_code == 401
     assert "validation URL has been sent" in response.json()["detail"]


### PR DESCRIPTION
`GET /auth/validate-jwt` reads the token only from the `Authorization: Bearer` header. The `token` query parameter is removed, and the docstring is updated.

### Why
Query strings are recorded by proxies, browser history and monitoring, so they are the wrong place for a credential. The header is the form every caller already uses.

### What
- The endpoint reads the header only.
- Tests: the four `*_query_param` tests in `tests/test_jwt.py` are removed — each had an identical `*_auth_header` twin, so no coverage is lost — and replaced by `test_validate_jwt_rejects_query_param_token`, which asserts a valid token in the query string yields 401, issues no new token and sends no recovery email.
- The cookie-expiration tests (`tests/test_auth.py`) and the revocation / missing-`jti` / expired-recovery tests (`tests/test_logout_revocation.py`) were converted to header form, so they keep exercising their original behaviour rather than passing because the query token is now ignored.

### Breaking change
Any caller still passing `?token=` gets a 401 and must move to the header. No in-house caller is affected: the emailed recovery link points at the frontend `/upgrade?token=...` page, and the frontend calls this endpoint with a header (`frontend/src/utils/api.ts`).

Follow-up in another repo: moad's generated OpenAPI client still describes this endpoint with a `?token=` query parameter (`src/external/generated/amazeeai.live.ts`, `src/server/external/generated/amazeeai.live.ts`). No hand-written moad code calls it, so nothing breaks today, but the client should be regenerated.

### Out of scope
A dedicated refresh-token mechanism with an absolute lifetime.

### Testing
`make backend-test` — 1438 passed, 2 skipped. `ruff check` clean. Rebased onto current `dev`.

Closes amazeeio/moad#723
