### PR TITLE
Set SameSite=Lax on the access_token cookie

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -274,6 +274,7 @@ async def logout(
     delete_settings = {
         "key": "access_token",
         "path": "/",
+        "httponly": True,
         "secure": True,
         "samesite": "lax",
     }

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -183,7 +183,7 @@ def create_and_set_access_token(
         "httponly": True,
         "max_age": cookie_expiration,
         "expires": cookie_expiration,
-        "samesite": "none",
+        "samesite": "lax",
         "secure": True,
         "path": "/",
     }
@@ -275,7 +275,7 @@ async def logout(
         "key": "access_token",
         "path": "/",
         "secure": True,
-        "samesite": "none",
+        "samesite": "lax",
     }
 
     # Only set domain if we got one from LAGOON_ROUTES

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -954,3 +954,45 @@ def test_validate_jwt_cookie_expiration_system_admin(client, test_admin, admin_t
     # Check the Set-Cookie header for max-age
     set_cookie_header = response.headers.get("set-cookie", "")
     assert "Max-Age=28800" in set_cookie_header or "max-age=28800" in set_cookie_header
+
+
+def test_login_cookie_attributes(client, test_user):
+    """
+    Given a user logging in
+    When the access_token cookie is issued
+    Then it carries Secure, HttpOnly and SameSite=Lax
+
+    SameSite=None was previously set, which attaches the cookie in third-party
+    contexts and removes the browser's default CSRF protection.
+    """
+    response = client.post(
+        "/auth/login", data={"username": test_user.email, "password": "testpassword"}
+    )
+    assert response.status_code == 200
+
+    # Starlette writes the attribute value in lower case; browsers do not care.
+    set_cookie_header = response.headers.get("set-cookie", "").lower()
+    assert "access_token=" in set_cookie_header
+    assert "samesite=lax" in set_cookie_header
+    assert "secure" in set_cookie_header
+    assert "httponly" in set_cookie_header
+
+
+def test_logout_clearing_cookie_matches_login_attributes(client, test_user, test_token):
+    """
+    Given a logged-in user
+    When the user logs out
+    Then the cleared cookie repeats the login attributes
+
+    A browser drops a Set-Cookie that does not match the original cookie's
+    SameSite, so a mismatch here would leave the session cookie in place.
+    """
+    response = client.post(
+        "/auth/logout", headers={"Authorization": f"Bearer {test_token}"}
+    )
+    assert response.status_code == 200
+
+    set_cookie_header = response.headers.get("set-cookie", "").lower()
+    assert "access_token=" in set_cookie_header
+    assert "samesite=lax" in set_cookie_header
+    assert "secure" in set_cookie_header

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -984,8 +984,9 @@ def test_logout_clearing_cookie_matches_login_attributes(client, test_user, test
     When the user logs out
     Then the cleared cookie repeats the login attributes
 
-    A browser drops a Set-Cookie that does not match the original cookie's
-    SameSite, so a mismatch here would leave the session cookie in place.
+    A browser matches the clearing cookie on name, path and domain, so the
+    attributes do not decide removal — but keeping the two calls identical
+    stops a later divergence from going unnoticed.
     """
     response = client.post(
         "/auth/logout", headers={"Authorization": f"Bearer {test_token}"}
@@ -996,3 +997,4 @@ def test_logout_clearing_cookie_matches_login_attributes(client, test_user, test
     assert "access_token=" in set_cookie_header
     assert "samesite=lax" in set_cookie_header
     assert "secure" in set_cookie_header
+    assert "httponly" in set_cookie_header


### PR DESCRIPTION
The `access_token` cookie is issued with `SameSite=Lax` instead of `None`. `Secure` is unchanged.

### What
- Both cookie sites change together: `create_and_set_access_token` (`response.set_cookie`) and `logout` (`response.delete_cookie`), and the logout call now also sets `HttpOnly` so the two are identical. Removal is keyed on name, path and domain, so that last part changes no behaviour; it stops the two call sites drifting apart unnoticed.
- Two tests in `tests/test_auth.py` pin the attributes: the login cookie carries `Secure`, `HttpOnly` and `SameSite=Lax`, and the logout cookie repeats them. Nothing asserted `SameSite` before, so a change back would have passed CI.

### Deploy check
All deployed frontends are same-site with their backend, so cookie auth is unaffected:

| Env | Frontend | Backend | Cookie domain |
|---|---|---|---|
| PROD | `dashboard.amazee.ai`, `amazee.ai` | `api.amazee.ai` | `amazee.ai` |
| DEV | `frontend.dev.amazeeai.us2.amazee.io` | `backend.dev.amazeeai.us2.amazee.io` | derived from `LAGOON_ROUTES` |

moad (`my.amazee.io`) and the Drupal module authenticate with Bearer headers, not this cookie. Note that CORS still accepts `FRONTEND_ROUTE` origins on any domain, so a future cross-site frontend deployment would need a different auth transport.

### Out of scope
The moad `sessionId` cookie.

### Testing
`make backend-test` — 1443 passed, 2 skipped. `ruff check` clean. Independent review found no issues. Rebased onto current `dev`.

Closes amazeeio/moad#727
