### PR TITLE
Scope the OpenAPI schema to the caller's access level

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -30,7 +30,7 @@ from app.middleware.audit import AuditLogMiddleware
 from app.middleware.auth import AuthMiddleware
 from app.middleware.caching import CacheControlMiddleware
 from app.middleware.prometheus import PrometheusMiddleware
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.openapi.docs import (
@@ -38,6 +38,14 @@ from fastapi.openapi.docs import (
     get_swagger_ui_oauth2_redirect_html,
 )
 from fastapi.openapi.utils import get_openapi
+from fastapi.responses import JSONResponse
+from fastapi.routing import APIRoute
+from copy import deepcopy
+from jose import jwt
+from sqlalchemy.orm import Session
+from app.db.database import get_db
+from app.api.users import get_user_by_email
+from app.core.security import assert_token_not_revoked
 from prometheus_fastapi_instrumentator import Instrumentator, metrics
 from starlette.middleware.base import BaseHTTPMiddleware
 
@@ -95,7 +103,7 @@ app = FastAPI(
     docs_url=None,  # Disable default /docs endpoint; custom Swagger UI at /
     redoc_url=None,  # Disable default /redoc endpoint
     # Public by design: the schema is the API's docs page (see PUBLIC_PATHS).
-    openapi_url="/openapi.json",
+    openapi_url=None,  # served per caller by scoped_openapi() below
     root_path_in_servers=True,
     openapi_tags=[
         {
@@ -316,3 +324,104 @@ def custom_openapi():
 
 
 app.openapi = custom_openapi
+
+
+# ── Caller-scoped OpenAPI visibility ─────────────────────────────────────────
+# `custom_openapi()` builds the full schema; the /openapi.json route below
+# returns only the operations the caller is entitled to see:
+#   - anonymous callers     -> operations requiring no authentication
+#   - authenticated users   -> the above plus operations requiring authentication
+#   - system administrators -> the full schema
+# Authenticating (session cookie or bearer token) progressively reveals more of
+# the schema. Each operation's tier is derived from its own route dependencies,
+# so the mapping stays in sync as endpoints are added. This governs schema
+# VISIBILITY only; each endpoint still enforces its own authorization.
+
+_TIER_RANK = {"public": 0, "user": 1, "admin": 2}
+_HTTP_METHODS = {"get", "post", "put", "patch", "delete", "options", "head"}
+# Dependencies that mark an operation as system-admin only.
+_ADMIN_DEPENDENCIES = {"get_role_min_system_admin", "require_system_admin"}
+
+
+def _route_tier(route: APIRoute) -> str:
+    """Classify a route as public / user / admin from its auth dependencies."""
+    names: set[str] = set()
+
+    def _walk(dep) -> None:
+        if dep is None:
+            return
+        call = getattr(dep, "call", None)
+        if call is not None:
+            names.add(getattr(call, "__name__", ""))
+        for sub in getattr(dep, "dependencies", None) or []:
+            _walk(sub)
+
+    _walk(getattr(route, "dependant", None))
+
+    if names & _ADMIN_DEPENDENCIES:
+        return "admin"
+    authish = any(
+        ("current_user" in name)
+        or ("role_min" in name)
+        or name.startswith("require_")
+        or ("key_creator" in name)
+        for name in names
+    )
+    return "user" if authish else "public"
+
+
+# (method, path) -> tier, built once from the fully-wired app.
+_OPENAPI_TIERS: dict[tuple[str, str], str] = {}
+for _route in app.routes:
+    if isinstance(_route, APIRoute):
+        _tier = _route_tier(_route)
+        for _method in _route.methods:
+            _OPENAPI_TIERS[(_method.upper(), _route.path)] = _tier
+
+
+def _caller_tier(request: Request, db: Session) -> str:
+    """Best-effort caller tier from the bearer token or session cookie."""
+    token = None
+    auth_header = request.headers.get("Authorization")
+    if auth_header and auth_header.startswith("Bearer "):
+        token = auth_header.split(" ", 1)[1]
+    if not token:
+        token = request.cookies.get("access_token")
+    if not token:
+        return "public"
+    try:
+        payload = jwt.decode(
+            token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM]
+        )
+        assert_token_not_revoked(db, payload)
+        email = payload.get("sub")
+        user = get_user_by_email(db, email) if email else None
+    except Exception:
+        return "public"
+    if not user:
+        return "public"
+    return "admin" if getattr(user, "is_admin", False) else "user"
+
+
+@app.get("/openapi.json", include_in_schema=False)
+async def scoped_openapi(request: Request, db: Session = Depends(get_db)):
+    full = app.openapi()
+    rank = _TIER_RANK[_caller_tier(request, db)]
+    schema = deepcopy(full)
+
+    kept_paths: dict = {}
+    for path, item in schema.get("paths", {}).items():
+        kept_ops: dict = {}
+        has_operation = False
+        for key, value in item.items():
+            if key.lower() in _HTTP_METHODS:
+                op_tier = _OPENAPI_TIERS.get((key.upper(), path), "user")
+                if _TIER_RANK[op_tier] <= rank:
+                    kept_ops[key] = value
+                    has_operation = True
+            else:
+                kept_ops[key] = value  # keep shared keys (parameters, etc.)
+        if has_operation:
+            kept_paths[path] = kept_ops
+    schema["paths"] = kept_paths
+    return JSONResponse(schema)

--- a/app/main.py
+++ b/app/main.py
@@ -41,11 +41,9 @@ from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
 from copy import deepcopy
-from jose import jwt
 from sqlalchemy.orm import Session
 from app.db.database import get_db
-from app.api.users import get_user_by_email
-from app.core.security import assert_token_not_revoked
+from app.core.security import get_current_user_from_auth
 from prometheus_fastapi_instrumentator import Instrumentator, metrics
 from starlette.middleware.base import BaseHTTPMiddleware
 
@@ -332,10 +330,11 @@ app.openapi = custom_openapi
 #   - anonymous callers     -> operations requiring no authentication
 #   - authenticated users   -> the above plus operations requiring authentication
 #   - system administrators -> the full schema
-# Authenticating (session cookie or bearer token) progressively reveals more of
-# the schema. Each operation's tier is derived from its own route dependencies,
-# so the mapping stays in sync as endpoints are added. This governs schema
-# VISIBILITY only; each endpoint still enforces its own authorization.
+# Authenticating (session cookie, JWT or API token) progressively reveals more
+# of the schema. Each operation's tier is derived from its own route
+# dependencies, so the mapping stays in sync as endpoints are added. This
+# governs schema VISIBILITY only; each endpoint still enforces its own
+# authorization.
 
 _TIER_RANK = {"public": 0, "user": 1, "admin": 2}
 _HTTP_METHODS = {"get", "post", "put", "patch", "delete", "options", "head"}
@@ -343,8 +342,8 @@ _HTTP_METHODS = {"get", "post", "put", "patch", "delete", "options", "head"}
 _ADMIN_DEPENDENCIES = {"get_role_min_system_admin", "require_system_admin"}
 
 
-def _route_tier(route: APIRoute) -> str:
-    """Classify a route as public / user / admin from its auth dependencies."""
+def _operation_tier(dependant) -> str:
+    """Classify an operation as public / user / admin from its dependencies."""
     names: set[str] = set()
 
     def _walk(dep) -> None:
@@ -356,7 +355,7 @@ def _route_tier(route: APIRoute) -> str:
         for sub in getattr(dep, "dependencies", None) or []:
             _walk(sub)
 
-    _walk(getattr(route, "dependant", None))
+    _walk(dependant)
 
     if names & _ADMIN_DEPENDENCIES:
         return "admin"
@@ -370,43 +369,79 @@ def _route_tier(route: APIRoute) -> str:
     return "user" if authish else "public"
 
 
-# (method, path) -> tier, built once from the fully-wired app.
-_OPENAPI_TIERS: dict[tuple[str, str], str] = {}
-for _route in app.routes:
-    if isinstance(_route, APIRoute):
-        _tier = _route_tier(_route)
-        for _method in _route.methods:
-            _OPENAPI_TIERS[(_method.upper(), _route.path)] = _tier
+def _iter_operations(routes):
+    """Yield one object per API operation, with its dependencies attached.
+
+    Routes added with include_router are not flattened into app.routes; the
+    app holds a router wrapper that resolves its operations on demand. Both
+    shapes expose operation_id / unique_id / dependant, which is all the
+    tiering needs.
+    """
+    for route in routes:
+        if isinstance(route, APIRoute):
+            yield route
+            continue
+        candidates = getattr(route, "effective_candidates", None)
+        if callable(candidates):
+            yield from candidates()
 
 
-def _caller_tier(request: Request, db: Session) -> str:
-    """Best-effort caller tier from the bearer token or session cookie."""
-    token = None
-    auth_header = request.headers.get("Authorization")
-    if auth_header and auth_header.startswith("Bearer "):
-        token = auth_header.split(" ", 1)[1]
-    if not token:
-        token = request.cookies.get("access_token")
-    if not token:
+def _operation_id(operation) -> str:
+    """The key the OpenAPI document uses for this operation."""
+    return getattr(operation, "operation_id", None) or getattr(
+        operation, "unique_id", ""
+    )
+
+
+# operationId -> tier, built once from the fully-wired app. operationId is the
+# key because it is the one identifier shared by the route object and the
+# generated document; matching on paths breaks on converter suffixes.
+_OPENAPI_TIERS: dict[str, str] = {
+    _operation_id(_operation): _operation_tier(getattr(_operation, "dependant", None))
+    for _operation in _iter_operations(app.routes)
+}
+
+
+async def _caller_tier(request: Request, db: Session) -> str:
+    """Best-effort caller tier from the credentials on the request.
+
+    Resolution is delegated to the normal auth dependency so that JWTs, API
+    tokens and the local bearer token are all recognised. Anything that does
+    not resolve to a user is treated as anonymous.
+    """
+    authorization = request.headers.get("Authorization")
+    access_token = request.cookies.get("access_token")
+    if not authorization and not access_token:
         return "public"
     try:
-        payload = jwt.decode(
-            token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM]
+        user = await get_current_user_from_auth(
+            access_token=access_token,
+            authorization=authorization,
+            db=db,
+            request=request,
         )
-        assert_token_not_revoked(db, payload)
-        email = payload.get("sub")
-        user = get_user_by_email(db, email) if email else None
     except Exception:
         return "public"
-    if not user:
+    if user is None:
         return "public"
-    return "admin" if getattr(user, "is_admin", False) else "user"
+    return "admin" if user.is_admin else "user"
 
 
-@app.get("/openapi.json", include_in_schema=False)
-async def scoped_openapi(request: Request, db: Session = Depends(get_db)):
-    full = app.openapi()
-    rank = _TIER_RANK[_caller_tier(request, db)]
+def _collect_refs(node, found: set[str]) -> None:
+    """Gather every component schema name reachable from a schema fragment."""
+    if isinstance(node, dict):
+        ref = node.get("$ref")
+        if isinstance(ref, str) and ref.startswith("#/components/schemas/"):
+            found.add(ref.rsplit("/", 1)[1])
+        for value in node.values():
+            _collect_refs(value, found)
+    elif isinstance(node, list):
+        for value in node:
+            _collect_refs(value, found)
+
+
+def _scope_schema(full: dict, rank: int) -> dict:
+    """Return a copy of the schema holding only what this rank may see."""
     schema = deepcopy(full)
 
     kept_paths: dict = {}
@@ -415,7 +450,9 @@ async def scoped_openapi(request: Request, db: Session = Depends(get_db)):
         has_operation = False
         for key, value in item.items():
             if key.lower() in _HTTP_METHODS:
-                op_tier = _OPENAPI_TIERS.get((key.upper(), path), "user")
+                # An operation missing from the map is treated as admin-only,
+                # so a gap makes the document smaller, never wider.
+                op_tier = _OPENAPI_TIERS.get(value.get("operationId", ""), "admin")
                 if _TIER_RANK[op_tier] <= rank:
                     kept_ops[key] = value
                     has_operation = True
@@ -424,4 +461,42 @@ async def scoped_openapi(request: Request, db: Session = Depends(get_db)):
         if has_operation:
             kept_paths[path] = kept_ops
     schema["paths"] = kept_paths
-    return JSONResponse(schema)
+
+    # Drop the request/response models that only the hidden operations used;
+    # their field names would otherwise still describe the hidden endpoints.
+    components = schema.get("components", {})
+    all_schemas = components.get("schemas") or {}
+    if all_schemas:
+        reachable: set[str] = set()
+        _collect_refs(kept_paths, reachable)
+        # A kept model may reference further models, so follow the chain.
+        pending = list(reachable)
+        while pending:
+            name = pending.pop()
+            nested: set[str] = set()
+            _collect_refs(all_schemas.get(name, {}), nested)
+            for new_name in nested - reachable:
+                reachable.add(new_name)
+                pending.append(new_name)
+        components["schemas"] = {
+            name: model for name, model in all_schemas.items() if name in reachable
+        }
+
+    # Keep only the tag descriptions that still label a visible operation.
+    if schema.get("tags"):
+        used_tags = {
+            tag
+            for item in kept_paths.values()
+            for key, operation in item.items()
+            if key.lower() in _HTTP_METHODS
+            for tag in operation.get("tags", [])
+        }
+        schema["tags"] = [tag for tag in schema["tags"] if tag.get("name") in used_tags]
+
+    return schema
+
+
+@app.get("/openapi.json", include_in_schema=False)
+async def scoped_openapi(request: Request, db: Session = Depends(get_db)):
+    rank = _TIER_RANK[await _caller_tier(request, db)]
+    return JSONResponse(_scope_schema(app.openapi(), rank))

--- a/app/main.py
+++ b/app/main.py
@@ -43,6 +43,7 @@ from fastapi.routing import APIRoute
 from copy import deepcopy
 from sqlalchemy.orm import Session
 from app.db.database import get_db
+from app.core.roles import UserRole
 from app.core.security import get_current_user_from_auth
 from prometheus_fastapi_instrumentator import Instrumentator, metrics
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -192,8 +193,10 @@ instrumentator = Instrumentator(
 # Add default metrics
 instrumentator.add(metrics.default())
 
-# Instrument the app
-instrumentator.instrument(app).expose(app)
+# Instrument the app. /metrics stays out of the OpenAPI document: it is an
+# operational endpoint gated by PROMETHEUS_API_KEY in AuthMiddleware, not part
+# of the API surface, and it carries no route dependency to classify it by.
+instrumentator.instrument(app).expose(app, include_in_schema=False)
 
 
 @app.get("/health")
@@ -339,12 +342,24 @@ app.openapi = custom_openapi
 _TIER_RANK = {"public": 0, "user": 1, "admin": 2}
 _HTTP_METHODS = {"get", "post", "put", "patch", "delete", "options", "head"}
 # Dependencies that mark an operation as system-admin only.
-_ADMIN_DEPENDENCIES = {"get_role_min_system_admin", "require_system_admin"}
+_ADMIN_DEPENDENCIES = {
+    "get_role_min_system_admin",
+    "require_system_admin",
+    "check_sales_or_higher",
+}
+# System roles that only privileged staff hold. An RBAC dependency limited to
+# these is admin tier even when its callable carries no name to match on.
+_ADMIN_ROLES = {UserRole.SYSTEM_ADMIN, UserRole.SALES}
 
 
 def _operation_tier(dependant) -> str:
     """Classify an operation as public / user / admin from its dependencies."""
     names: set[str] = set()
+
+    # An RBAC dependency used as an instance (Depends(require_system_admin()))
+    # has no __name__, so the name patterns below would read it as public.
+    # Classify those by the roles they allow instead.
+    role_tiers: set[str] = set()
 
     def _walk(dep) -> None:
         if dep is None:
@@ -352,13 +367,18 @@ def _operation_tier(dependant) -> str:
         call = getattr(dep, "call", None)
         if call is not None:
             names.add(getattr(call, "__name__", ""))
+            allowed = getattr(call, "allowed_roles", None)
+            if allowed:
+                role_tiers.add("admin" if set(allowed) <= _ADMIN_ROLES else "user")
         for sub in getattr(dep, "dependencies", None) or []:
             _walk(sub)
 
     _walk(dependant)
 
-    if names & _ADMIN_DEPENDENCIES:
+    if "admin" in role_tiers or names & _ADMIN_DEPENDENCIES:
         return "admin"
+    if role_tiers:
+        return "user"
     authish = any(
         ("current_user" in name)
         or ("role_min" in name)

--- a/tests/test_openapi_scoping.py
+++ b/tests/test_openapi_scoping.py
@@ -5,7 +5,13 @@ users additionally get the authenticated ones, and system admins get everything.
 This is visibility only — every endpoint still enforces its own authorization.
 """
 
-from app.main import _OPENAPI_TIERS, _TIER_RANK, _scope_schema, app
+import os
+import subprocess
+import sys
+
+from app.core.rbac import require_private_ai_access, require_system_admin
+from app.core.roles import UserRole
+from app.main import _OPENAPI_TIERS, _TIER_RANK, _operation_tier, _scope_schema, app
 
 ADMIN_ONLY_PATH = "/regions/admin"
 USER_PATH = "/auth/me"
@@ -162,3 +168,65 @@ def test_invalid_credentials_fall_back_to_the_public_schema(client):
     )
     assert response.status_code == 200
     assert USER_PATH not in response.json()["paths"]
+
+
+def test_sales_endpoints_are_admin_tier():
+    """The sales role is privileged staff, not an ordinary user."""
+    full = app.openapi()
+    sales_op = full["paths"]["/teams/sales/list-teams"]["get"]
+    assert _OPENAPI_TIERS[sales_op["operationId"]] == "admin"
+
+
+def test_metrics_is_not_in_the_document():
+    """/metrics is an operational endpoint, gated separately from the API.
+
+    It is only registered when ENABLE_METRICS is on, which is the deployed
+    setting but not the test one, so the app is imported in a subprocess with
+    metrics enabled. Otherwise this passes without proving anything.
+    """
+    code = (
+        "from app.main import app\n"
+        "paths = app.openapi()['paths']\n"
+        "assert any(r.path == '/metrics' for r in app.routes), 'metrics not wired'\n"
+        "assert '/metrics' not in paths, sorted(paths)\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        env={**os.environ, "ENABLE_METRICS": "true"},
+        cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+class _FakeDependant:
+    def __init__(self, call=None, dependencies=None):
+        self.call = call
+        self.dependencies = dependencies or []
+
+
+def test_unnamed_rbac_dependency_is_not_treated_as_public():
+    """An RBAC dependency used as an instance carries no __name__ to match on."""
+    admin_instance = require_system_admin()
+    assert not hasattr(admin_instance, "__name__")
+
+    assert (
+        _operation_tier(_FakeDependant(dependencies=[_FakeDependant(admin_instance)]))
+        == "admin"
+    )
+    assert (
+        _operation_tier(
+            _FakeDependant(dependencies=[_FakeDependant(require_private_ai_access())])
+        )
+        == "user"
+    )
+
+
+def test_sales_only_rbac_dependency_is_admin_tier():
+    from app.core.rbac import RBACDependency
+
+    sales_only = RBACDependency([UserRole.SALES])
+    assert _operation_tier(
+        _FakeDependant(dependencies=[_FakeDependant(sales_only)])
+    ) == ("admin")

--- a/tests/test_openapi_scoping.py
+++ b/tests/test_openapi_scoping.py
@@ -1,0 +1,164 @@
+"""The published OpenAPI schema shows only what the caller is entitled to see.
+
+Anonymous callers get the endpoints that need no authentication, authenticated
+users additionally get the authenticated ones, and system admins get everything.
+This is visibility only — every endpoint still enforces its own authorization.
+"""
+
+from app.main import _OPENAPI_TIERS, _TIER_RANK, _scope_schema, app
+
+ADMIN_ONLY_PATH = "/regions/admin"
+USER_PATH = "/auth/me"
+PUBLIC_PATH = "/health"
+
+
+def _operations(schema):
+    return {
+        (method.upper(), path)
+        for path, item in schema["paths"].items()
+        for method in item
+        if method.lower() in {"get", "post", "put", "patch", "delete"}
+    }
+
+
+def test_every_operation_in_the_schema_has_a_tier():
+    """An unmapped operation is hidden from everyone but admins.
+
+    This is the guard for a FastAPI upgrade that changes how included routers
+    expose their operations: the map would silently go empty and the public
+    docs would lose almost every endpoint.
+    """
+    full = app.openapi()
+    unmapped = [
+        (method, path)
+        for path, item in full["paths"].items()
+        for method, operation in item.items()
+        if method.lower() in {"get", "post", "put", "patch", "delete"}
+        and operation.get("operationId") not in _OPENAPI_TIERS
+    ]
+    assert unmapped == []
+
+
+def test_tier_map_covers_routes_from_included_routers():
+    """Routes added with include_router are not flattened into app.routes."""
+    full = app.openapi()
+    converter_route = full["paths"]["/admin/models/{model_id_or_id}"]["get"]
+    assert _OPENAPI_TIERS[converter_route["operationId"]] == "admin"
+    team_route = full["paths"]["/auth/me"]["get"]
+    assert _OPENAPI_TIERS[team_route["operationId"]] == "user"
+
+
+def test_anonymous_schema_hides_authenticated_and_admin_paths():
+    public = _scope_schema(app.openapi(), 0)
+    assert PUBLIC_PATH in public["paths"]
+    assert USER_PATH not in public["paths"]
+    assert ADMIN_ONLY_PATH not in public["paths"]
+
+
+def test_user_schema_hides_admin_paths_but_shows_public_ones():
+    user = _scope_schema(app.openapi(), 1)
+    assert PUBLIC_PATH in user["paths"]
+    assert USER_PATH in user["paths"]
+    assert ADMIN_ONLY_PATH not in user["paths"]
+
+
+def test_admin_schema_is_the_full_schema():
+    full = app.openapi()
+    admin = _scope_schema(full, 2)
+    assert _operations(admin) == _operations(full)
+    assert admin["components"]["schemas"].keys() == full["components"]["schemas"].keys()
+
+
+def test_scoping_widens_monotonically():
+    full = app.openapi()
+    public, user, admin = (_scope_schema(full, rank) for rank in (0, 1, 2))
+    assert _operations(public) < _operations(user) < _operations(admin)
+
+
+def test_hidden_operations_do_not_leave_their_models_behind(client):
+    """Component schemas are pruned too, or they still describe hidden endpoints."""
+    public = _scope_schema(app.openapi(), 0)
+    kept = public["components"]["schemas"]
+
+    assert "RegionAdminResponse" not in kept
+    # Models still used by a visible operation survive, including nested ones.
+    assert len(kept) < len(app.openapi()["components"]["schemas"])
+
+
+def test_tags_are_pruned_to_visible_operations():
+    """Tag descriptions must not survive the operations they label.
+
+    The document does not carry a top-level tags list today, so this exercises
+    _scope_schema directly.
+    """
+    schema = {
+        "paths": {
+            "/health": {"get": {"operationId": "health_check_health_get"}},
+            "/regions/admin": {"get": {"operationId": "hidden", "tags": ["regions"]}},
+        },
+        "components": {"schemas": {}},
+        "tags": [{"name": "regions"}, {"name": "system"}],
+    }
+
+    scoped = _scope_schema(schema, _TIER_RANK["public"])
+
+    assert "/regions/admin" not in scoped["paths"]
+    assert scoped["tags"] == []
+
+
+def test_scoping_does_not_mutate_the_cached_schema():
+    full = app.openapi()
+    before = len(full["paths"])
+    _scope_schema(full, 0)
+    assert len(app.openapi()["paths"]) == before
+
+
+def test_anonymous_request_gets_the_public_schema(client):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    paths = response.json()["paths"]
+    assert PUBLIC_PATH in paths
+    assert ADMIN_ONLY_PATH not in paths
+
+
+def test_user_jwt_gets_the_user_schema(client, test_token):
+    response = client.get(
+        "/openapi.json", headers={"Authorization": f"Bearer {test_token}"}
+    )
+    assert response.status_code == 200
+    paths = response.json()["paths"]
+    assert USER_PATH in paths
+    assert ADMIN_ONLY_PATH not in paths
+
+
+def test_admin_jwt_gets_the_full_schema(client, admin_token):
+    response = client.get(
+        "/openapi.json", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert response.status_code == 200
+    assert ADMIN_ONLY_PATH in response.json()["paths"]
+
+
+def test_api_token_is_recognised_not_treated_as_anonymous(client, test_token):
+    """An API token must resolve to its owner, or users see the public schema."""
+    created = client.post(
+        "/auth/token",
+        json={"name": "openapi-scope"},
+        headers={"Authorization": f"Bearer {test_token}"},
+    )
+    assert created.status_code == 200, created.text
+    api_token = created.json()["token"]
+
+    response = client.get(
+        "/openapi.json", headers={"Authorization": f"Bearer {api_token}"}
+    )
+    assert response.status_code == 200
+    assert USER_PATH in response.json()["paths"]
+
+
+def test_invalid_credentials_fall_back_to_the_public_schema(client):
+    response = client.get(
+        "/openapi.json", headers={"Authorization": "Bearer not-a-token"}
+    )
+    assert response.status_code == 200
+    assert USER_PATH not in response.json()["paths"]


### PR DESCRIPTION
`/openapi.json` is now served per caller: anonymous callers get the operations that need no authentication, authenticated users additionally get the authenticated ones, and system administrators get the full document. The schema and the Swagger UI at `/` stay reachable without auth — they are the API's docs.

This is visibility only. Every endpoint still enforces its own authorization; nothing about access control changes.

### How
- Each operation's tier comes from its own route dependencies, so the mapping stays in sync as endpoints are added: `get_role_min_system_admin` and `require_system_admin` mean admin, other auth dependencies mean user, none means public.
- The map is keyed on `operationId`, the one identifier shared by the route object and the generated document. Keying on `(method, path)` silently misses routes whose path carries a converter (`/{id:path}`).
- In this FastAPI version, routes added with `include_router` are not flattened into `app.routes`; the app holds a router wrapper that resolves its operations on demand. `_iter_operations` handles both shapes. Because that is internal FastAPI API, a test asserts that every operation in the document is present in the map, so a FastAPI upgrade that changes the shape fails CI instead of quietly emptying the public docs.
- An operation missing from the map is treated as admin-only, so the failure mode is a smaller document rather than a wider one. Same for an RBAC dependency used as an instance (`Depends(require_system_admin())`), which carries no `__name__` to match on: those are classified by the roles they allow.
- `/metrics` is excluded from the document. It carries no route dependency, and it is only registered when `ENABLE_METRICS` is on — the deployed setting, but not the test one — so it would otherwise have been listed publicly while `AuthMiddleware` answers it with a 404 without the Prometheus key.
- `check_sales_or_higher` counts as admin: it guards a staff-only bulk endpoint.
- The caller is resolved with the normal auth dependency, so JWTs, API tokens and the local bearer token all count as authenticated. Anything that does not resolve is anonymous.
- Request and response models reachable only from hidden operations are pruned transitively, along with tag descriptions that no longer label a visible operation. `deepcopy` protects the cached full document.



`CacheControlMiddleware` already sets `no-store` on this path, so per-caller documents are not proxy-cached.

### Out of scope
The same tiered idea for moad's GraphQL introspection, and the LiteLLM instance's own docs.

### Testing
`make backend-test` — 1459 passed, 2 skipped. 17 new tests in `tests/test_openapi_scoping.py`. `ruff check` clean. Rebased onto current `dev`.

Closes amazeeio/moad#724
