### PR TITLE
fix(users): report team-member caps in regions without keys

### DIFF
--- a/app/api/users.py
+++ b/app/api/users.py
@@ -225,7 +225,18 @@ async def _fetch_region_spend(
             )
         except Exception as exc:
             if _is_litellm_404(exc):
-                return None
+                # No LiteLLM team in this region, so there is no spend to
+                # report. A configured cap is still real configuration, so keep
+                # the row (with zero spend) instead of hiding the cap.
+                if max_budget is None:
+                    return None
+                return UserSpendRegion(
+                    region_id=region.id,
+                    region_name=region.name,
+                    spend=0.0,
+                    status="ok",
+                    max_budget=max_budget,
+                )
             if _is_litellm_unavailable(exc):
                 logger.warning(
                     "LiteLLM unavailable for team %s (%s) in region %s: %s",
@@ -374,9 +385,16 @@ async def _compute_user_spend(
     for team_id in team_ids:
         team_name = team_names[team_id]
         for region in regions_by_team.get(team_id, {}).values():
+            # A region is reported when the member has spend to report there
+            # (a team-owned or user-owned key exists) *or* when a team-member
+            # cap is configured for it. Without the cap clause, a cap set in a
+            # region the member has no key in yet is written successfully but
+            # can never be read back — callers see `max_budget: null` and
+            # conclude the write failed (moad-dev member spending limits).
             if (
                 (team_id, region.id) not in key_team_region_set
                 and region.id not in user_key_regions_by_team.get(team_id, set())
+                and (team_id, region.id) not in max_budget_by_team_region
             ):
                 continue
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -776,6 +776,162 @@ def test_get_user_spend_includes_team_member_region_max_budget(
 
 
 @patch("app.api.users.LiteLLMService.get_team_info", new_callable=AsyncMock)
+def test_get_user_spend_reports_member_cap_in_region_without_keys(
+    mock_get_team_info, client, admin_token, db
+):
+    """A cap set before the member has a key must still be readable.
+
+    Region inclusion is otherwise gated on key existence, which made a
+    successful cap write unreadable until the member created a key.
+    """
+    team = DBTeam(
+        name="Capless Team",
+        admin_email="capless-team@example.com",
+        is_active=True,
+        created_at=datetime.now(UTC),
+        budget_type="periodic",
+    )
+    region_with_cap = DBRegion(
+        name="region-cap",
+        postgres_host="host",
+        postgres_port=5432,
+        postgres_admin_user="postgres",
+        postgres_admin_password="postgres",
+        litellm_api_url="http://litellm.cap",
+        litellm_api_key="kc",
+        is_active=True,
+        is_dedicated=False,
+    )
+    region_without_cap = DBRegion(
+        name="region-nocap",
+        postgres_host="host",
+        postgres_port=5432,
+        postgres_admin_user="postgres",
+        postgres_admin_password="postgres",
+        litellm_api_url="http://litellm.nocap",
+        litellm_api_key="kn",
+        is_active=True,
+        is_dedicated=False,
+    )
+    user = DBUser(
+        email="dave+1@example.com",
+        hashed_password=get_password_hash("pw"),
+        is_active=True,
+        is_admin=False,
+        team=team,
+    )
+    db.add_all([team, region_with_cap, region_without_cap, user])
+    db.commit()
+    db.refresh(team)
+    db.refresh(region_with_cap)
+    db.refresh(region_without_cap)
+    db.refresh(user)
+    db.add_all(
+        [
+            DBTeamRegion(team_id=team.id, region_id=region_with_cap.id),
+            DBTeamRegion(team_id=team.id, region_id=region_without_cap.id),
+        ]
+    )
+    db.add(
+        DBSpendCap(
+            scope="team_member",
+            region_id=region_with_cap.id,
+            team_id=team.id,
+            user_id=user.id,
+            max_budget=10.0,
+            budget_duration="1mo",
+        )
+    )
+    db.commit()
+
+    # The team exists in LiteLLM (it is created with the region association),
+    # it just has no keys for this member yet.
+    mock_get_team_info.return_value = {"keys": []}
+
+    response = client.get(
+        "/users/spend?email=dave@example.com",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    regions = data["teams"][0]["regions"]
+    # Only the cap-bearing region is reported: a keyless region without a cap
+    # stays omitted.
+    assert len(regions) == 1
+    assert regions[0]["region_name"] == "region-cap"
+    assert regions[0]["max_budget"] == 10.0
+    assert regions[0]["spend"] == 0.0
+    assert regions[0]["status"] == "ok"
+    assert mock_get_team_info.await_count == 1
+
+
+@patch("app.api.users.LiteLLMService.get_team_info", new_callable=AsyncMock)
+def test_get_user_spend_reports_member_cap_when_litellm_team_missing(
+    mock_get_team_info, client, admin_token, db
+):
+    """A 404 from LiteLLM drops the region — unless a cap is configured."""
+    team = DBTeam(
+        name="Missing Team",
+        admin_email="missing-team@example.com",
+        is_active=True,
+        created_at=datetime.now(UTC),
+        budget_type="periodic",
+    )
+    region = DBRegion(
+        name="region-missing",
+        postgres_host="host",
+        postgres_port=5432,
+        postgres_admin_user="postgres",
+        postgres_admin_password="postgres",
+        litellm_api_url="http://litellm.missing",
+        litellm_api_key="km",
+        is_active=True,
+        is_dedicated=False,
+    )
+    user = DBUser(
+        email="erin+1@example.com",
+        hashed_password=get_password_hash("pw"),
+        is_active=True,
+        is_admin=False,
+        team=team,
+    )
+    db.add_all([team, region, user])
+    db.commit()
+    db.refresh(team)
+    db.refresh(region)
+    db.refresh(user)
+    db.add(DBTeamRegion(team_id=team.id, region_id=region.id))
+    db.add(
+        DBSpendCap(
+            scope="team_member",
+            region_id=region.id,
+            team_id=team.id,
+            user_id=user.id,
+            max_budget=25.0,
+            budget_duration="1mo",
+        )
+    )
+    db.commit()
+
+    mock_get_team_info.side_effect = HTTPException(
+        status_code=500,
+        detail="Failed to get LiteLLM team info: Status 404: team not found",
+    )
+
+    response = client.get(
+        "/users/spend?email=erin@example.com",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    regions = data["teams"][0]["regions"]
+    assert len(regions) == 1
+    assert regions[0]["max_budget"] == 25.0
+    assert regions[0]["spend"] == 0.0
+    assert regions[0]["status"] == "ok"
+
+
+@patch("app.api.users.LiteLLMService.get_team_info", new_callable=AsyncMock)
 def test_get_user_spend_unavailable_region_not_cached(
     mock_get_team_info, client, admin_token, db
 ):


### PR DESCRIPTION
## Problem

`GET /users/spend` only emits a region entry when the member — or their team — owns a key in that region (`app/api/users.py`, the `continue` in `_compute_user_spend`). That gate has been there since the endpoint was introduced, which was correct while the endpoint was a pure *spend* projection. `max_budget` was later added to that same key-gated shape, so it inherited the gate.

Consequence: a team-member cap written via `PUT /spend/{region_id}/team/{team_id}/member/{user_id}/budget` returns `200` with the value echoed, is stored, and is enforced — but no reader can see it until the member creates a key in that region. There is no `GET` on the member-budget endpoint, so `/users/spend` is the only read path.

For moad this reads as a failed write: the members page sets the cap, refetches `/users/spend`, gets `max_budget: null`, and drops back to the empty "Set Spending Limit" form. Reproduced on dev — a `$10` cap on team 7399 / region 34 (`flip@amazee.io`) had been stored the whole time and only became readable once a key was provisioned for that member:

```
PUT /spend/34/team/7399/member/14423/budget  → 200 {"max_budget": 10.0, ...}
GET /users/spend?email=flip@amazee.io        → team 7399: {"regions": []}
# after provisioning a key for that member in region 34:
GET /users/spend?email=flip@amazee.io        → {"region_id": 34, ..., "max_budget": 10.0}
```

## Change

- A team-associated region is included when a `team_member` `spend_caps` row exists for it, even with no keys present. Regions with neither keys nor a cap stay omitted, so the response does not grow for the common case (existing `test_get_user_spend_skips_regions_without_user_keys` still covers that).
- When LiteLLM 404s for the team (no team object in that region) but a cap is configured, keep the row with `spend: 0.0`, `status: "ok"` instead of dropping it and hiding the cap. `status: "unavailable"` was deliberately avoided here: it flags `had_region_failures`, which suppresses response caching and would force a full LiteLLM fan-out on every request.

## Tests

Two new cases in `tests/test_users.py`:

- `test_get_user_spend_reports_member_cap_in_region_without_keys` — cap-bearing keyless region is reported with its `max_budget`; a keyless region without a cap stays omitted.
- `test_get_user_spend_reports_member_cap_when_litellm_team_missing` — a LiteLLM 404 no longer hides a configured cap.

## Notes / not in scope

`/users/spend` is cached for 15 minutes and invalidated by budget writes, but **not** by key creation or deletion — both of which change the region list and the spend figures. Observed on dev: a key created at 14:03 was still absent from the response at 14:12 (`cached_at` pinned at 13:59:33) until a budget write busted the cache. Worth an `invalidate_user_spend_cache` call on the key create/delete paths; left out here to keep this fix focused.